### PR TITLE
Implement pytest args and run commands

### DIFF
--- a/src/opcli/commands/pytest_cmd.py
+++ b/src/opcli/commands/pytest_cmd.py
@@ -1,6 +1,10 @@
 """CLI commands for pytest/tox integration test execution."""
 
+from pathlib import Path
+
 import typer
+
+from opcli.core.pytest_args import assemble_pytest_args, run_pytest
 
 app = typer.Typer(
     help="Assemble pytest flags from build output and run integration tests.",
@@ -17,11 +21,14 @@ def run(
     tox_env: str = typer.Option("integration", "-e", help="Tox environment name."),
 ) -> None:
     """Run integration tests via tox. Extra args after -- are forwarded to pytest."""
-    _extra_args = ctx.args
-    raise NotImplementedError("Implement in core/pytest_args.py — run logic")
+    run_pytest(Path.cwd(), tox_env=tox_env, extra_args=ctx.args or None)
 
 
 @app.command()
 def args() -> None:
     """Print assembled tox/pytest flags from artifacts-generated.yaml."""
-    raise NotImplementedError("Implement in core/pytest_args.py — args logic")
+    flags = assemble_pytest_args(Path.cwd())
+    if flags:
+        typer.echo(" ".join(flags))
+    else:
+        typer.echo("# No flags assembled (no charms/resources found)")

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -1,0 +1,106 @@
+"""Core logic for ``opcli pytest args`` and ``opcli pytest run``.
+
+Reads ``artifacts-generated.yaml`` and assembles the flags that tox/pytest
+need to locate built charms and their OCI-image resources.
+
+Convention (matching operator-workflows):
+    --charm-file <path>          for each locally built charm
+    --<resource-name> <path>     for each OCI-image resource with a local file
+    --<resource-name> <image>    for each OCI-image resource with a registry image
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from opcli.core.exceptions import ConfigurationError
+from opcli.core.subprocess import run_command
+from opcli.core.yaml_io import load_artifacts_generated, load_artifacts_plan
+from opcli.models.artifacts import ArtifactsPlan
+from opcli.models.artifacts_generated import ArtifactsGenerated
+
+logger = logging.getLogger(__name__)
+
+_ARTIFACTS_YAML = "artifacts.yaml"
+_ARTIFACTS_GENERATED_YAML = "artifacts-generated.yaml"
+
+
+def _resolve_resource_value(
+    resource_rock: str | None,
+    generated: ArtifactsGenerated,
+) -> str | None:
+    """Find the output value for a rock linked to a charm resource."""
+    if resource_rock is None:
+        return None
+    for rock in generated.rocks:
+        if rock.name == resource_rock:
+            return rock.output.file or rock.output.image
+    return None
+
+
+def assemble_pytest_args(
+    root: Path,
+) -> list[str]:
+    """Build the list of pytest flags from the generated artifacts.
+
+    Returns:
+        A list of CLI flags like
+        ``["--charm-file", "path.charm", "--img", "path.rock"]``.
+
+    Raises:
+        ConfigurationError: If required YAML files are missing.
+    """
+    gen_path = root / _ARTIFACTS_GENERATED_YAML
+    if not gen_path.exists():
+        msg = (
+            f"{_ARTIFACTS_GENERATED_YAML} not found. Run 'opcli artifacts build' first."
+        )
+        raise ConfigurationError(msg)
+
+    generated = load_artifacts_generated(gen_path)
+
+    # Load the plan to get resource definitions (rock links).
+    plan_path = root / _ARTIFACTS_YAML
+    plan: ArtifactsPlan | None = None
+    if plan_path.exists():
+        plan = load_artifacts_plan(plan_path)
+
+    args: list[str] = []
+
+    for charm in generated.charms:
+        if charm.output.file:
+            args.extend(["--charm-file", charm.output.file])
+
+        # Resolve resource flags from the plan's resource definitions.
+        if plan is None:
+            continue
+        plan_charm = next((c for c in plan.charms if c.name == charm.name), None)
+        if plan_charm is None:
+            continue
+        for res_name, res_def in plan_charm.resources.items():
+            value = _resolve_resource_value(res_def.rock, generated)
+            if value:
+                args.extend([f"--{res_name}", value])
+
+    return args
+
+
+def run_pytest(
+    root: Path,
+    *,
+    tox_env: str = "integration",
+    extra_args: list[str] | None = None,
+) -> None:
+    """Assemble flags and run ``tox -e <env> -- <flags> <extra>``.
+
+    Raises:
+        ConfigurationError: If required YAML files are missing.
+        SubprocessError: If tox exits non-zero.
+    """
+    assembled = assemble_pytest_args(root)
+    cmd = ["tox", "-e", tox_env, "--"]
+    cmd.extend(assembled)
+    if extra_args:
+        cmd.extend(extra_args)
+    run_command(cmd, cwd=str(root))

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -1,0 +1,161 @@
+"""Tests for ``opcli pytest args`` and ``opcli pytest run``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from opcli.core.exceptions import ConfigurationError
+from opcli.core.pytest_args import assemble_pytest_args, run_pytest
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+_PLAN_WITH_RESOURCES = """\
+version: 1
+rocks:
+- name: myrock
+  source: rock_dir
+charms:
+- name: mycharm
+  source: .
+  resources:
+    myrock-image:
+      type: oci-image
+      rock: myrock
+"""
+
+_GENERATED_LOCAL = """\
+version: 1
+rocks:
+- name: myrock
+  source: rock_dir
+  output:
+    file: ./rock_dir/myrock.rock
+charms:
+- name: mycharm
+  source: .
+  output:
+    file: ./mycharm.charm
+"""
+
+_GENERATED_CI = """\
+version: 1
+rocks:
+- name: myrock
+  source: rock_dir
+  output:
+    image: ghcr.io/canonical/myrock:abc123
+charms:
+- name: mycharm
+  source: .
+  output:
+    artifact: charm-mycharm
+    run-id: "999"
+"""
+
+
+class TestAssemblePytestArgs:
+    """Tests for assemble_pytest_args()."""
+
+    def test_missing_generated_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="not found"):
+            assemble_pytest_args(tmp_path)
+
+    def test_local_charm_with_rock_resource(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts.yaml", _PLAN_WITH_RESOURCES)
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_LOCAL)
+
+        args = assemble_pytest_args(tmp_path)
+
+        assert "--charm-file" in args
+        assert "./mycharm.charm" in args
+        assert "--myrock-image" in args
+        assert "./rock_dir/myrock.rock" in args
+
+    def test_ci_charm_with_image_resource(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts.yaml", _PLAN_WITH_RESOURCES)
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_CI)
+
+        args = assemble_pytest_args(tmp_path)
+
+        # CI charm has artifact output, not file — no --charm-file
+        assert "--charm-file" not in args
+        # Rock has image output
+        assert "--myrock-image" in args
+        assert "ghcr.io/canonical/myrock:abc123" in args
+
+    def test_no_plan_still_produces_charm_file(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_LOCAL)
+        # No artifacts.yaml → no resource linking, but charm-file still works
+
+        args = assemble_pytest_args(tmp_path)
+
+        assert "--charm-file" in args
+        assert "--myrock-image" not in args
+
+    def test_charm_without_resources(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n- name: simple\n  source: .\n",
+        )
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            "version: 1\ncharms:\n- name: simple\n  source: .\n"
+            "  output:\n    file: ./simple.charm\n",
+        )
+
+        args = assemble_pytest_args(tmp_path)
+
+        assert args == ["--charm-file", "./simple.charm"]
+
+    def test_empty_generated(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+
+        args = assemble_pytest_args(tmp_path)
+        assert args == []
+
+
+class TestRunPytest:
+    """Tests for run_pytest()."""
+
+    def test_runs_tox_with_assembled_args(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts.yaml", _PLAN_WITH_RESOURCES)
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_LOCAL)
+
+        with patch("opcli.core.pytest_args.run_command") as mock_run:
+            run_pytest(tmp_path)
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:4] == ["tox", "-e", "integration", "--"]
+        assert "--charm-file" in cmd
+        assert "./mycharm.charm" in cmd
+
+    def test_custom_tox_env(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+
+        with patch("opcli.core.pytest_args.run_command") as mock_run:
+            run_pytest(tmp_path, tox_env="e2e")
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[2] == "e2e"
+
+    def test_extra_args_forwarded(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+
+        with patch("opcli.core.pytest_args.run_command") as mock_run:
+            run_pytest(tmp_path, extra_args=["-k", "test_foo", "-v"])
+
+        cmd = mock_run.call_args[0][0]
+        assert "-k" in cmd
+        assert "test_foo" in cmd
+        assert "-v" in cmd
+
+    def test_missing_generated_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="not found"):
+            run_pytest(tmp_path)


### PR DESCRIPTION
## What

Wires up `opcli pytest args` and `opcli pytest run`.

### `pytest args`
- Reads `artifacts-generated.yaml` + `artifacts.yaml` (for resource links)
- Assembles `--charm-file` and `--<resource-name>` flags
- Works for both local (file paths) and CI (image refs) outputs

### `pytest run`  
- Assembles flags then runs `tox -e <env> -- <flags> <extra_args>`
- Supports `-e` for custom tox environment, `--` for extra pytest args

### Tests
- 10 new tests: flag assembly (local, CI, no plan, no resources, empty), tox dispatch, custom env, extra args forwarding
- Total: 75 tests passing