### PR TITLE
fix: move MODULE variants to suite environment in spread init

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -59,6 +59,24 @@ def _generate_spread_yaml(
 ) -> str:
     """Build the default ``spread.yaml`` content."""
     buf = StringIO()
+
+    # Root environment: project-wide vars (CONCIERGE, standard vars)
+    root_env: dict[str, str] = {
+        "SUDO_USER": "",
+        "SUDO_UID": "",
+        "LANG": "C.UTF-8",
+        "LANGUAGE": "en",
+        "CONCIERGE": '$(HOST: echo "${CONCIERGE:-concierge.yaml}")',
+    }
+
+    # Suite environment: MODULE variants (scoped to this suite)
+    suite_env: dict[str, str] = {}
+    if modules:
+        for mod in modules:
+            suite_env[f"MODULE/{mod}"] = mod
+    else:
+        suite_env["MODULE/tests"] = "tests"
+
     data: dict[str, object] = {
         "project": project_name,
         "path": "/home/ubuntu/proj",
@@ -68,27 +86,13 @@ def _generate_spread_yaml(
                 "systems": ["ubuntu-24.04"],
             },
         },
-    }
-
-    env: dict[str, str] = {
-        "SUDO_USER": "",
-        "SUDO_UID": "",
-        "LANG": "C.UTF-8",
-        "LANGUAGE": "en",
-        "CONCIERGE": '$(HOST: echo "${CONCIERGE:-concierge.yaml}")',
-    }
-    if modules:
-        for mod in modules:
-            env[f"MODULE/{mod}"] = mod
-    else:
-        env["MODULE/tests"] = "tests"
-    data["environment"] = env
-
-    data["exclude"] = [".git", ".tox", ".venv", ".*_cache"]
-
-    data["suites"] = {
-        "tests/": {
-            "summary": "integration tests",
+        "environment": root_env,
+        "exclude": [".git", ".tox", ".venv", ".*_cache"],
+        "suites": {
+            "tests/": {
+                "summary": "integration tests",
+                "environment": suite_env,
+            },
         },
     }
 

--- a/tests/integration/test_spread_lxd.py
+++ b/tests/integration/test_spread_lxd.py
@@ -45,7 +45,6 @@ backends:
 
 environment:
   CONCIERGE: concierge.yaml
-  MODULE/test_basic: test_basic
 
 exclude:
   - .git
@@ -53,6 +52,8 @@ exclude:
 suites:
   tests/:
     summary: integration tests
+    environment:
+      MODULE/test_basic: test_basic
 """
 
 _TASK_YAML = """\

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -28,10 +28,12 @@ backends:
     systems:
       - ubuntu-24.04
 environment:
-  MODULE/test_charm: test_charm
+  CONCIERGE: concierge.yaml
 suites:
   tests/:
     summary: integration tests
+    environment:
+      MODULE/test_charm: test_charm
 """
 
 
@@ -79,6 +81,23 @@ class TestSpreadInit:
         assert env["LANG"] == "C.UTF-8"
         assert env["LANGUAGE"] == "en"
         assert "CONCIERGE" in env
+        # MODULE variants belong in the suite, not the root environment
+        assert not any(k.startswith("MODULE") for k in env)
+
+    def test_module_vars_in_suite_environment(self, tmp_path: Path) -> None:
+        test_dir = tmp_path / "tests" / "integration"
+        test_dir.mkdir(parents=True)
+        (test_dir / "test_charm.py").write_text("")
+        (test_dir / "test_actions.py").write_text("")
+
+        spread_path, _ = spread_init(tmp_path)
+
+        parsed = _yaml.load(StringIO(spread_path.read_text()))
+        suite_env = parsed["suites"]["tests/"]["environment"]
+        assert suite_env["MODULE/test_charm"] == "test_charm"
+        assert suite_env["MODULE/test_actions"] == "test_actions"
+        # Also not in root environment
+        assert "MODULE/test_charm" not in parsed["environment"]
 
     def test_discovers_test_modules(self, tmp_path: Path) -> None:
         test_dir = tmp_path / "tests" / "integration"
@@ -89,10 +108,11 @@ class TestSpreadInit:
 
         spread_path, _ = spread_init(tmp_path)
 
-        content = spread_path.read_text()
-        assert "MODULE/test_charm" in content
-        assert "MODULE/test_actions" in content
-        assert "conftest" not in content
+        parsed = _yaml.load(StringIO(spread_path.read_text()))
+        suite_env = parsed["suites"]["tests/"]["environment"]
+        assert "MODULE/test_charm" in suite_env
+        assert "MODULE/test_actions" in suite_env
+        assert not any("conftest" in k for k in suite_env)
 
     def test_refuses_overwrite_without_force(self, tmp_path: Path) -> None:
         _write(tmp_path / "spread.yaml", "existing\n")


### PR DESCRIPTION
## Problem

MODULE environment variables were being placed at the root `environment:` in the generated `spread.yaml`, but the spec places them under `suites: tests/: environment:`.

MODULE variants are suite-scoped — they describe which test module to run for tasks in the `tests/` suite. Placing them at root was incorrect per the spec.

## Fix

- Move `MODULE/...` variants to `suites: tests/: environment:`
- Root environment keeps only project-wide vars: `CONCIERGE`, `SUDO_USER`, `SUDO_UID`, `LANG`, `LANGUAGE`
- Updated `_MINIMAL_SPREAD` fixture and all related unit tests to match the correct structure
- Added explicit test asserting MODULE is NOT in root environment