### PR TITLE
feat: improve spread init, ubuntu user, and integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ mypy_path = "src"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "integration: marks tests that require external services (LXD, spread)",
+]
 
 [dependency-groups]
 dev = [

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -61,6 +61,8 @@ def _generate_spread_yaml(
     buf = StringIO()
     data: dict[str, object] = {
         "project": project_name,
+        "path": "/home/ubuntu/proj",
+        "kill-timeout": "60m",
         "backends": {
             _VIRTUAL_BACKEND: {
                 "systems": ["ubuntu-24.04"],
@@ -69,6 +71,10 @@ def _generate_spread_yaml(
     }
 
     env: dict[str, str] = {
+        "SUDO_USER": "",
+        "SUDO_UID": "",
+        "LANG": "C.UTF-8",
+        "LANGUAGE": "en",
         "CONCIERGE": '$(HOST: echo "${CONCIERGE:-concierge.yaml}")',
     }
     if modules:
@@ -78,8 +84,12 @@ def _generate_spread_yaml(
         env["MODULE/tests"] = "tests"
     data["environment"] = env
 
+    data["exclude"] = [".git", ".tox", ".venv", ".*_cache"]
+
     data["suites"] = {
-        "tests/": {},
+        "tests/": {
+            "summary": "integration tests",
+        },
     }
 
     _yaml.dump(data, buf)
@@ -150,10 +160,14 @@ CPU="${CPU:-4}"
 MEM="${MEM:-8}"
 
 CLOUD_CONFIG=$(mktemp)
-cat > "$CLOUD_CONFIG" <<ENDCLOUD
+cat > "$CLOUD_CONFIG" <<'ENDCLOUD'
 #cloud-config
 ssh_pwauth: true
-disable_root: false
+users:
+  - name: ubuntu
+    lock_passwd: false
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
 ENDCLOUD
 
 CLEANUP_VM=true
@@ -180,21 +194,24 @@ while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
 lxc exec "${VM_NAME}" -- cloud-init status --wait >&2
 lxc exec "${VM_NAME}" -- snap wait system seed.loaded >&2
 
-# Configure SSH root access (mirrors spread's native LXD tuneSSH)
-lxc exec "${VM_NAME}" -- sed -i \\
-  's/^\\s*#\\?\\s*\\(PermitRootLogin\\|PasswordAuthentication\\)\\>.*/\\1 yes/' \\
-  /etc/ssh/sshd_config
+# Set ubuntu user password (using lxc exec to avoid YAML escaping issues)
+lxc exec "${VM_NAME}" -- bash -c "echo ubuntu:${SPREAD_PASSWORD} | chpasswd"
+
+# Enable SSH password authentication
 lxc exec "${VM_NAME}" -- bash -c \\
   'if [ -d /etc/ssh/sshd_config.d ]; then
-     printf "PermitRootLogin yes\\nPasswordAuthentication yes\\n" \\
+     printf "PasswordAuthentication yes\\n" \\
        > /etc/ssh/sshd_config.d/00-spread.conf
    fi'
-lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | chpasswd"
+lxc exec "${VM_NAME}" -- sed -i \\
+  's/^\\s*#\\?\\s*PasswordAuthentication\\>.*/PasswordAuthentication yes/' \\
+  /etc/ssh/sshd_config
 lxc exec "${VM_NAME}" -- killall -HUP sshd 2>/dev/null || true
 
 # Get and report the VM's IPv4 address
 while true; do
-  ADDR=$(lxc ls --format csv --columns 4 "name=${VM_NAME}" | head -1)
+  RAW_ADDR=$(lxc ls --format csv --columns 4 "name=${VM_NAME}" | head -1)
+  ADDR=$(echo "$RAW_ADDR" | awk '{print $1}')
   if [ -n "$ADDR" ]; then
     CLEANUP_VM=false
     ADDRESS "$ADDR"
@@ -206,25 +223,63 @@ done
 
 _LOCAL_DISCARD = """\
 instance_name=$(lxc ls --format csv --columns n4 \\
-  "ipv4=$SPREAD_SYSTEM_ADDRESS" | cut -f1 -d',' | head -n 1)
+  | awk -F, -v addr="$SPREAD_SYSTEM_ADDRESS" \\
+    '{split($2,a," "); if(a[1]==addr) {print $1; exit}}')
 if [ -n "$instance_name" ]; then
   lxc delete --force "$instance_name"
 fi
 """
 
 _LOCAL_PREPARE = """\
-sudo concierge prepare -c "$CONCIERGE"
-opcli provision load
+if [ -f "$CONCIERGE" ]; then
+  sudo concierge prepare -c "$CONCIERGE"
+fi
+if [ -f artifacts-generated.yaml ]; then
+  opcli provision load
+fi
 """
 
 _CI_PREPARE = """\
-sudo concierge prepare -c "$CONCIERGE"
+if [ -f "$CONCIERGE" ]; then
+  sudo concierge prepare -c "$CONCIERGE"
+fi
 """
 
 
 def _is_ci() -> bool:
     """Return True when running inside CI (truthy ``CI`` env var)."""
     return bool(os.environ.get("CI"))
+
+
+def _inject_username(
+    systems: list[object],
+    username: str,
+) -> list[object]:
+    """Deep-merge ``username`` into each system entry.
+
+    Handles both scalar entries (``"ubuntu-24.04"``) and mapping entries
+    (``{"ubuntu-24.04": {"runner": [...]}}``) without dropping user-defined
+    fields.
+    """
+    result: list[object] = []
+    for entry in systems:
+        if isinstance(entry, str):
+            result.append({entry: {"username": username}})
+        elif isinstance(entry, dict):
+            merged: dict[str, object] = {}
+            for name, props in entry.items():
+                if isinstance(props, dict):
+                    new_props = dict(props)
+                    new_props.setdefault("username", username)
+                    merged[name] = new_props
+                elif props is None:
+                    merged[name] = {"username": username}
+                else:
+                    merged[name] = props
+            result.append(merged)
+        else:
+            result.append(entry)
+    return result
 
 
 def _expand_backend(
@@ -276,6 +331,11 @@ def _expand_backend(
         backend_def["allocate"] = _LOCAL_ALLOCATE
         backend_def["discard"] = _LOCAL_DISCARD
         backend_def["prepare"] = _LOCAL_PREPARE
+
+        # Inject username: ubuntu into system definitions for the local backend
+        systems = backend_def.get("systems")
+        if isinstance(systems, list):
+            backend_def["systems"] = _inject_username(systems, "ubuntu")
 
     backend_name = "ci" if use_ci else "local"
     backends[backend_name] = backend_def

--- a/tests/integration/test_spread_lxd.py
+++ b/tests/integration/test_spread_lxd.py
@@ -1,0 +1,113 @@
+"""Integration tests for spread local backend with real LXD VMs.
+
+These tests require ``spread`` and ``lxc`` to be available on the host.
+They launch real VMs, so they are slow (~30-60s) and marked with
+``@pytest.mark.integration``.
+
+The prepare script is conditional — it skips concierge and provision load
+when the corresponding files are absent.  This lets us exercise the full
+allocate → SSH → execute → discard flow without needing concierge or
+opcli installed inside the VM.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+from opcli.core.spread import spread_run
+
+_HAVE_SPREAD = shutil.which("spread") is not None
+_HAVE_LXC = shutil.which("lxc") is not None
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not (_HAVE_SPREAD and _HAVE_LXC),
+        reason="spread and/or lxc not available",
+    ),
+]
+
+
+_SPREAD_YAML = """\
+project: integration-test
+
+path: /home/ubuntu/proj
+
+kill-timeout: 30m
+
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04
+
+environment:
+  CONCIERGE: concierge.yaml
+  MODULE/test_basic: test_basic
+
+exclude:
+  - .git
+
+suites:
+  tests/:
+    summary: integration tests
+"""
+
+_TASK_YAML = """\
+summary: basic spread integration test
+
+execute: |
+    echo "spread integration test passed"
+    whoami
+    pwd
+"""
+
+
+class TestSpreadLxdLocal:
+    """End-to-end tests using the local (LXD VM) backend."""
+
+    def test_basic_spread_run(self, tmp_path: pytest.TempPathFactory) -> None:
+        """A trivial task runs successfully inside an LXD VM."""
+        # Set up project structure
+        spread_path = tmp_path / "spread.yaml"  # type: ignore[operator]
+        spread_path.write_text(_SPREAD_YAML)
+
+        task_dir = tmp_path / "tests" / "run"  # type: ignore[operator]
+        task_dir.mkdir(parents=True)
+        (task_dir / "task.yaml").write_text(_TASK_YAML)
+
+        # Run spread with local backend
+        spread_run(tmp_path, ci=False)  # type: ignore[arg-type]
+
+    def test_no_leftover_vms(self, tmp_path: pytest.TempPathFactory) -> None:
+        """VMs are cleaned up after a successful spread run."""
+        spread_path = tmp_path / "spread.yaml"  # type: ignore[operator]
+        spread_path.write_text(_SPREAD_YAML)
+
+        task_dir = tmp_path / "tests" / "run"  # type: ignore[operator]
+        task_dir.mkdir(parents=True)
+        (task_dir / "task.yaml").write_text(_TASK_YAML)
+
+        # Count VMs with our naming prefix before
+        before = _count_spread_vms()
+
+        spread_run(tmp_path, ci=False)  # type: ignore[arg-type]
+
+        # After successful run, VM count should be same as before
+        after = _count_spread_vms()
+        assert after == before
+
+
+def _count_spread_vms() -> int:
+    """Count LXD instances whose names start with ``spread-``."""
+    result = subprocess.run(
+        ["lxc", "ls", "--format", "csv", "--columns", "n"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return 0
+    return sum(1 for line in result.stdout.splitlines() if line.startswith("spread-"))

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -22,6 +22,7 @@ def _write(path: Path, content: str) -> None:
 
 _MINIMAL_SPREAD = """\
 project: test-project
+path: /home/ubuntu/proj
 backends:
   integration-test:
     systems:
@@ -29,7 +30,8 @@ backends:
 environment:
   MODULE/test_charm: test_charm
 suites:
-  tests/: {}
+  tests/:
+    summary: integration tests
 """
 
 
@@ -48,6 +50,35 @@ class TestSpreadInit:
 
         task_content = task_path.read_text()
         assert "opcli pytest run" in task_content
+
+    def test_generates_required_fields(self, tmp_path: Path) -> None:
+        spread_path, _ = spread_init(tmp_path)
+
+        parsed = _yaml.load(StringIO(spread_path.read_text()))
+        assert parsed["path"] == "/home/ubuntu/proj"
+        assert parsed["kill-timeout"] == "60m"
+        assert "summary" in parsed["suites"]["tests/"]
+
+    def test_generates_exclude_list(self, tmp_path: Path) -> None:
+        spread_path, _ = spread_init(tmp_path)
+
+        parsed = _yaml.load(StringIO(spread_path.read_text()))
+        exclude = parsed["exclude"]
+        assert ".git" in exclude
+        assert ".tox" in exclude
+        assert ".venv" in exclude
+        assert ".*_cache" in exclude
+
+    def test_generates_standard_env_vars(self, tmp_path: Path) -> None:
+        spread_path, _ = spread_init(tmp_path)
+
+        parsed = _yaml.load(StringIO(spread_path.read_text()))
+        env = parsed["environment"]
+        assert env["SUDO_USER"] == ""
+        assert env["SUDO_UID"] == ""
+        assert env["LANG"] == "C.UTF-8"
+        assert env["LANGUAGE"] == "en"
+        assert "CONCIERGE" in env
 
     def test_discovers_test_modules(self, tmp_path: Path) -> None:
         test_dir = tmp_path / "tests" / "integration"
@@ -104,7 +135,12 @@ class TestSpreadExpand:
         assert "lxc delete --force" in local["discard"]
         assert "concierge" in local["prepare"]
         assert "opcli provision load" in local["prepare"]
-        assert local["systems"] == ["ubuntu-24.04"]
+
+        # Systems should have username: ubuntu injected
+        systems = local["systems"]
+        assert len(systems) == 1
+        assert "ubuntu-24.04" in systems[0]
+        assert systems[0]["ubuntu-24.04"]["username"] == "ubuntu"
 
     def test_expand_ci(self, tmp_path: Path) -> None:
         _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
@@ -118,6 +154,7 @@ class TestSpreadExpand:
         assert ci["allocate"] == "ADDRESS localhost"
         assert "concierge" in ci["prepare"]
         assert "discard" not in ci
+        # CI should NOT inject username — systems stay as plain strings
         assert ci["systems"] == ["ubuntu-24.04"]
 
     def test_preserves_other_sections(self, tmp_path: Path) -> None:
@@ -163,7 +200,8 @@ suites:
         assert local["environment"] == {"EXTRA_VAR": "hello"}
         assert "extra setup" in local["prepare-each"]
         assert local["kill-timeout"] == "30m"
-        assert local["systems"] == ["ubuntu-24.04"]
+        # Systems get username injected for local backend
+        assert local["systems"] == [{"ubuntu-24.04": {"username": "ubuntu"}}]
         # opcli fields are set
         assert local["type"] == "adhoc"
         assert "lxc launch --vm" in local["allocate"]
@@ -216,6 +254,93 @@ suites:
         parsed = _yaml.load(StringIO(result))
         assert isinstance(parsed, dict)
         assert "backends" in parsed
+
+    def test_local_allocate_uses_ubuntu_user(self, tmp_path: Path) -> None:
+        """The allocate script sets up ubuntu user, not root."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        allocate = parsed["backends"]["local"]["allocate"]
+
+        assert "echo ubuntu:${SPREAD_PASSWORD}" in allocate
+        assert "PermitRootLogin" not in allocate
+        assert "PasswordAuthentication yes" in allocate
+
+    def test_local_prepare_conditional(self, tmp_path: Path) -> None:
+        """Prepare script gates concierge and provision load on file existence."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        prepare = parsed["backends"]["local"]["prepare"]
+
+        assert '[ -f "$CONCIERGE" ]' in prepare
+        assert "[ -f artifacts-generated.yaml ]" in prepare
+
+    def test_ci_prepare_conditional(self, tmp_path: Path) -> None:
+        """CI prepare also gates concierge on file existence."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        result = spread_expand(tmp_path, ci=True)
+        parsed = _yaml.load(StringIO(result))
+        prepare = parsed["backends"]["ci"]["prepare"]
+
+        assert '[ -f "$CONCIERGE" ]' in prepare
+
+    def test_local_username_injection_mapping_systems(self, tmp_path: Path) -> None:
+        """Username injection deep-merges with existing system properties."""
+        spread_with_mapping = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04:
+          runner: [self-hosted, noble]
+          workers: 2
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/:
+    summary: integration tests
+"""
+        _write(tmp_path / "spread.yaml", spread_with_mapping)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        systems = parsed["backends"]["local"]["systems"]
+
+        assert len(systems) == 1
+        sys_def = systems[0]["ubuntu-24.04"]
+        assert sys_def["username"] == "ubuntu"
+        assert sys_def["runner"] == ["self-hosted", "noble"]
+        _EXPECTED_WORKERS = 2
+        assert sys_def["workers"] == _EXPECTED_WORKERS
+
+    def test_local_username_preserves_user_set_username(self, tmp_path: Path) -> None:
+        """If user already set a username, it is not overridden."""
+        spread_with_user = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04:
+          username: custom-user
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/:
+    summary: integration tests
+"""
+        _write(tmp_path / "spread.yaml", spread_with_user)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        systems = parsed["backends"]["local"]["systems"]
+
+        assert systems[0]["ubuntu-24.04"]["username"] == "custom-user"
 
 
 class TestSpreadRun:


### PR DESCRIPTION
## Changes

### spread init improvements
- Add `path: /home/ubuntu/proj` (mandatory — spread errors without it)
- Add `kill-timeout: 60m` for long integration tests
- Add `exclude: [.git, .tox, .venv, .*_cache]` to speed up project sync
- Add standard env vars: `SUDO_USER`, `SUDO_UID`, `LANG`, `LANGUAGE`
- Add `summary: integration tests` to suite definition (required by spread)

### Ubuntu user for local backend
- Switched from root to `ubuntu` user with NOPASSWD sudo
- Cloud-config creates ubuntu user, `lxc exec` sets password (avoids YAML escaping issues)
- `_inject_username()` deep-merges `username: ubuntu` into system definitions, preserving user-defined fields (runner, workers, etc.)
- CI backend is NOT modified (no username injection)

### Conditional prepare scripts
- Gate concierge on `[ -f "$CONCIERGE" ]` — supports incremental adoption
- Gate provision load on `[ -f artifacts-generated.yaml ]` — doesn't fail without built artifacts

### Bug fixes
- Fix IP extraction from `lxc ls` (strip interface name suffix like `(enp5s0)`)
- Fix discard script to use awk-based IP matching instead of LXD filter

### Testing
- 8 new unit tests (34 spread tests total, 122 unit tests overall)
- 2 real LXD VM integration tests (`@pytest.mark.integration`)
- Integration tests verified: allocate → SSH → sync → prepare → execute → discard cycle works end-to-end