### PR TITLE
feat: print command and cwd for each artifact build step

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import glob as globmod
 import logging
+import shlex
 from pathlib import Path
+
+import typer
 
 from opcli.core.discovery import discover_artifacts
 from opcli.core.exceptions import ConfigurationError, OpcliError
@@ -93,9 +96,18 @@ def _find_output_file(source_dir: Path, kind: str) -> str:
     return matches[0]
 
 
+def _log_build_command(name: str, kind: str, cmd: list[str], cwd: Path) -> None:
+    """Print the build command and working directory for reproducibility."""
+    typer.echo(f"Building {kind} '{name}':")
+    typer.echo(f"  cwd: {cwd}")
+    typer.echo(f"  cmd: {shlex.join(cmd)}")
+
+
 def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
     source_dir = root / rock.source
-    run_command([*_PACK_COMMANDS["rock"]], cwd=str(source_dir))
+    cmd = [*_PACK_COMMANDS["rock"]]
+    _log_build_command(rock.name, "rock", cmd, source_dir)
+    run_command(cmd, cwd=str(source_dir))
     output_file = _find_output_file(source_dir, "rock")
     return GeneratedRock(
         name=rock.name,
@@ -106,7 +118,9 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
 
 def _build_charm(charm: CharmArtifact, root: Path) -> GeneratedCharm:
     source_dir = root / charm.source
-    run_command([*_PACK_COMMANDS["charm"]], cwd=str(source_dir))
+    cmd = [*_PACK_COMMANDS["charm"]]
+    _log_build_command(charm.name, "charm", cmd, source_dir)
+    run_command(cmd, cwd=str(source_dir))
     output_file = _find_output_file(source_dir, "charm")
     return GeneratedCharm(
         name=charm.name,
@@ -117,7 +131,9 @@ def _build_charm(charm: CharmArtifact, root: Path) -> GeneratedCharm:
 
 def _build_snap(snap: SnapArtifact, root: Path) -> GeneratedSnap:
     source_dir = root / snap.source
-    run_command([*_PACK_COMMANDS["snap"]], cwd=str(source_dir))
+    cmd = [*_PACK_COMMANDS["snap"]]
+    _log_build_command(snap.name, "snap", cmd, source_dir)
+    run_command(cmd, cwd=str(source_dir))
     output_file = _find_output_file(source_dir, "snap")
     return GeneratedSnap(
         name=snap.name,

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -173,3 +173,20 @@ class TestArtifactsBuild:
         gen = load_artifacts_generated(result)
         assert len(gen.rocks) == 1
         assert len(gen.charms) == 1
+
+    def test_build_prints_command_and_cwd(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n- name: mycharm\n  source: .\n",
+        )
+        _write(tmp_path / "mycharm_amd64.charm", "fake charm")
+
+        with patch("opcli.core.artifacts.run_command"):
+            artifacts_build(tmp_path)
+
+        captured = capsys.readouterr().out
+        assert "Building charm 'mycharm':" in captured
+        assert f"cwd: {tmp_path}" in captured
+        assert "cmd: charmcraft pack" in captured


### PR DESCRIPTION
Each build step now prints the artifact kind/name, working directory, and the exact command. Makes it easy to reproduce failures manually.

Example output:
```
Building charm 'mycharm':
  cwd: /path/to/source
  cmd: charmcraft pack
```

Includes a test verifying the output.