### PR TITLE
Implement spread init, expand, and run commands

### DIFF
--- a/src/opcli/commands/spread.py
+++ b/src/opcli/commands/spread.py
@@ -1,6 +1,10 @@
 """CLI commands for spread-based test execution."""
 
+from pathlib import Path
+
 import typer
+
+from opcli.core.spread import spread_expand, spread_init, spread_run
 
 app = typer.Typer(
     help="Generate, expand, and run spread-based integration tests.",
@@ -12,11 +16,13 @@ app = typer.Typer(
 def init(
     *,
     force: bool = typer.Option(
-        False, "--force", help="Overwrite existing spread.yaml."
+        False, "--force", help="Overwrite existing spread.yaml and task.yaml."
     ),
 ) -> None:
     """Generate spread.yaml and tests/run/task.yaml."""
-    raise NotImplementedError("Implement in core/spread.py")
+    spread_path, task_path = spread_init(Path.cwd(), force=force)
+    typer.echo(f"Wrote {spread_path}")
+    typer.echo(f"Wrote {task_path}")
 
 
 @app.command(
@@ -30,11 +36,11 @@ def run(ctx: typer.Context) -> None:
 
     Extra args after -- are forwarded to spread.
     """
-    _extra_args = ctx.args
-    raise NotImplementedError("Implement in core/spread.py")
+    spread_run(Path.cwd(), extra_args=ctx.args or None)
 
 
 @app.command()
 def expand() -> None:
     """Print the fully expanded spread.yaml to stdout."""
-    raise NotImplementedError("Implement in core/spread.py — expand logic")
+    content = spread_expand(Path.cwd())
+    typer.echo(content, nl=False)

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -1,0 +1,264 @@
+"""Core logic for ``opcli spread init``, ``expand``, and ``run``.
+
+``init`` discovers integration test modules and generates ``spread.yaml``
+plus ``tests/run/task.yaml``.
+
+``expand`` reads ``spread.yaml``, replaces the virtual ``integration-test``
+backend with a concrete ``local:`` or ``ci:`` backend, and returns the
+expanded YAML.  The original file is **never** modified.
+
+``run`` expands to a temporary file and invokes ``spread`` as a subprocess.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from copy import deepcopy
+from io import StringIO
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+from opcli.core.exceptions import ConfigurationError
+from opcli.core.subprocess import run_command
+
+logger = logging.getLogger(__name__)
+
+_yaml = YAML()
+_yaml.default_flow_style = False
+
+_SPREAD_YAML = "spread.yaml"
+_TASK_YAML_REL = "tests/run/task.yaml"
+_VIRTUAL_BACKEND = "integration-test"
+
+
+# ---------------------------------------------------------------------------
+#  spread init
+# ---------------------------------------------------------------------------
+
+
+def _discover_test_modules(root: Path) -> list[str]:
+    """Find ``test_*.py`` files under ``tests/integration/``."""
+    integration_dir = root / "tests" / "integration"
+    if not integration_dir.is_dir():
+        return []
+    modules = sorted(p.stem for p in integration_dir.glob("test_*.py") if p.is_file())
+    return modules
+
+
+def _generate_spread_yaml(
+    project_name: str,
+    modules: list[str],
+) -> str:
+    """Build the default ``spread.yaml`` content."""
+    buf = StringIO()
+    data: dict[str, object] = {
+        "project": project_name,
+        "backends": {
+            _VIRTUAL_BACKEND: {
+                "systems": ["ubuntu-24.04"],
+            },
+        },
+    }
+
+    env: dict[str, str] = {
+        "CONCIERGE": '$(HOST: echo "${CONCIERGE:-concierge.yaml}")',
+    }
+    if modules:
+        for mod in modules:
+            env[f"MODULE/{mod}"] = mod
+    else:
+        env["MODULE/tests"] = "tests"
+    data["environment"] = env
+
+    data["suites"] = {
+        "tests/": {},
+    }
+
+    _yaml.dump(data, buf)
+    return buf.getvalue()
+
+
+_TASK_YAML_CONTENT = """\
+summary: integration tests
+
+execute: |
+    $( opcli pytest run -- -k $MODULE )
+"""
+
+
+def spread_init(root: Path, *, force: bool = False) -> tuple[Path, Path]:
+    """Generate ``spread.yaml`` and ``tests/run/task.yaml``.
+
+    Returns:
+        Tuple of (spread.yaml path, task.yaml path).
+
+    Raises:
+        ConfigurationError: If files exist and *force* is ``False``.
+    """
+    spread_path = root / _SPREAD_YAML
+    task_path = root / _TASK_YAML_REL
+
+    if not force:
+        for p in (spread_path, task_path):
+            if p.exists():
+                msg = f"{p.name} already exists. Use --force to overwrite."
+                raise ConfigurationError(msg)
+
+    project_name = root.resolve().name
+    modules = _discover_test_modules(root)
+
+    spread_content = _generate_spread_yaml(project_name, modules)
+    spread_path.write_text(spread_content)
+    logger.info("Wrote %s", spread_path)
+
+    task_path.parent.mkdir(parents=True, exist_ok=True)
+    task_path.write_text(_TASK_YAML_CONTENT)
+    logger.info("Wrote %s", task_path)
+
+    return spread_path, task_path
+
+
+# ---------------------------------------------------------------------------
+#  spread expand
+# ---------------------------------------------------------------------------
+
+_LOCAL_PREPARE = """\
+#!/bin/bash
+set -eu
+sudo concierge prepare -c "$CONCIERGE"
+opcli provision load
+"""
+
+_CI_PREPARE = """\
+#!/bin/bash
+set -eu
+sudo concierge prepare -c "$CONCIERGE"
+"""
+
+
+def _is_ci() -> bool:
+    """Return True when running inside CI (truthy ``CI`` env var)."""
+    return bool(os.environ.get("CI"))
+
+
+def _expand_backend(
+    spread_data: dict[str, object],
+    *,
+    ci: bool | None = None,
+) -> dict[str, object]:
+    """Replace the virtual backend with a concrete one.
+
+    Args:
+        spread_data: Parsed spread.yaml (mutated in place on a deep copy).
+        ci: Force CI mode if True, local if False, auto-detect if None.
+
+    Returns:
+        New dict with the backend replaced.
+    """
+    data = deepcopy(spread_data)
+    backends = data.get("backends")
+    if not isinstance(backends, dict):
+        msg = "spread.yaml has no 'backends' section"
+        raise ConfigurationError(msg)
+
+    virtual = backends.pop(_VIRTUAL_BACKEND, None)
+    if virtual is None:
+        msg = (
+            f"spread.yaml has no '{_VIRTUAL_BACKEND}' virtual backend. "
+            "Nothing to expand."
+        )
+        raise ConfigurationError(msg)
+
+    use_ci = ci if ci is not None else _is_ci()
+
+    if use_ci:
+        backend_def: dict[str, object] = {
+            "type": "adhoc",
+            "allocate": "ADDRESS localhost",
+            "prepare": _CI_PREPARE,
+        }
+    else:
+        backend_def = {
+            "prepare": _LOCAL_PREPARE,
+        }
+
+    if isinstance(virtual, dict):
+        systems = virtual.get("systems")
+        if systems:
+            backend_def["systems"] = systems
+
+    backend_name = "ci" if use_ci else "local"
+    backends[backend_name] = backend_def
+    data["backends"] = backends
+    return data
+
+
+def spread_expand(
+    root: Path,
+    *,
+    ci: bool | None = None,
+) -> str:
+    """Read ``spread.yaml`` and return the expanded content as a string.
+
+    Raises:
+        ConfigurationError: If ``spread.yaml`` is missing or malformed.
+    """
+    spread_path = root / _SPREAD_YAML
+    if not spread_path.exists():
+        msg = f"{_SPREAD_YAML} not found. Run 'opcli spread init' first."
+        raise ConfigurationError(msg)
+
+    with spread_path.open() as fh:
+        data = _yaml.load(fh)
+
+    if not isinstance(data, dict):
+        msg = f"{_SPREAD_YAML} does not contain a YAML mapping"
+        raise ConfigurationError(msg)
+
+    expanded = _expand_backend(data, ci=ci)
+    buf = StringIO()
+    _yaml.dump(expanded, buf)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+#  spread run
+# ---------------------------------------------------------------------------
+
+
+def spread_run(
+    root: Path,
+    *,
+    extra_args: list[str] | None = None,
+    ci: bool | None = None,
+) -> None:
+    """Expand ``spread.yaml`` and run ``spread``.
+
+    The expanded file is written to a temporary location — the original
+    ``spread.yaml`` is never modified.
+
+    Raises:
+        ConfigurationError: If ``spread.yaml`` is missing or malformed.
+        SubprocessError: If spread exits non-zero.
+    """
+    expanded_content = spread_expand(root, ci=ci)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".yaml",
+        prefix="spread-expanded-",
+        delete=False,
+    ) as tmp:
+        tmp.write(expanded_content)
+        tmp_path = tmp.name
+
+    try:
+        cmd = ["spread", f"-spread={tmp_path}"]
+        if extra_args:
+            cmd.extend(extra_args)
+        run_command(cmd, cwd=str(root))
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -1,0 +1,202 @@
+"""Tests for ``opcli spread init``, ``expand``, and ``run``."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from ruamel.yaml import YAML
+
+from opcli.core.exceptions import ConfigurationError
+from opcli.core.spread import spread_expand, spread_init, spread_run
+
+_yaml = YAML()
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+_MINIMAL_SPREAD = """\
+project: test-project
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/: {}
+"""
+
+
+class TestSpreadInit:
+    """Tests for spread_init()."""
+
+    def test_generates_files(self, tmp_path: Path) -> None:
+        spread_path, task_path = spread_init(tmp_path)
+
+        assert spread_path.exists()
+        assert task_path.exists()
+        assert task_path == tmp_path / "tests" / "run" / "task.yaml"
+
+        content = spread_path.read_text()
+        assert "integration-test" in content
+
+        task_content = task_path.read_text()
+        assert "opcli pytest run" in task_content
+
+    def test_discovers_test_modules(self, tmp_path: Path) -> None:
+        test_dir = tmp_path / "tests" / "integration"
+        test_dir.mkdir(parents=True)
+        (test_dir / "test_charm.py").write_text("")
+        (test_dir / "test_actions.py").write_text("")
+        (test_dir / "conftest.py").write_text("")  # not a test module
+
+        spread_path, _ = spread_init(tmp_path)
+
+        content = spread_path.read_text()
+        assert "MODULE/test_charm" in content
+        assert "MODULE/test_actions" in content
+        assert "conftest" not in content
+
+    def test_refuses_overwrite_without_force(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", "existing\n")
+
+        with pytest.raises(ConfigurationError, match="already exists"):
+            spread_init(tmp_path)
+
+    def test_overwrites_with_force(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", "old\n")
+        _write(tmp_path / "tests" / "run" / "task.yaml", "old\n")
+
+        spread_path, task_path = spread_init(tmp_path, force=True)
+        assert "integration-test" in spread_path.read_text()
+        assert "opcli pytest run" in task_path.read_text()
+
+    def test_project_name_from_directory(self, tmp_path: Path) -> None:
+        spread_path, _ = spread_init(tmp_path)
+        content = spread_path.read_text()
+        assert f"project: {tmp_path.resolve().name}" in content
+
+
+class TestSpreadExpand:
+    """Tests for spread_expand()."""
+
+    def test_missing_spread_yaml_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="not found"):
+            spread_expand(tmp_path)
+
+    def test_expand_local(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        result = spread_expand(tmp_path, ci=False)
+
+        assert "local:" in result or "local" in result
+        assert "integration-test" not in result
+        assert "concierge" in result
+
+    def test_expand_ci(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        result = spread_expand(tmp_path, ci=True)
+
+        assert "ci:" in result or "ci" in result
+        assert "integration-test" not in result
+        assert "adhoc" in result
+        assert "localhost" in result
+
+    def test_preserves_other_sections(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        result = spread_expand(tmp_path, ci=False)
+
+        assert "project: test-project" in result
+        assert "MODULE/test_charm" in result
+        assert "suites:" in result
+
+    def test_preserves_systems(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        result = spread_expand(tmp_path, ci=False)
+
+        assert "ubuntu-24.04" in result
+
+    def test_no_virtual_backend_raises(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "spread.yaml",
+            "project: x\nbackends:\n  lxd:\n    systems: []\n",
+        )
+        with pytest.raises(ConfigurationError, match="no 'integration-test'"):
+            spread_expand(tmp_path)
+
+    def test_auto_detects_ci_env(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        with patch.dict("os.environ", {"CI": "true"}):
+            result = spread_expand(tmp_path)
+        assert "adhoc" in result
+
+        with patch.dict("os.environ", {"CI": ""}, clear=False):
+            result = spread_expand(tmp_path)
+        assert "adhoc" not in result
+
+    def test_expanded_is_valid_yaml(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        result = spread_expand(tmp_path, ci=False)
+
+        parsed = _yaml.load(StringIO(result))
+        assert isinstance(parsed, dict)
+        assert "backends" in parsed
+
+
+class TestSpreadRun:
+    """Tests for spread_run()."""
+
+    def test_runs_spread_with_expanded_file(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        with patch("opcli.core.spread.run_command") as mock_run:
+            spread_run(tmp_path, ci=False)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "spread"
+        assert any(arg.startswith("-spread=") for arg in cmd)
+
+    def test_extra_args_forwarded(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        with patch("opcli.core.spread.run_command") as mock_run:
+            spread_run(
+                tmp_path,
+                extra_args=["local:ubuntu-24.04:tests/run:test_charm"],
+                ci=False,
+            )
+
+        cmd = mock_run.call_args[0][0]
+        assert "local:ubuntu-24.04:tests/run:test_charm" in cmd
+
+    def test_temp_file_cleaned_up(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        temp_paths: list[str] = []
+
+        def capture_cmd(cmd: list[str], **_kwargs: object) -> None:
+            for arg in cmd:
+                if arg.startswith("-spread="):
+                    temp_paths.append(arg.split("=", 1)[1])
+
+        with patch("opcli.core.spread.run_command", side_effect=capture_cmd):
+            spread_run(tmp_path, ci=False)
+
+        assert len(temp_paths) == 1
+        assert not Path(temp_paths[0]).exists()
+
+    def test_missing_spread_yaml_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="not found"):
+            spread_run(tmp_path)


### PR DESCRIPTION
## What

Implements all three spread commands — the most complex piece of opcli.

### `spread init`
- Discovers `test_*.py` modules under `tests/integration/`
- Generates `spread.yaml` with virtual `integration-test` backend and MODULE variants
- Generates `tests/run/task.yaml` with opcli pytest invocation

### `spread expand`
- Reads `spread.yaml` with ruamel.yaml (preserves all sections)
- Replaces `integration-test` virtual backend with concrete `local:` or `ci:` backend
- Auto-detects mode via `CI` env var, or accepts explicit override
- Never modifies the original file

### `spread run`
- Expands to a temp file, invokes `spread -spread=<tempfile> <extra_args>`
- Cleans up temp file in finally block

### Tests
- 17 new tests covering init, expand (local/CI/auto-detect/invalid), run (dispatch/args/cleanup)
- Total: 92 tests passing