### PR TITLE
fix: use reroot pattern for spread instead of fake -spread= flag

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -231,17 +231,34 @@ def _expand(root: Path, *, ci: bool | None = None) -> dict[str, Any]:
     return _expand_backend(data, ci=ci)
 
 
-def _compose_reroot(existing_reroot: str | None) -> str:
+def _compose_reroot(existing_reroot: object | None) -> str:
     """Return a ``reroot`` value that accounts for the temp sub-directory.
 
     The expanded ``spread.yaml`` lives one directory below the project root,
     so we need ``..`` to point back.  If the user already specified a
     ``reroot`` in their original ``spread.yaml``, we compose ``../`` with
     that existing value (normalised).
+
+    Raises:
+        ConfigurationError: If *existing_reroot* is not a string or is absolute.
     """
-    if existing_reroot:
-        return posixpath.normpath(posixpath.join("..", existing_reroot))
-    return ".."
+    if existing_reroot is None:
+        return ".."
+
+    if not isinstance(existing_reroot, str):
+        msg = (
+            "'reroot' in spread.yaml must be a string, "
+            f"got {type(existing_reroot).__name__}"
+        )
+        raise ConfigurationError(msg)
+
+    if posixpath.isabs(existing_reroot):
+        msg = (
+            f"'reroot' in spread.yaml must be a relative path, got '{existing_reroot}'"
+        )
+        raise ConfigurationError(msg)
+
+    return posixpath.normpath(posixpath.join("..", existing_reroot))
 
 
 def spread_expand(

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -7,17 +7,22 @@ plus ``tests/run/task.yaml``.
 backend with a concrete ``local:`` or ``ci:`` backend, and returns the
 expanded YAML.  The original file is **never** modified.
 
-``run`` expands to a temporary file and invokes ``spread`` as a subprocess.
+``run`` creates a temporary directory inside the project root containing
+the expanded ``spread.yaml`` with ``reroot: ..`` and runs ``spread`` from
+that directory.  Spread discovers ``spread.yaml`` in the temp dir and
+uses ``reroot`` to locate the actual project tree one level up.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import posixpath
 import tempfile
 from copy import deepcopy
 from io import StringIO
 from pathlib import Path
+from typing import Any
 
 from ruamel.yaml import YAML
 
@@ -196,15 +201,14 @@ def _expand_backend(
     return data
 
 
-def spread_expand(
-    root: Path,
-    *,
-    ci: bool | None = None,
-) -> str:
-    """Read ``spread.yaml`` and return the expanded content as a string.
+def _load_spread_yaml(root: Path) -> dict[str, Any]:
+    """Load and validate ``spread.yaml`` from *root*.
+
+    Returns:
+        Parsed YAML mapping.
 
     Raises:
-        ConfigurationError: If ``spread.yaml`` is missing or malformed.
+        ConfigurationError: If the file is missing or not a YAML mapping.
     """
     spread_path = root / _SPREAD_YAML
     if not spread_path.exists():
@@ -218,7 +222,42 @@ def spread_expand(
         msg = f"{_SPREAD_YAML} does not contain a YAML mapping"
         raise ConfigurationError(msg)
 
-    expanded = _expand_backend(data, ci=ci)
+    return data
+
+
+def _expand(root: Path, *, ci: bool | None = None) -> dict[str, Any]:
+    """Load ``spread.yaml``, expand its virtual backend, return the dict."""
+    data = _load_spread_yaml(root)
+    return _expand_backend(data, ci=ci)
+
+
+def _compose_reroot(existing_reroot: str | None) -> str:
+    """Return a ``reroot`` value that accounts for the temp sub-directory.
+
+    The expanded ``spread.yaml`` lives one directory below the project root,
+    so we need ``..`` to point back.  If the user already specified a
+    ``reroot`` in their original ``spread.yaml``, we compose ``../`` with
+    that existing value (normalised).
+    """
+    if existing_reroot:
+        return posixpath.normpath(posixpath.join("..", existing_reroot))
+    return ".."
+
+
+def spread_expand(
+    root: Path,
+    *,
+    ci: bool | None = None,
+) -> str:
+    """Read ``spread.yaml`` and return the expanded content as a string.
+
+    The output is for display / debugging; it does **not** include the
+    ``reroot`` field that ``spread_run`` injects.
+
+    Raises:
+        ConfigurationError: If ``spread.yaml`` is missing or malformed.
+    """
+    expanded = _expand(root, ci=ci)
     buf = StringIO()
     _yaml.dump(expanded, buf)
     return buf.getvalue()
@@ -237,28 +276,28 @@ def spread_run(
 ) -> None:
     """Expand ``spread.yaml`` and run ``spread``.
 
-    The expanded file is written to a temporary location — the original
-    ``spread.yaml`` is never modified.
+    A temporary directory is created **inside** *root* containing the
+    expanded ``spread.yaml`` with ``reroot: ..`` so that ``spread``
+    discovers the config in the temp dir and resolves the project tree
+    from the parent.  The original ``spread.yaml`` is never modified.
 
     Raises:
         ConfigurationError: If ``spread.yaml`` is missing or malformed.
         SubprocessError: If spread exits non-zero.
     """
-    expanded_content = spread_expand(root, ci=ci)
+    expanded = _expand(root, ci=ci)
+    expanded["reroot"] = _compose_reroot(expanded.get("reroot"))
 
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        suffix=".yaml",
-        prefix="spread-expanded-",
-        delete=False,
-    ) as tmp:
-        tmp.write(expanded_content)
-        tmp_path = tmp.name
+    with tempfile.TemporaryDirectory(
+        prefix=".opcli-spread-",
+        dir=root,
+    ) as temp_dir:
+        temp_dir_path = Path(temp_dir)
+        spread_file = temp_dir_path / _SPREAD_YAML
+        with spread_file.open("w") as fh:
+            _yaml.dump(expanded, fh)
 
-    try:
-        cmd = ["spread", f"-spread={tmp_path}"]
+        cmd = ["spread"]
         if extra_args:
             cmd.extend(extra_args)
-        run_command(cmd, cwd=str(root))
-    finally:
-        Path(tmp_path).unlink(missing_ok=True)
+        run_command(cmd, cwd=str(temp_dir_path))

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -267,6 +267,20 @@ class TestSpreadRun:
         # ../custom/path normalised
         assert written_yaml[0]["reroot"] == "../custom/path"
 
+    def test_non_string_reroot_raises(self, tmp_path: Path) -> None:
+        spread_with_bad_reroot = _MINIMAL_SPREAD + "reroot: 42\n"
+        _write(tmp_path / "spread.yaml", spread_with_bad_reroot)
+
+        with pytest.raises(ConfigurationError, match="must be a string"):
+            spread_run(tmp_path, ci=False)
+
+    def test_absolute_reroot_raises(self, tmp_path: Path) -> None:
+        spread_with_abs_reroot = _MINIMAL_SPREAD + "reroot: /absolute/path\n"
+        _write(tmp_path / "spread.yaml", spread_with_abs_reroot)
+
+        with pytest.raises(ConfigurationError, match="must be a relative path"):
+            spread_run(tmp_path, ci=False)
+
     def test_expand_output_has_no_reroot(self, tmp_path: Path) -> None:
         """spread_expand() for display should not include reroot."""
         _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 from ruamel.yaml import YAML
 
-from opcli.core.exceptions import ConfigurationError
+from opcli.core.exceptions import ConfigurationError, SubprocessError
 from opcli.core.spread import spread_expand, spread_init, spread_run
 
 _yaml = YAML()
@@ -157,16 +157,51 @@ class TestSpreadExpand:
 class TestSpreadRun:
     """Tests for spread_run()."""
 
-    def test_runs_spread_with_expanded_file(self, tmp_path: Path) -> None:
+    def test_runs_spread_from_temp_dir(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        captured_cwd: list[str] = []
+
+        def capture_cmd(cmd: list[str], **kwargs: object) -> None:
+            captured_cwd.append(str(kwargs.get("cwd", "")))
+
+        with patch("opcli.core.spread.run_command", side_effect=capture_cmd):
+            spread_run(tmp_path, ci=False)
+
+        assert len(captured_cwd) == 1
+        cwd = Path(captured_cwd[0])
+        # Temp dir must be inside the project root
+        assert cwd.parent == tmp_path
+        assert cwd.name.startswith(".opcli-spread-")
+
+    def test_no_fake_spread_flag(self, tmp_path: Path) -> None:
         _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
 
         with patch("opcli.core.spread.run_command") as mock_run:
             spread_run(tmp_path, ci=False)
 
-        mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
-        assert cmd[0] == "spread"
-        assert any(arg.startswith("-spread=") for arg in cmd)
+        assert cmd == ["spread"]
+        # No -spread= flag should ever appear
+        assert not any(arg.startswith("-spread=") for arg in cmd)
+
+    def test_temp_dir_contains_spread_yaml_with_reroot(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        written_yaml: list[dict[str, object]] = []
+
+        def capture_cmd(cmd: list[str], **kwargs: object) -> None:
+            cwd = Path(str(kwargs.get("cwd", "")))
+            spread_file = cwd / "spread.yaml"
+            assert spread_file.exists()
+            with spread_file.open() as fh:
+                written_yaml.append(_yaml.load(fh))
+
+        with patch("opcli.core.spread.run_command", side_effect=capture_cmd):
+            spread_run(tmp_path, ci=False)
+
+        assert len(written_yaml) == 1
+        assert written_yaml[0]["reroot"] == ".."
 
     def test_extra_args_forwarded(self, tmp_path: Path) -> None:
         _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
@@ -174,28 +209,71 @@ class TestSpreadRun:
         with patch("opcli.core.spread.run_command") as mock_run:
             spread_run(
                 tmp_path,
-                extra_args=["local:ubuntu-24.04:tests/run:test_charm"],
+                extra_args=["-v", "local:ubuntu-24.04:tests/run:test_charm"],
                 ci=False,
             )
 
         cmd = mock_run.call_args[0][0]
-        assert "local:ubuntu-24.04:tests/run:test_charm" in cmd
+        assert cmd == [
+            "spread",
+            "-v",
+            "local:ubuntu-24.04:tests/run:test_charm",
+        ]
 
-    def test_temp_file_cleaned_up(self, tmp_path: Path) -> None:
+    def test_temp_dir_cleaned_up_on_success(self, tmp_path: Path) -> None:
         _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
 
-        temp_paths: list[str] = []
+        captured_cwd: list[str] = []
 
-        def capture_cmd(cmd: list[str], **_kwargs: object) -> None:
-            for arg in cmd:
-                if arg.startswith("-spread="):
-                    temp_paths.append(arg.split("=", 1)[1])
+        def capture_cmd(cmd: list[str], **kwargs: object) -> None:
+            captured_cwd.append(str(kwargs.get("cwd", "")))
 
         with patch("opcli.core.spread.run_command", side_effect=capture_cmd):
             spread_run(tmp_path, ci=False)
 
-        assert len(temp_paths) == 1
-        assert not Path(temp_paths[0]).exists()
+        assert not Path(captured_cwd[0]).exists()
+
+    def test_temp_dir_cleaned_up_on_failure(self, tmp_path: Path) -> None:
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        captured_cwd: list[str] = []
+
+        def failing_cmd(cmd: list[str], **kwargs: object) -> None:
+            captured_cwd.append(str(kwargs.get("cwd", "")))
+            raise SubprocessError(cmd=cmd, returncode=1, stderr="spread failed")
+
+        with (
+            patch("opcli.core.spread.run_command", side_effect=failing_cmd),
+            pytest.raises(SubprocessError),
+        ):
+            spread_run(tmp_path, ci=False)
+
+        assert not Path(captured_cwd[0]).exists()
+
+    def test_preserves_existing_reroot(self, tmp_path: Path) -> None:
+        spread_with_reroot = _MINIMAL_SPREAD + "reroot: custom/path\n"
+        _write(tmp_path / "spread.yaml", spread_with_reroot)
+
+        written_yaml: list[dict[str, object]] = []
+
+        def capture_cmd(cmd: list[str], **kwargs: object) -> None:
+            cwd = Path(str(kwargs.get("cwd", "")))
+            with (cwd / "spread.yaml").open() as fh:
+                written_yaml.append(_yaml.load(fh))
+
+        with patch("opcli.core.spread.run_command", side_effect=capture_cmd):
+            spread_run(tmp_path, ci=False)
+
+        # ../custom/path normalised
+        assert written_yaml[0]["reroot"] == "../custom/path"
+
+    def test_expand_output_has_no_reroot(self, tmp_path: Path) -> None:
+        """spread_expand() for display should not include reroot."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        assert "reroot" not in parsed
 
     def test_missing_spread_yaml_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ConfigurationError, match="not found"):


### PR DESCRIPTION
## Problem

`spread_run()` was using `spread -spread=<tempfile>` — a flag that **does not exist** in spread. Spread always reads `spread.yaml` from the current directory.

## Solution

Adopted the same pattern used by [craft-application](https://github.com/canonical/craft-application/blob/main/craft_application/services/testing.py):

1. Create a temp directory inside the project root (`.opcli-spread-*`)
2. Write the expanded `spread.yaml` there with `reroot: ..` — this is a native spread field that tells it the project root is one level up
3. Run `spread` with `cwd=temp_dir`
4. Clean up the temp dir (even on failure via `TemporaryDirectory` context manager)

### Additional improvements

- Refactored to avoid double YAML parse/dump: `_load_spread_yaml()` and `_expand()` return dicts; `spread_expand()` serializes for display; `spread_run()` injects reroot and serializes into the temp dir
- Handles pre-existing `reroot` values by composing `../existing/path`
- `spread_expand()` output (for display) does NOT include `reroot` since it's only meaningful in the temp-dir context

## Tests

- 9 tests for `spread_run()` (up from 4): temp dir location, no fake flag, reroot injection, arg forwarding, cleanup on success, cleanup on failure, existing reroot composition, expand has no reroot, missing yaml error
- All 106 tests pass, lint/mypy clean