### PR TITLE
fix: detect snap/snapcraft.yaml and use parent as source

### DIFF
--- a/src/opcli/core/discovery.py
+++ b/src/opcli/core/discovery.py
@@ -81,6 +81,21 @@ def _source_relative(marker_path: Path, root: Path) -> str:
     return str(rel) if str(rel) != "." else "."
 
 
+def _snap_source_relative(marker_path: Path, root: Path) -> str:
+    """Return the snap project root relative to *root*.
+
+    Snapcraft supports ``snapcraft.yaml`` in the project root **or** under
+    a ``snap/`` subdirectory.  When the marker lives at ``*/snap/snapcraft.yaml``
+    the project root (where ``snapcraft pack`` should run) is the parent of
+    ``snap/``.
+    """
+    if marker_path.parent.name == "snap":
+        rel = marker_path.parent.parent.relative_to(root)
+    else:
+        rel = marker_path.parent.relative_to(root)
+    return str(rel) if str(rel) != "." else "."
+
+
 def _process_marker(
     path: Path,
     root: Path,
@@ -97,7 +112,8 @@ def _process_marker(
         rocks.append(RockArtifact(name=name, source=source))
     elif kind == "snap":
         name = _read_yaml_name(path)
-        snaps.append(SnapArtifact(name=name, source=source))
+        snap_source = _snap_source_relative(path, root)
+        snaps.append(SnapArtifact(name=name, source=snap_source))
     elif kind == "charm":
         name = _read_yaml_name(path)
         raw_resources = _read_charm_resources(path)

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -57,6 +57,25 @@ class TestDiscovery:
         assert plan.snaps[0].name == "mysnap"
         assert plan.snaps[0].source == "snap_dir"
 
+    def test_snap_under_snap_subdir(self, tmp_path: Path) -> None:
+        """snapcraft.yaml under snap/ → source is the parent directory."""
+        _write(
+            tmp_path / "myproject" / "snap" / "snapcraft.yaml",
+            "name: mysnap\n",
+        )
+        plan = discover_artifacts(tmp_path)
+        assert len(plan.snaps) == 1
+        assert plan.snaps[0].name == "mysnap"
+        assert plan.snaps[0].source == "myproject"
+
+    def test_snap_under_snap_subdir_at_root(self, tmp_path: Path) -> None:
+        """snap/snapcraft.yaml at repo root → source is '.'."""
+        _write(tmp_path / "snap" / "snapcraft.yaml", "name: mysnap\n")
+        plan = discover_artifacts(tmp_path)
+        assert len(plan.snaps) == 1
+        assert plan.snaps[0].name == "mysnap"
+        assert plan.snaps[0].source == "."
+
     def test_monorepo(self, tmp_path: Path) -> None:
         _write(tmp_path / "charmcraft.yaml", "name: main-charm\ntype: charm\n")
         _write(tmp_path / "rock_a" / "rockcraft.yaml", "name: rock-a\n")


### PR DESCRIPTION
When `snapcraft.yaml` lives under a `snap/` subdirectory (a standard snapcraft convention), discovery now correctly sets `source` to the parent of `snap/` — where `snapcraft pack` should actually run.

| Layout | Before | After |
|---|---|---|
| `myproject/snapcraft.yaml` | `source: myproject` ✅ | `source: myproject` ✅ |
| `myproject/snap/snapcraft.yaml` | `source: myproject/snap` ❌ | `source: myproject` ✅ |
| `snap/snapcraft.yaml` (at root) | `source: snap` ❌ | `source: .` ✅ |

2 new tests added.