### PR TITLE
feat: log command and cwd for all subprocess invocations

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -9,10 +9,7 @@ from __future__ import annotations
 
 import glob as globmod
 import logging
-import shlex
 from pathlib import Path
-
-import typer
 
 from opcli.core.discovery import discover_artifacts
 from opcli.core.exceptions import ConfigurationError, OpcliError
@@ -96,18 +93,9 @@ def _find_output_file(source_dir: Path, kind: str) -> str:
     return matches[0]
 
 
-def _log_build_command(name: str, kind: str, cmd: list[str], cwd: Path) -> None:
-    """Print the build command and working directory for reproducibility."""
-    typer.echo(f"Building {kind} '{name}':")
-    typer.echo(f"  cwd: {cwd}")
-    typer.echo(f"  cmd: {shlex.join(cmd)}")
-
-
 def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
     source_dir = root / rock.source
-    cmd = [*_PACK_COMMANDS["rock"]]
-    _log_build_command(rock.name, "rock", cmd, source_dir)
-    run_command(cmd, cwd=str(source_dir))
+    run_command([*_PACK_COMMANDS["rock"]], cwd=str(source_dir))
     output_file = _find_output_file(source_dir, "rock")
     return GeneratedRock(
         name=rock.name,
@@ -118,9 +106,7 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
 
 def _build_charm(charm: CharmArtifact, root: Path) -> GeneratedCharm:
     source_dir = root / charm.source
-    cmd = [*_PACK_COMMANDS["charm"]]
-    _log_build_command(charm.name, "charm", cmd, source_dir)
-    run_command(cmd, cwd=str(source_dir))
+    run_command([*_PACK_COMMANDS["charm"]], cwd=str(source_dir))
     output_file = _find_output_file(source_dir, "charm")
     return GeneratedCharm(
         name=charm.name,
@@ -131,9 +117,7 @@ def _build_charm(charm: CharmArtifact, root: Path) -> GeneratedCharm:
 
 def _build_snap(snap: SnapArtifact, root: Path) -> GeneratedSnap:
     source_dir = root / snap.source
-    cmd = [*_PACK_COMMANDS["snap"]]
-    _log_build_command(snap.name, "snap", cmd, source_dir)
-    run_command(cmd, cwd=str(source_dir))
+    run_command([*_PACK_COMMANDS["snap"]], cwd=str(source_dir))
     output_file = _find_output_file(source_dir, "snap")
     return GeneratedSnap(
         name=snap.name,

--- a/src/opcli/core/subprocess.py
+++ b/src/opcli/core/subprocess.py
@@ -3,15 +3,21 @@
 All external command execution goes through :func:`run_command` so that
 tests can mock a single boundary and we get consistent timeout /
 error handling everywhere.
+
+Every invocation prints the command and working directory so that
+failures can be reproduced manually by copy-pasting from the output.
 """
 
 from __future__ import annotations
 
 import io
+import shlex
 import subprocess
 import sys
 import threading
 from dataclasses import dataclass
+
+import typer
 
 from opcli.core.exceptions import SubprocessError
 
@@ -69,6 +75,13 @@ def run_command(
     return _run_captured(cmd, cwd=cwd, timeout=timeout, check=check)
 
 
+def _log_command(cmd: list[str], cwd: str | None) -> None:
+    """Print the command and working directory for reproducibility."""
+    typer.echo(f"$ {shlex.join(cmd)}")
+    if cwd:
+        typer.echo(f"  cwd: {cwd}")
+
+
 def _run_streaming(
     cmd: list[str],
     *,
@@ -77,6 +90,7 @@ def _run_streaming(
     check: bool = True,
 ) -> SubprocessResult:
     """Run *cmd* with real-time output to the terminal."""
+    _log_command(cmd, cwd)
     try:
         proc = subprocess.Popen(
             cmd,
@@ -151,6 +165,7 @@ def _run_captured(
     check: bool = True,
 ) -> SubprocessResult:
     """Run *cmd* with fully buffered output (no terminal echo)."""
+    _log_command(cmd, cwd)
     try:
         proc = subprocess.run(
             cmd,

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -173,20 +173,3 @@ class TestArtifactsBuild:
         gen = load_artifacts_generated(result)
         assert len(gen.rocks) == 1
         assert len(gen.charms) == 1
-
-    def test_build_prints_command_and_cwd(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        _write(
-            tmp_path / "artifacts.yaml",
-            "version: 1\ncharms:\n- name: mycharm\n  source: .\n",
-        )
-        _write(tmp_path / "mycharm_amd64.charm", "fake charm")
-
-        with patch("opcli.core.artifacts.run_command"):
-            artifacts_build(tmp_path)
-
-        captured = capsys.readouterr().out
-        assert "Building charm 'mycharm':" in captured
-        assert f"cwd: {tmp_path}" in captured
-        assert "cmd: charmcraft pack" in captured

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -160,3 +160,29 @@ class TestSubprocessWrapper:
                 run_command(["missing-tool"])
 
             assert exc_info.value.returncode == 127  # noqa: PLR2004
+
+    def test_logs_command_and_cwd(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("opcli.core.subprocess.subprocess.Popen") as mock_popen:
+            proc = mock_popen.return_value
+            proc.stdout = io.StringIO("")
+            proc.stderr = io.StringIO("")
+            proc.returncode = 0
+            proc.wait.return_value = 0
+
+            run_command(["charmcraft", "pack"], cwd="/some/dir")
+
+        captured = capsys.readouterr().out
+        assert "$ charmcraft pack" in captured
+        assert "cwd: /some/dir" in captured
+
+    def test_logs_command_without_cwd(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with patch("opcli.core.subprocess.subprocess.run") as mock_run:
+            mock_run.return_value.stdout = "ok"
+            mock_run.return_value.stderr = ""
+            mock_run.return_value.returncode = 0
+
+            run_command(["echo", "hello"], stream=False)
+
+        captured = capsys.readouterr().out
+        assert "$ echo hello" in captured
+        assert "cwd:" not in captured


### PR DESCRIPTION
Moved command logging into the central `run_command()` wrapper so every subprocess call automatically prints the command and cwd. Applies to all commands: build, spread, provision, pytest.

Output:
```
$ charmcraft pack
  cwd: /path/to/source
```

Replaces the per-build logging from PR #9 — now universal. 112 tests pass.