### PR TITLE
Add Pydantic models, discovery, and YAML I/O

### DIFF
--- a/src/opcli/core/discovery.py
+++ b/src/opcli/core/discovery.py
@@ -1,0 +1,173 @@
+"""Artifact discovery — walk a repository to find charms, rocks, and snaps.
+
+Discovery looks for ``charmcraft.yaml``, ``rockcraft.yaml``, and
+``snapcraft.yaml`` marker files, extracts names, and links charm OCI-image
+resources to discovered rocks when the match is unambiguous.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from opcli.core.exceptions import DiscoveryError
+from opcli.models.artifacts import (
+    ArtifactResource,
+    ArtifactsPlan,
+    CharmArtifact,
+    RockArtifact,
+    SnapArtifact,
+)
+
+logger = logging.getLogger(__name__)
+
+_yaml = YAML()
+
+_PRUNE_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".venv",
+        "venv",
+        ".tox",
+        "build",
+        "dist",
+        "__pycache__",
+        "node_modules",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".pytest_cache",
+    }
+)
+
+_MARKER_FILES: dict[str, str] = {
+    "charmcraft.yaml": "charm",
+    "rockcraft.yaml": "rock",
+    "snapcraft.yaml": "snap",
+}
+
+
+def _read_yaml_name(path: Path) -> str:
+    """Read the ``name`` field from a craft YAML file."""
+    with path.open() as fh:
+        data = _yaml.load(fh)
+    if not isinstance(data, dict):
+        msg = f"{path} does not contain a YAML mapping"
+        raise DiscoveryError(msg)
+    name = data.get("name")
+    if not isinstance(name, str) or not name:
+        msg = f"{path} is missing a valid 'name' field"
+        raise DiscoveryError(msg)
+    return name
+
+
+def _read_charm_resources(path: Path) -> dict[str, dict[str, Any]]:
+    """Read the ``resources`` section from a charmcraft.yaml file."""
+    with path.open() as fh:
+        data = _yaml.load(fh)
+    if not isinstance(data, dict):
+        return {}
+    resources = data.get("resources")
+    if not isinstance(resources, dict):
+        return {}
+    return dict(resources)
+
+
+def _source_relative(marker_path: Path, root: Path) -> str:
+    """Return the marker file's directory as a relative path from *root*."""
+    rel = marker_path.parent.relative_to(root)
+    return str(rel) if str(rel) != "." else "."
+
+
+def _process_marker(
+    path: Path,
+    root: Path,
+    rocks: list[RockArtifact],
+    snaps: list[SnapArtifact],
+    charm_raw: list[tuple[str, str, dict[str, dict[str, Any]]]],
+) -> None:
+    """Process a single marker file found during discovery."""
+    kind = _MARKER_FILES[path.name]
+    source = _source_relative(path, root)
+
+    if kind == "rock":
+        name = _read_yaml_name(path)
+        rocks.append(RockArtifact(name=name, source=source))
+    elif kind == "snap":
+        name = _read_yaml_name(path)
+        snaps.append(SnapArtifact(name=name, source=source))
+    elif kind == "charm":
+        name = _read_yaml_name(path)
+        raw_resources = _read_charm_resources(path)
+        charm_raw.append((name, source, raw_resources))
+
+
+def _link_charm_resources(
+    charm_name: str,
+    raw_resources: dict[str, dict[str, Any]],
+    rock_names: set[str],
+) -> dict[str, ArtifactResource]:
+    """Build charm resources, auto-linking OCI images to rocks when unambiguous."""
+    resources: dict[str, ArtifactResource] = {}
+    for res_name, res_data in raw_resources.items():
+        if not isinstance(res_data, dict):
+            continue
+        if res_data.get("type") != "oci-image":
+            continue
+        upstream = res_data.get("upstream-source", "")
+        candidates = []
+        if isinstance(upstream, str) and upstream in rock_names:
+            candidates.append(upstream)
+        if res_name in rock_names and res_name not in candidates:
+            candidates.append(res_name)
+        rock_ref = candidates[0] if len(candidates) == 1 else None
+        if len(candidates) > 1:
+            logger.warning(
+                "Ambiguous rock match for resource '%s' in charm '%s'; "
+                "skipping auto-link (candidates: %s)",
+                res_name,
+                charm_name,
+                ", ".join(candidates),
+            )
+        resources[res_name] = ArtifactResource(type="oci-image", rock=rock_ref)
+    return resources
+
+
+def discover_artifacts(root: Path) -> ArtifactsPlan:
+    """Walk *root* and discover charms, rocks, and snaps.
+
+    The walk prunes common non-source directories and does not follow
+    symlinked directories.  Charm resources of ``type: oci-image`` are
+    linked to discovered rocks when the match is unambiguous.
+
+    Raises:
+        DiscoveryError: If a marker file cannot be read or is malformed.
+    """
+    root = root.resolve()
+    rocks: list[RockArtifact] = []
+    charms: list[CharmArtifact] = []
+    snaps: list[SnapArtifact] = []
+
+    charm_raw: list[tuple[str, str, dict[str, dict[str, Any]]]] = []
+
+    for path in sorted(root.rglob("*")):
+        if path.is_dir() and path.is_symlink():
+            continue
+        if path.is_dir() and path.name in _PRUNE_DIRS:
+            continue
+        if not path.is_file() or path.name not in _MARKER_FILES:
+            continue
+        if any(part in _PRUNE_DIRS for part in path.relative_to(root).parts[:-1]):
+            continue
+        _process_marker(path, root, rocks, snaps, charm_raw)
+
+    rock_names = {r.name for r in rocks}
+    for charm_name, charm_source, raw_resources in charm_raw:
+        resources = _link_charm_resources(charm_name, raw_resources, rock_names)
+        charms.append(
+            CharmArtifact(name=charm_name, source=charm_source, resources=resources)
+        )
+
+    return ArtifactsPlan(rocks=rocks, charms=charms, snaps=snaps)

--- a/src/opcli/core/yaml_io.py
+++ b/src/opcli/core/yaml_io.py
@@ -1,0 +1,57 @@
+"""YAML read/write helpers backed by ruamel.yaml.
+
+These thin wrappers centralise YAML I/O so the rest of the codebase never
+imports ruamel.yaml directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from opcli.models.artifacts import ArtifactsPlan
+from opcli.models.artifacts_generated import ArtifactsGenerated
+
+_yaml = YAML()
+_yaml.default_flow_style = False
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    """Load a YAML file and return its contents as a plain dict."""
+    with path.open() as fh:
+        data = _yaml.load(fh)
+    if not isinstance(data, dict):
+        msg = f"{path} does not contain a YAML mapping"
+        raise ValueError(msg)
+    return dict(data)
+
+
+def dump_yaml(data: dict[str, Any], path: Path) -> None:
+    """Write *data* to a YAML file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as fh:
+        _yaml.dump(data, fh)
+
+
+def load_artifacts_plan(path: Path) -> ArtifactsPlan:
+    """Load and validate ``artifacts.yaml``."""
+    raw = load_yaml(path)
+    return ArtifactsPlan.model_validate(raw)
+
+
+def dump_artifacts_plan(plan: ArtifactsPlan, path: Path) -> None:
+    """Serialize an :class:`ArtifactsPlan` to YAML."""
+    dump_yaml(plan.model_dump(exclude_none=True), path)
+
+
+def load_artifacts_generated(path: Path) -> ArtifactsGenerated:
+    """Load and validate ``artifacts-generated.yaml``."""
+    raw = load_yaml(path)
+    return ArtifactsGenerated.model_validate(raw)
+
+
+def dump_artifacts_generated(gen: ArtifactsGenerated, path: Path) -> None:
+    """Serialize an :class:`ArtifactsGenerated` to YAML."""
+    dump_yaml(gen.model_dump(exclude_none=True, by_alias=True), path)

--- a/src/opcli/models/artifacts.py
+++ b/src/opcli/models/artifacts.py
@@ -1,1 +1,74 @@
-"""Pydantic models for artifacts.yaml."""
+"""Pydantic models for artifacts.yaml.
+
+This schema declares the charms, rocks, and snaps in a repository, and
+the links between charms and their OCI-image resources (rocks).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+
+class ArtifactResource(BaseModel):
+    """A resource declared by a charm (e.g. an OCI image backed by a rock)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["oci-image"]
+    rock: str | None = None
+
+
+class CharmArtifact(BaseModel):
+    """A charm declared in artifacts.yaml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    source: str
+    resources: dict[str, ArtifactResource] = {}
+
+
+class RockArtifact(BaseModel):
+    """A rock declared in artifacts.yaml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    source: str
+
+
+class SnapArtifact(BaseModel):
+    """A snap declared in artifacts.yaml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    source: str
+
+
+class ArtifactsPlan(BaseModel):
+    """Top-level schema for ``artifacts.yaml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[1] = 1
+    rocks: list[RockArtifact] = []
+    charms: list[CharmArtifact] = []
+    snaps: list[SnapArtifact] = []
+
+    @model_validator(mode="after")
+    def _unique_names(self) -> ArtifactsPlan:
+        """Ensure no duplicate names within each artifact kind."""
+        checks: list[tuple[str, list[str]]] = [
+            ("rock", [r.name for r in self.rocks]),
+            ("charm", [c.name for c in self.charms]),
+            ("snap", [s.name for s in self.snaps]),
+        ]
+        for kind, names in checks:
+            dupes = {n for n in names if names.count(n) > 1}
+            if dupes:
+                msg = f"Duplicate {kind} name(s): {', '.join(sorted(dupes))}"
+                raise ValueError(msg)
+        return self

--- a/src/opcli/models/artifacts_generated.py
+++ b/src/opcli/models/artifacts_generated.py
@@ -1,1 +1,72 @@
-"""Pydantic models for artifacts-generated.yaml."""
+"""Pydantic models for artifacts-generated.yaml.
+
+Extends the build plan with paths/references of the built artifacts.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ArtifactOutput(BaseModel):
+    """Location of a built artifact — local file, OCI image, or GitHub artifact."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    file: str | None = None
+    image: str | None = None
+    artifact: str | None = None
+    run_id: str | None = Field(default=None, alias="run-id")
+
+    @model_validator(mode="after")
+    def _at_least_one_output(self) -> ArtifactOutput:
+        if not any([self.file, self.image, self.artifact]):
+            msg = "ArtifactOutput must specify at least one of file, image, or artifact"
+            raise ValueError(msg)
+        if self.artifact and not self.run_id:
+            msg = "run-id is required when artifact is set"
+            raise ValueError(msg)
+        return self
+
+
+class GeneratedRock(BaseModel):
+    """A rock with its build output."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    source: str
+    output: ArtifactOutput
+
+
+class GeneratedCharm(BaseModel):
+    """A charm with its build output."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    source: str
+    output: ArtifactOutput
+
+
+class GeneratedSnap(BaseModel):
+    """A snap with its build output."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    source: str
+    output: ArtifactOutput
+
+
+class ArtifactsGenerated(BaseModel):
+    """Top-level schema for ``artifacts-generated.yaml``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[1] = 1
+    rocks: list[GeneratedRock] = []
+    charms: list[GeneratedCharm] = []
+    snaps: list[GeneratedSnap] = []

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,0 +1,171 @@
+"""Tests for artifact discovery and YAML I/O."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opcli.core.discovery import discover_artifacts
+from opcli.core.exceptions import DiscoveryError
+from opcli.core.yaml_io import (
+    dump_artifacts_generated,
+    dump_artifacts_plan,
+    load_artifacts_generated,
+    load_artifacts_plan,
+)
+from opcli.models.artifacts import ArtifactsPlan
+from opcli.models.artifacts_generated import (
+    ArtifactOutput,
+    ArtifactsGenerated,
+    GeneratedRock,
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestDiscovery:
+    """Tests for discover_artifacts()."""
+
+    def test_empty_repo(self, tmp_path: Path) -> None:
+        plan = discover_artifacts(tmp_path)
+        assert plan.rocks == []
+        assert plan.charms == []
+        assert plan.snaps == []
+
+    def test_single_charm(self, tmp_path: Path) -> None:
+        _write(tmp_path / "charmcraft.yaml", "name: mycharm\ntype: charm\n")
+        plan = discover_artifacts(tmp_path)
+        assert len(plan.charms) == 1
+        assert plan.charms[0].name == "mycharm"
+        assert plan.charms[0].source == "."
+
+    def test_single_rock(self, tmp_path: Path) -> None:
+        _write(tmp_path / "myrock" / "rockcraft.yaml", "name: myrock\n")
+        plan = discover_artifacts(tmp_path)
+        assert len(plan.rocks) == 1
+        assert plan.rocks[0].name == "myrock"
+        assert plan.rocks[0].source == "myrock"
+
+    def test_single_snap(self, tmp_path: Path) -> None:
+        _write(tmp_path / "snap_dir" / "snapcraft.yaml", "name: mysnap\n")
+        plan = discover_artifacts(tmp_path)
+        assert len(plan.snaps) == 1
+        assert plan.snaps[0].name == "mysnap"
+        assert plan.snaps[0].source == "snap_dir"
+
+    def test_monorepo(self, tmp_path: Path) -> None:
+        _write(tmp_path / "charmcraft.yaml", "name: main-charm\ntype: charm\n")
+        _write(tmp_path / "rock_a" / "rockcraft.yaml", "name: rock-a\n")
+        _write(tmp_path / "rock_b" / "rockcraft.yaml", "name: rock-b\n")
+        _write(tmp_path / "snap_c" / "snapcraft.yaml", "name: snap-c\n")
+        plan = discover_artifacts(tmp_path)
+        assert len(plan.rocks) == 2  # noqa: PLR2004
+        assert len(plan.charms) == 1
+        assert len(plan.snaps) == 1
+
+    def test_deep_nested_artifact(self, tmp_path: Path) -> None:
+        _write(tmp_path / "a" / "b" / "c" / "rockcraft.yaml", "name: deep-rock\n")
+        plan = discover_artifacts(tmp_path)
+        assert len(plan.rocks) == 1
+        assert plan.rocks[0].source == "a/b/c"
+
+    def test_pruned_directories_skipped(self, tmp_path: Path) -> None:
+        _write(tmp_path / ".venv" / "rockcraft.yaml", "name: venv-rock\n")
+        _write(tmp_path / ".git" / "rockcraft.yaml", "name: git-rock\n")
+        _write(tmp_path / ".tox" / "rockcraft.yaml", "name: tox-rock\n")
+        plan = discover_artifacts(tmp_path)
+        assert plan.rocks == []
+
+    def test_charm_with_oci_resource_auto_links_rock(self, tmp_path: Path) -> None:
+        _write(tmp_path / "rock_dir" / "rockcraft.yaml", "name: myrock\n")
+        _write(
+            tmp_path / "charmcraft.yaml",
+            "name: mycharm\ntype: charm\nresources:\n  myrock:\n    type: oci-image\n",
+        )
+        plan = discover_artifacts(tmp_path)
+        assert plan.charms[0].resources["myrock"].rock == "myrock"
+
+    def test_charm_resource_no_match_leaves_rock_none(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "charmcraft.yaml",
+            "name: mycharm\ntype: charm\n"
+            "resources:\n"
+            "  unknown-img:\n"
+            "    type: oci-image\n",
+        )
+        plan = discover_artifacts(tmp_path)
+        assert plan.charms[0].resources["unknown-img"].rock is None
+
+    def test_malformed_yaml_raises(self, tmp_path: Path) -> None:
+        _write(tmp_path / "charmcraft.yaml", "- just a list\n")
+        with pytest.raises(DiscoveryError, match="not contain a YAML mapping"):
+            discover_artifacts(tmp_path)
+
+    def test_missing_name_raises(self, tmp_path: Path) -> None:
+        _write(tmp_path / "rockcraft.yaml", "version: 1\n")
+        with pytest.raises(DiscoveryError, match="missing a valid 'name'"):
+            discover_artifacts(tmp_path)
+
+
+class TestYamlIO:
+    """Tests for YAML round-trip helpers."""
+
+    def test_artifacts_plan_round_trip(self, tmp_path: Path) -> None:
+        plan = ArtifactsPlan.model_validate(
+            {
+                "version": 1,
+                "rocks": [{"name": "r1", "source": "rd"}],
+                "charms": [{"name": "c1", "source": "."}],
+            }
+        )
+        path = tmp_path / "artifacts.yaml"
+        dump_artifacts_plan(plan, path)
+        loaded = load_artifacts_plan(path)
+        assert loaded == plan
+
+    def test_artifacts_generated_round_trip(self, tmp_path: Path) -> None:
+        gen = ArtifactsGenerated(
+            rocks=[
+                GeneratedRock(
+                    name="r1",
+                    source="rd",
+                    output=ArtifactOutput(file="./r1.rock"),
+                )
+            ],
+        )
+        path = tmp_path / "artifacts-generated.yaml"
+        dump_artifacts_generated(gen, path)
+        loaded = load_artifacts_generated(path)
+        assert loaded == gen
+
+    def test_run_id_alias_survives_round_trip(self, tmp_path: Path) -> None:
+        gen = ArtifactsGenerated(
+            rocks=[
+                GeneratedRock(
+                    name="r1",
+                    source="rd",
+                    output=ArtifactOutput(artifact="a1", run_id="42"),
+                )
+            ],
+        )
+        path = tmp_path / "gen.yaml"
+        dump_artifacts_generated(gen, path)
+        raw = path.read_text()
+        assert "run-id" in raw
+        loaded = load_artifacts_generated(path)
+        assert loaded.rocks[0].output.run_id == "42"
+
+    def test_load_invalid_yaml_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text("- just a list\n")
+        with pytest.raises(ValueError, match="YAML mapping"):
+            load_artifacts_plan(path)
+
+    def test_dump_creates_parent_dirs(self, tmp_path: Path) -> None:
+        path = tmp_path / "sub" / "dir" / "artifacts.yaml"
+        dump_artifacts_plan(ArtifactsPlan(), path)
+        assert path.exists()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,178 @@
+"""Tests for Pydantic models (artifacts.yaml and artifacts-generated.yaml)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from opcli.models.artifacts import (
+    ArtifactResource,
+    ArtifactsPlan,
+    CharmArtifact,
+    RockArtifact,
+)
+from opcli.models.artifacts_generated import (
+    ArtifactOutput,
+    ArtifactsGenerated,
+    GeneratedCharm,
+    GeneratedRock,
+    GeneratedSnap,
+)
+
+
+class TestArtifactsPlan:
+    """Validation tests for artifacts.yaml models."""
+
+    def test_minimal_valid(self) -> None:
+        plan = ArtifactsPlan()
+        assert plan.version == 1
+        assert plan.rocks == []
+        assert plan.charms == []
+        assert plan.snaps == []
+
+    def test_full_example(self) -> None:
+        plan = ArtifactsPlan(
+            rocks=[
+                RockArtifact(name="indico", source="indico_rock"),
+                RockArtifact(name="indico-nginx", source="nginx_rock"),
+            ],
+            charms=[
+                CharmArtifact(
+                    name="indico",
+                    source=".",
+                    resources={
+                        "indico-image": ArtifactResource(
+                            type="oci-image", rock="indico"
+                        ),
+                    },
+                ),
+            ],
+        )
+        assert len(plan.rocks) == 2  # noqa: PLR2004
+        assert len(plan.charms) == 1
+        assert plan.charms[0].resources["indico-image"].rock == "indico"
+
+    def test_duplicate_rock_names_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate rock"):
+            ArtifactsPlan(
+                rocks=[
+                    RockArtifact(name="myrock", source="a"),
+                    RockArtifact(name="myrock", source="b"),
+                ]
+            )
+
+    def test_duplicate_charm_names_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Duplicate charm"):
+            ArtifactsPlan(
+                charms=[
+                    CharmArtifact(name="mycharm", source="a"),
+                    CharmArtifact(name="mycharm", source="b"),
+                ]
+            )
+
+    def test_extra_fields_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            ArtifactsPlan.model_validate({"version": 1, "unknown_key": "val"})
+
+    def test_wrong_version_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ArtifactsPlan.model_validate({"version": 2})
+
+    def test_resource_wrong_type_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ArtifactResource(type="file")  # type: ignore[arg-type]
+
+    def test_from_yaml_dict(self) -> None:
+        """Validate a dict that mimics YAML load output."""
+        data = {
+            "version": 1,
+            "rocks": [{"name": "myrock", "source": "rock_dir"}],
+            "charms": [
+                {
+                    "name": "mycharm",
+                    "source": ".",
+                    "resources": {
+                        "img": {"type": "oci-image", "rock": "myrock"},
+                    },
+                }
+            ],
+            "snaps": [{"name": "mysnap", "source": "snap_dir"}],
+        }
+        plan = ArtifactsPlan.model_validate(data)
+        assert plan.rocks[0].name == "myrock"
+        assert plan.charms[0].resources["img"].rock == "myrock"
+        assert plan.snaps[0].name == "mysnap"
+
+
+class TestArtifactsGenerated:
+    """Validation tests for artifacts-generated.yaml models."""
+
+    def test_local_output(self) -> None:
+        out = ArtifactOutput(file="./myrock.rock")
+        assert out.file == "./myrock.rock"
+        assert out.image is None
+
+    def test_ci_output_with_image(self) -> None:
+        out = ArtifactOutput(image="ghcr.io/canonical/indico:abc1234")
+        assert out.image is not None
+
+    def test_ci_output_artifact_requires_run_id(self) -> None:
+        with pytest.raises(ValidationError, match="run-id is required"):
+            ArtifactOutput(artifact="charm-indico")
+
+    def test_ci_output_artifact_with_run_id(self) -> None:
+        out = ArtifactOutput(artifact="charm-indico", run_id="123456")
+        assert out.artifact == "charm-indico"
+        assert out.run_id == "123456"
+
+    def test_empty_output_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="at least one"):
+            ArtifactOutput()
+
+    def test_run_id_alias_from_yaml(self) -> None:
+        """YAML uses ``run-id`` (hyphen), Python uses ``run_id``."""
+        data = {"artifact": "charm-x", "run-id": "999"}
+        out = ArtifactOutput.model_validate(data)
+        assert out.run_id == "999"
+
+    def test_run_id_serialized_with_hyphen(self) -> None:
+        out = ArtifactOutput(artifact="charm-x", run_id="999")
+        dumped = out.model_dump(by_alias=True, exclude_none=True)
+        assert "run-id" in dumped
+        assert "run_id" not in dumped
+
+    def test_full_generated_example(self) -> None:
+        gen = ArtifactsGenerated(
+            rocks=[
+                GeneratedRock(
+                    name="indico",
+                    source="indico_rock",
+                    output=ArtifactOutput(file="./indico.rock"),
+                )
+            ],
+            charms=[
+                GeneratedCharm(
+                    name="indico",
+                    source=".",
+                    output=ArtifactOutput(file="./indico.charm"),
+                )
+            ],
+        )
+        assert gen.rocks[0].output.file == "./indico.rock"
+        assert gen.charms[0].output.file == "./indico.charm"
+
+    def test_generated_extra_fields_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            ArtifactsGenerated.model_validate({"version": 1, "junk": True})
+
+    def test_snap_generated(self) -> None:
+        gen = ArtifactsGenerated(
+            snaps=[
+                GeneratedSnap(
+                    name="mysnap",
+                    source="snap_dir",
+                    output=ArtifactOutput(file="./mysnap.snap"),
+                )
+            ],
+        )
+        assert gen.snaps[0].name == "mysnap"


### PR DESCRIPTION
## What

Foundation PR for opcli implementation: Pydantic V2 models, artifact discovery, and YAML I/O helpers.

### Models
- **artifacts.yaml**: `ArtifactsPlan` with rocks/charms/snaps, `Literal[1]` version, `extra=forbid`, unique name validators
- **artifacts-generated.yaml**: `ArtifactsGenerated` with `ArtifactOutput` (`run-id` alias, at-least-one-output validator)

### Discovery
- Walks repo recursively, prunes .git/.venv/.tox/etc, no symlink following
- Auto-links charm `oci-image` resources to discovered rocks when unambiguous

### YAML I/O
- `load_yaml`/`dump_yaml` wrappers over ruamel.yaml
- Typed load/dump for both model types with alias handling

### Tests
- 34 new tests covering model validation, discovery scenarios, YAML round-trips
- Total: 53 tests passing