### PR TITLE
Implement provision run and load commands

### DIFF
--- a/src/opcli/commands/provision.py
+++ b/src/opcli/commands/provision.py
@@ -1,6 +1,10 @@
 """CLI commands for environment provisioning."""
 
+from pathlib import Path
+
 import typer
+
+from opcli.core.provision import provision_load, provision_run
 
 app = typer.Typer(
     help="Provision test environments with concierge.",
@@ -11,7 +15,8 @@ app = typer.Typer(
 @app.command()
 def run() -> None:
     """Run concierge prepare to provision the test environment."""
-    raise NotImplementedError("Implement in core/provision.py")
+    provision_run(Path.cwd())
+    typer.echo("Provisioning complete.")
 
 
 @app.command()
@@ -22,4 +27,9 @@ def load(
     ),
 ) -> None:
     """Load OCI image artifacts into a local image registry."""
-    raise NotImplementedError("Implement in core/provision.py — load logic")
+    pushed = provision_load(Path.cwd(), registry=registry)
+    if pushed:
+        for ref in pushed:
+            typer.echo(f"Pushed {ref}")
+    else:
+        typer.echo("No rock images to load.")

--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -1,0 +1,117 @@
+"""Core logic for ``opcli provision run`` and ``opcli provision load``.
+
+``run`` invokes concierge to provision the test environment.
+
+``load`` reads ``artifacts-generated.yaml`` and pushes locally-built rock
+OCI images into a container image registry so that Juju / MicroK8s can
+pull them during integration tests.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from opcli.core.exceptions import ConfigurationError
+from opcli.core.subprocess import run_command
+from opcli.core.yaml_io import load_artifacts_generated
+
+logger = logging.getLogger(__name__)
+
+_CONCIERGE_YAML = "concierge.yaml"
+_ARTIFACTS_GENERATED_YAML = "artifacts-generated.yaml"
+_DEFAULT_REGISTRY = "localhost:32000"
+
+
+def provision_run(
+    root: Path,
+    *,
+    concierge_file: str = _CONCIERGE_YAML,
+) -> None:
+    """Run ``sudo concierge prepare`` to provision the test environment.
+
+    Raises:
+        ConfigurationError: If the concierge file does not exist.
+        SubprocessError: If concierge exits non-zero.
+    """
+    concierge_path = root / concierge_file
+    if not concierge_path.exists():
+        msg = (
+            f"{concierge_file} not found. "
+            "Create a concierge.yaml in the repository root."
+        )
+        raise ConfigurationError(msg)
+
+    run_command(
+        ["sudo", "concierge", "prepare", "-c", str(concierge_path)],
+        cwd=str(root),
+    )
+    logger.info("Provisioning complete via %s", concierge_file)
+
+
+def provision_load(
+    root: Path,
+    *,
+    registry: str = _DEFAULT_REGISTRY,
+) -> list[str]:
+    """Push locally-built rock images to *registry*.
+
+    Reads ``artifacts-generated.yaml`` and for each rock with a local
+    ``file`` output, converts the ``.rock`` archive to an OCI image and
+    pushes it to the target registry using ``skopeo``.
+
+    Returns:
+        List of image references that were pushed.
+
+    Raises:
+        ConfigurationError: If ``artifacts-generated.yaml`` is missing.
+        SubprocessError: If a push command fails.
+    """
+    gen_path = root / _ARTIFACTS_GENERATED_YAML
+    if not gen_path.exists():
+        msg = (
+            f"{_ARTIFACTS_GENERATED_YAML} not found. Run 'opcli artifacts build' first."
+        )
+        raise ConfigurationError(msg)
+
+    generated = load_artifacts_generated(gen_path)
+    pushed: list[str] = []
+
+    for rock in generated.rocks:
+        if not rock.output.file:
+            continue
+
+        rock_path = Path(rock.output.file)
+        image_ref = f"{registry}/{rock.name}:latest"
+
+        # rockcraft.load converts a .rock archive to a local Docker image
+        run_command(
+            [
+                "sudo",
+                "rockcraft.skopeo",
+                "--insecure-policy",
+                "copy",
+                f"oci-archive:{rock_path}",
+                f"docker-daemon:{rock.name}:latest",
+            ],
+            cwd=str(root),
+        )
+
+        # Push to the target registry
+        run_command(
+            [
+                "sudo",
+                "rockcraft.skopeo",
+                "--insecure-policy",
+                "copy",
+                "--dest-tls-verify=false",
+                f"docker-daemon:{rock.name}:latest",
+                f"docker://{image_ref}",
+            ],
+            cwd=str(root),
+        )
+
+        pushed.append(image_ref)
+        logger.info("Pushed %s", image_ref)
+
+    return pushed

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -1,0 +1,136 @@
+"""Tests for ``opcli provision run`` and ``opcli provision load``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from opcli.core.exceptions import ConfigurationError
+from opcli.core.provision import provision_load, provision_run
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+_GENERATED_WITH_ROCKS = """\
+version: 1
+rocks:
+- name: myrock
+  source: rock_dir
+  output:
+    file: ./rock_dir/myrock.rock
+- name: otherrock
+  source: other
+  output:
+    image: ghcr.io/canonical/otherrock:abc
+charms:
+- name: mycharm
+  source: .
+  output:
+    file: ./mycharm.charm
+"""
+
+
+class TestProvisionRun:
+    """Tests for provision_run()."""
+
+    def test_runs_concierge(self, tmp_path: Path) -> None:
+        _write(tmp_path / "concierge.yaml", "providers: {}\n")
+
+        with patch("opcli.core.provision.run_command") as mock_run:
+            provision_run(tmp_path)
+
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert "concierge" in cmd
+        assert "prepare" in cmd
+        assert any("concierge.yaml" in arg for arg in cmd)
+
+    def test_missing_concierge_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="not found"):
+            provision_run(tmp_path)
+
+    def test_custom_concierge_file(self, tmp_path: Path) -> None:
+        _write(tmp_path / "concierge_juju4.yaml", "providers: {}\n")
+
+        with patch("opcli.core.provision.run_command") as mock_run:
+            provision_run(tmp_path, concierge_file="concierge_juju4.yaml")
+
+        cmd = mock_run.call_args[0][0]
+        assert any("concierge_juju4.yaml" in arg for arg in cmd)
+
+
+class TestProvisionLoad:
+    """Tests for provision_load()."""
+
+    def test_missing_generated_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="not found"):
+            provision_load(tmp_path)
+
+    def test_pushes_local_rocks(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_WITH_ROCKS)
+
+        with patch("opcli.core.provision.run_command") as mock_run:
+            pushed = provision_load(tmp_path)
+
+        # Only myrock has a file output; otherrock has image (CI) → skipped
+        assert len(pushed) == 1
+        assert "myrock" in pushed[0]
+        assert "localhost:32000" in pushed[0]
+        # Two skopeo calls: copy to docker-daemon, then push to registry
+        assert mock_run.call_count == 2  # noqa: PLR2004
+
+    def test_custom_registry(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_WITH_ROCKS)
+
+        with patch("opcli.core.provision.run_command") as mock_run:
+            pushed = provision_load(tmp_path, registry="myregistry:5000")
+
+        assert "myregistry:5000" in pushed[0]
+        # Verify the push command uses the custom registry
+        push_cmd = mock_run.call_args_list[1][0][0]
+        assert any("myregistry:5000" in arg for arg in push_cmd)
+
+    def test_no_local_rocks_returns_empty(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            "version: 1\n"
+            "rocks:\n- name: r1\n  source: rd\n"
+            "  output:\n    image: ghcr.io/r1:v1\n",
+        )
+
+        with patch("opcli.core.provision.run_command") as mock_run:
+            pushed = provision_load(tmp_path)
+
+        assert pushed == []
+        mock_run.assert_not_called()
+
+    def test_empty_generated_returns_empty(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+
+        with patch("opcli.core.provision.run_command") as mock_run:
+            pushed = provision_load(tmp_path)
+
+        assert pushed == []
+        mock_run.assert_not_called()
+
+    def test_skopeo_commands_correct(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_WITH_ROCKS)
+
+        with patch("opcli.core.provision.run_command") as mock_run:
+            provision_load(tmp_path)
+
+        # First call: copy rock archive to docker daemon
+        copy_cmd = mock_run.call_args_list[0][0][0]
+        assert "rockcraft.skopeo" in copy_cmd
+        assert any("oci-archive:" in arg for arg in copy_cmd)
+        assert any("docker-daemon:" in arg for arg in copy_cmd)
+
+        # Second call: push from docker daemon to registry
+        push_cmd = mock_run.call_args_list[1][0][0]
+        assert "rockcraft.skopeo" in push_cmd
+        assert any("docker://" in arg for arg in push_cmd)


### PR DESCRIPTION
## What

Final command family — wires up `opcli provision run` and `opcli provision load`.

### `provision run`
- Runs `sudo concierge prepare -c concierge.yaml`
- Supports custom concierge file for multi-env setups (e.g. `concierge_juju4.yaml`)

### `provision load`
- Reads `artifacts-generated.yaml`, finds rocks with local file outputs
- Uses `rockcraft.skopeo` to copy rock archives → docker daemon → target registry
- Defaults to `localhost:32000` (MicroK8s), configurable via `-r`
- Skips rocks with CI outputs (already in GHCR)

### Tests
- 9 new tests: concierge dispatch, skopeo command verification, custom registry, CI-skip, empty scenarios
- **Total: 101 tests passing — all 4 command families fully implemented** 🎉