### PR TITLE
Implement artifacts init and build commands

### DIFF
--- a/src/opcli/commands/artifacts.py
+++ b/src/opcli/commands/artifacts.py
@@ -1,6 +1,10 @@
 """CLI commands for artifact discovery and building."""
 
+from pathlib import Path
+
 import typer
+
+from opcli.core.artifacts import artifacts_build, artifacts_init
 
 app = typer.Typer(
     help="Discover and build charms, rocks, and snaps.",
@@ -16,7 +20,8 @@ def init(
     ),
 ) -> None:
     """Discover artifacts and generate artifacts.yaml."""
-    raise NotImplementedError("Implement in core/artifacts.py")
+    path = artifacts_init(Path.cwd(), force=force)
+    typer.echo(f"Wrote {path}")
 
 
 @app.command()
@@ -28,6 +33,15 @@ def build(
     rock: list[str] = typer.Option(
         [], "--rock", help="Build only this rock. Repeatable."
     ),
+    snap: list[str] = typer.Option(
+        [], "--snap", help="Build only this snap. Repeatable."
+    ),
 ) -> None:
     """Build artifacts and produce artifacts-generated.yaml."""
-    raise NotImplementedError("Implement in core/artifacts.py")
+    path = artifacts_build(
+        Path.cwd(),
+        charm_names=charm or None,
+        rock_names=rock or None,
+        snap_names=snap or None,
+    )
+    typer.echo(f"Wrote {path}")

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -1,0 +1,188 @@
+"""Core logic for ``opcli artifacts init`` and ``opcli artifacts build``.
+
+``init`` discovers artifacts and writes ``artifacts.yaml``.
+``build`` reads the plan, invokes pack tools, and writes
+``artifacts-generated.yaml``.
+"""
+
+from __future__ import annotations
+
+import glob as globmod
+import logging
+from pathlib import Path
+
+from opcli.core.discovery import discover_artifacts
+from opcli.core.exceptions import ConfigurationError, OpcliError
+from opcli.core.subprocess import run_command
+from opcli.core.yaml_io import (
+    dump_artifacts_generated,
+    dump_artifacts_plan,
+    load_artifacts_plan,
+)
+from opcli.models.artifacts import (
+    CharmArtifact,
+    RockArtifact,
+    SnapArtifact,
+)
+from opcli.models.artifacts_generated import (
+    ArtifactOutput,
+    ArtifactsGenerated,
+    GeneratedCharm,
+    GeneratedRock,
+    GeneratedSnap,
+)
+
+logger = logging.getLogger(__name__)
+
+_ARTIFACTS_YAML = "artifacts.yaml"
+_ARTIFACTS_GENERATED_YAML = "artifacts-generated.yaml"
+
+_PACK_COMMANDS: dict[str, list[str]] = {
+    "charm": ["charmcraft", "pack"],
+    "rock": ["rockcraft", "pack"],
+    "snap": ["snapcraft", "pack"],
+}
+
+_OUTPUT_GLOBS: dict[str, str] = {
+    "charm": "*.charm",
+    "rock": "*.rock",
+    "snap": "*.snap",
+}
+
+
+def artifacts_init(root: Path, *, force: bool = False) -> Path:
+    """Discover artifacts and write ``artifacts.yaml``.
+
+    Returns:
+        The path to the written file.
+
+    Raises:
+        ConfigurationError: If the file already exists and *force* is False.
+    """
+    dest = root / _ARTIFACTS_YAML
+    if dest.exists() and not force:
+        msg = f"{_ARTIFACTS_YAML} already exists. Use --force to overwrite."
+        raise ConfigurationError(msg)
+
+    plan = discover_artifacts(root)
+    dump_artifacts_plan(plan, dest)
+    logger.info(
+        "Wrote %s (%d charms, %d rocks, %d snaps)",
+        dest,
+        len(plan.charms),
+        len(plan.rocks),
+        len(plan.snaps),
+    )
+    return dest
+
+
+def _find_output_file(source_dir: Path, kind: str) -> str:
+    """Glob for the built artifact in *source_dir*."""
+    pattern = _OUTPUT_GLOBS[kind]
+    matches = sorted(globmod.glob(str(source_dir / pattern)))
+    if not matches:
+        msg = f"No {pattern} found in {source_dir} after pack"
+        raise OpcliError(msg)
+    if len(matches) > 1:
+        logger.warning(
+            "Multiple %s files in %s; using %s",
+            pattern,
+            source_dir,
+            matches[0],
+        )
+    return matches[0]
+
+
+def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
+    source_dir = root / rock.source
+    run_command([*_PACK_COMMANDS["rock"]], cwd=str(source_dir))
+    output_file = _find_output_file(source_dir, "rock")
+    return GeneratedRock(
+        name=rock.name,
+        source=rock.source,
+        output=ArtifactOutput(file=output_file),
+    )
+
+
+def _build_charm(charm: CharmArtifact, root: Path) -> GeneratedCharm:
+    source_dir = root / charm.source
+    run_command([*_PACK_COMMANDS["charm"]], cwd=str(source_dir))
+    output_file = _find_output_file(source_dir, "charm")
+    return GeneratedCharm(
+        name=charm.name,
+        source=charm.source,
+        output=ArtifactOutput(file=output_file),
+    )
+
+
+def _build_snap(snap: SnapArtifact, root: Path) -> GeneratedSnap:
+    source_dir = root / snap.source
+    run_command([*_PACK_COMMANDS["snap"]], cwd=str(source_dir))
+    output_file = _find_output_file(source_dir, "snap")
+    return GeneratedSnap(
+        name=snap.name,
+        source=snap.source,
+        output=ArtifactOutput(file=output_file),
+    )
+
+
+def artifacts_build(
+    root: Path,
+    *,
+    charm_names: list[str] | None = None,
+    rock_names: list[str] | None = None,
+    snap_names: list[str] | None = None,
+) -> Path:
+    """Build artifacts and write ``artifacts-generated.yaml``.
+
+    If *charm_names*, *rock_names*, or *snap_names* are given, only
+    those artifacts are built.  Otherwise all declared artifacts are built.
+
+    Returns:
+        The path to the written file.
+
+    Raises:
+        ConfigurationError: If ``artifacts.yaml`` does not exist.
+        OpcliError: If a build fails or no output file is found.
+    """
+    plan_path = root / _ARTIFACTS_YAML
+    if not plan_path.exists():
+        msg = f"{_ARTIFACTS_YAML} not found. Run 'opcli artifacts init' first."
+        raise ConfigurationError(msg)
+
+    plan = load_artifacts_plan(plan_path)
+    rocks_to_build = _filter_by_name(plan.rocks, rock_names, "rock")
+    charms_to_build = _filter_by_name(plan.charms, charm_names, "charm")
+    snaps_to_build = _filter_by_name(plan.snaps, snap_names, "snap")
+
+    gen_rocks = [_build_rock(r, root) for r in rocks_to_build]
+    gen_charms = [_build_charm(c, root) for c in charms_to_build]
+    gen_snaps = [_build_snap(s, root) for s in snaps_to_build]
+
+    generated = ArtifactsGenerated(
+        rocks=gen_rocks,
+        charms=gen_charms,
+        snaps=gen_snaps,
+    )
+
+    dest = root / _ARTIFACTS_GENERATED_YAML
+    dump_artifacts_generated(generated, dest)
+    logger.info("Wrote %s", dest)
+    return dest
+
+
+def _filter_by_name[T: (RockArtifact, CharmArtifact, SnapArtifact)](
+    items: list[T],
+    names: list[str] | None,
+    kind: str,
+) -> list[T]:
+    """Return items filtered by *names*, or all if *names* is None/empty."""
+    if not names:
+        return items
+    name_set = set(names)
+    available = {item.name for item in items}
+    unknown = name_set - available
+    if unknown:
+        msg = f"Unknown {kind}(s): {', '.join(sorted(unknown))}"
+        raise ConfigurationError(msg)
+    return [item for item in items if item.name in name_set]

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1,0 +1,175 @@
+"""Tests for ``opcli artifacts init`` and ``opcli artifacts build``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from opcli.core.artifacts import artifacts_build, artifacts_init
+from opcli.core.exceptions import ConfigurationError, OpcliError
+from opcli.core.yaml_io import load_artifacts_generated, load_artifacts_plan
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestArtifactsInit:
+    """Tests for artifacts_init()."""
+
+    def test_generates_artifacts_yaml(self, tmp_path: Path) -> None:
+        _write(tmp_path / "charmcraft.yaml", "name: mycharm\ntype: charm\n")
+        _write(tmp_path / "rock_dir" / "rockcraft.yaml", "name: myrock\n")
+
+        result = artifacts_init(tmp_path)
+
+        assert result == tmp_path / "artifacts.yaml"
+        assert result.exists()
+        plan = load_artifacts_plan(result)
+        assert len(plan.charms) == 1
+        assert len(plan.rocks) == 1
+        assert plan.charms[0].name == "mycharm"
+        assert plan.rocks[0].name == "myrock"
+
+    def test_refuses_overwrite_without_force(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts.yaml", "version: 1\n")
+
+        with pytest.raises(ConfigurationError, match="already exists"):
+            artifacts_init(tmp_path)
+
+    def test_overwrites_with_force(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts.yaml", "version: 1\n")
+        _write(tmp_path / "charmcraft.yaml", "name: new-charm\ntype: charm\n")
+
+        result = artifacts_init(tmp_path, force=True)
+
+        plan = load_artifacts_plan(result)
+        assert plan.charms[0].name == "new-charm"
+
+    def test_empty_repo(self, tmp_path: Path) -> None:
+        result = artifacts_init(tmp_path)
+        plan = load_artifacts_plan(result)
+        assert plan.charms == []
+        assert plan.rocks == []
+        assert plan.snaps == []
+
+
+class TestArtifactsBuild:
+    """Tests for artifacts_build()."""
+
+    def test_missing_artifacts_yaml_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="not found"):
+            artifacts_build(tmp_path)
+
+    def test_build_single_charm(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n- name: mycharm\n  source: .\n",
+        )
+        # Simulate charmcraft pack producing a .charm file
+        _write(tmp_path / "mycharm_amd64.charm", "fake charm")
+
+        with patch("opcli.core.artifacts.run_command") as mock_run:
+            result = artifacts_build(tmp_path)
+
+        mock_run.assert_called_once()
+        assert "charmcraft" in mock_run.call_args[0][0]
+        gen = load_artifacts_generated(result)
+        assert len(gen.charms) == 1
+        assert gen.charms[0].name == "mycharm"
+        assert gen.charms[0].output.file is not None
+        assert gen.charms[0].output.file.endswith(".charm")
+
+    def test_build_single_rock(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\nrocks:\n- name: myrock\n  source: rock_dir\n",
+        )
+        rock_dir = tmp_path / "rock_dir"
+        rock_dir.mkdir()
+        _write(rock_dir / "myrock_1.0_amd64.rock", "fake rock")
+
+        with patch("opcli.core.artifacts.run_command") as mock_run:
+            result = artifacts_build(tmp_path)
+
+        mock_run.assert_called_once()
+        assert "rockcraft" in mock_run.call_args[0][0]
+        gen = load_artifacts_generated(result)
+        assert len(gen.rocks) == 1
+        assert gen.rocks[0].output.file is not None
+
+    def test_build_single_snap(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\nsnaps:\n- name: mysnap\n  source: snap_dir\n",
+        )
+        snap_dir = tmp_path / "snap_dir"
+        snap_dir.mkdir()
+        _write(snap_dir / "mysnap_1.0_amd64.snap", "fake snap")
+
+        with patch("opcli.core.artifacts.run_command") as mock_run:
+            result = artifacts_build(tmp_path)
+
+        mock_run.assert_called_once()
+        assert "snapcraft" in mock_run.call_args[0][0]
+        gen = load_artifacts_generated(result)
+        assert len(gen.snaps) == 1
+
+    def test_build_filtered_by_charm_name(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n"
+            "- name: charm-a\n  source: a\n"
+            "- name: charm-b\n  source: b\n",
+        )
+        (tmp_path / "a").mkdir()
+        _write(tmp_path / "a" / "charm-a.charm", "fake")
+
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path, charm_names=["charm-a"])
+
+        gen = load_artifacts_generated(result)
+        assert len(gen.charms) == 1
+        assert gen.charms[0].name == "charm-a"
+
+    def test_unknown_charm_name_raises(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n- name: real\n  source: .\n",
+        )
+        with pytest.raises(ConfigurationError, match="Unknown charm"):
+            artifacts_build(tmp_path, charm_names=["nonexistent"])
+
+    def test_no_output_file_raises(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\nrocks:\n- name: myrock\n  source: rock_dir\n",
+        )
+        (tmp_path / "rock_dir").mkdir()
+
+        with (
+            patch("opcli.core.artifacts.run_command"),
+            pytest.raises(OpcliError, match=r"No \*.rock found"),
+        ):
+            artifacts_build(tmp_path)
+
+    def test_build_monorepo(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "rocks:\n- name: myrock\n  source: rock_dir\n"
+            "charms:\n- name: mycharm\n  source: .\n",
+        )
+        (tmp_path / "rock_dir").mkdir()
+        _write(tmp_path / "rock_dir" / "myrock.rock", "fake")
+        _write(tmp_path / "mycharm.charm", "fake")
+
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path)
+
+        gen = load_artifacts_generated(result)
+        assert len(gen.rocks) == 1
+        assert len(gen.charms) == 1


### PR DESCRIPTION
## What

Wires up `opcli artifacts init` and `opcli artifacts build` with real core logic.

### `artifacts init`
- Discovers charms/rocks/snaps via existing discovery module
- Writes `artifacts.yaml`; refuses overwrite without `--force`

### `artifacts build`
- Reads `artifacts.yaml`, dispatches to `charmcraft pack`/`rockcraft pack`/`snapcraft pack`
- Globs for output files, writes `artifacts-generated.yaml`
- Supports `--charm`/`--rock`/`--snap` filters with unknown-name validation

### Tests
- 12 new tests (init, build, filtering, error paths)
- Total: 65 tests passing