### PR TITLE
feat: add tutorial-test backend and opcli tutorial expand command

### DIFF
--- a/src/opcli/app.py
+++ b/src/opcli/app.py
@@ -2,7 +2,7 @@
 
 import typer
 
-from opcli.commands import artifacts, provision, pytest_cmd, spread
+from opcli.commands import artifacts, provision, pytest_cmd, spread, tutorial_cmd
 
 app = typer.Typer(
     name="opcli",
@@ -14,3 +14,4 @@ app.add_typer(artifacts.app, name="artifacts")
 app.add_typer(provision.app, name="provision")
 app.add_typer(spread.app, name="spread")
 app.add_typer(pytest_cmd.app, name="pytest")
+app.add_typer(tutorial_cmd.app, name="tutorial")

--- a/src/opcli/commands/tutorial_cmd.py
+++ b/src/opcli/commands/tutorial_cmd.py
@@ -1,0 +1,40 @@
+"""``opcli tutorial`` command group."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from opcli.core.exceptions import OpcliError
+from opcli.core.tutorial import expand_tutorial
+
+app = typer.Typer(help="Tutorial testing commands.")
+
+
+@app.command()
+def expand(
+    tutorial_file: Annotated[
+        Path,
+        typer.Argument(
+            help="Path to the tutorial file (.md or .rst).",
+            exists=True,
+            readable=True,
+        ),
+    ],
+) -> None:
+    """Extract shell commands from a tutorial file and print them to stdout.
+
+    The output is a shell script suitable for use with eval in a spread task.yaml:
+
+        eval "$(opcli tutorial expand "$TUTORIAL")"
+
+    Supports Markdown (.md) and reStructuredText (.rst) files.
+    """
+    try:
+        script = expand_tutorial(tutorial_file)
+        typer.echo(script)
+    except OpcliError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(1) from exc

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -36,7 +36,9 @@ _yaml.default_flow_style = False
 
 _SPREAD_YAML = "spread.yaml"
 _TASK_YAML_REL = "tests/integration/run/task.yaml"
+_TUTORIAL_TASK_YAML_REL = "tests/tutorial/run/task.yaml"
 _VIRTUAL_BACKEND = "integration-test"
+_TUTORIAL_BACKEND = "tutorial-test"
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +93,7 @@ def _generate_spread_yaml(
         "suites": {
             "tests/integration/": {
                 "summary": "integration tests",
+                "backends": [_VIRTUAL_BACKEND],
                 "environment": suite_env,
             },
         },
@@ -105,6 +108,13 @@ summary: integration tests
 
 execute: |
     $( opcli pytest run -- -k $MODULE )
+"""
+
+_TUTORIAL_TASK_YAML_CONTENT = """\
+summary: tutorial test
+
+execute: |
+    eval "$(opcli tutorial expand "$TUTORIAL")"
 """
 
 
@@ -249,6 +259,22 @@ if [ -f "$CONCIERGE" ]; then
 fi
 """
 
+# Tutorial backend: install opcli from the synced project so that
+# ``opcli tutorial expand`` is available inside the VM.
+_TUTORIAL_LOCAL_PREPARE = """\
+pip install /home/ubuntu/proj --quiet
+"""
+
+
+# Map each virtual backend name to:
+#   (concrete_local, concrete_ci, local_prepare, ci_prepare)
+# The CI prepare for tutorial-test is empty — workflows are expected to
+# install opcli before invoking spread.
+_BACKEND_CONFIGS: dict[str, tuple[str, str, str, str]] = {
+    _VIRTUAL_BACKEND: ("local", "ci", _LOCAL_PREPARE, _CI_PREPARE),
+    _TUTORIAL_BACKEND: ("local-tutorial", "ci-tutorial", _TUTORIAL_LOCAL_PREPARE, ""),
+}
+
 
 def _is_ci() -> bool:
     """Return True when running inside CI (truthy ``CI`` env var)."""
@@ -286,25 +312,81 @@ def _inject_username(
     return result
 
 
+def _build_concrete_backend(
+    virtual: object,
+    *,
+    use_ci: bool,
+    local_prepare: str,
+    ci_prepare: str,
+) -> dict[str, object]:
+    """Return a concrete adhoc backend dict built from a virtual backend entry."""
+    backend_def: dict[str, object] = (
+        deepcopy(virtual) if isinstance(virtual, dict) else {}
+    )
+    backend_def["type"] = "adhoc"
+
+    if use_ci:
+        backend_def["allocate"] = "ADDRESS localhost"
+        if ci_prepare:
+            backend_def["prepare"] = ci_prepare
+    else:
+        backend_def["allocate"] = _LOCAL_ALLOCATE
+        backend_def["discard"] = _LOCAL_DISCARD
+        if local_prepare:
+            backend_def["prepare"] = local_prepare
+
+        systems = backend_def.get("systems")
+        if isinstance(systems, list):
+            backend_def["systems"] = _inject_username(systems, "ubuntu")
+
+    return backend_def
+
+
+def _replace_suite_backend_name(
+    data: dict[str, object],
+    virtual_name: str,
+    concrete_name: str,
+) -> None:
+    """Replace *virtual_name* with *concrete_name* in all suite ``backends:`` lists."""
+    suites = data.get("suites")
+    if not isinstance(suites, dict):
+        return
+    for suite_cfg in suites.values():
+        if isinstance(suite_cfg, dict):
+            suite_backends = suite_cfg.get("backends")
+            if isinstance(suite_backends, list):
+                suite_cfg["backends"] = [
+                    concrete_name if b == virtual_name else b for b in suite_backends
+                ]
+
+
 def _expand_backend(
     spread_data: dict[str, object],
     *,
     ci: bool | None = None,
 ) -> dict[str, object]:
-    """Replace the virtual backend with a concrete one.
+    """Replace all known virtual backends with concrete ones.
 
-    The virtual ``integration-test`` backend is removed and replaced with
-    ``local:`` (LXD VM via adhoc) or ``ci:`` (adhoc localhost).  All
-    user-defined fields in the virtual backend (``systems``, ``environment``,
-    ``prepare-each``, ``kill-timeout``, etc.) are preserved — only the
-    opcli-managed fields are overwritten.
+    Recognises ``integration-test`` and ``tutorial-test`` virtual backends.
+    Each is removed from the YAML and replaced with its concrete counterpart
+    (``local`` / ``ci`` for integration, ``local-tutorial`` / ``ci-tutorial``
+    for tutorials).  All user-defined fields (``systems``, ``environment``,
+    ``prepare-each``, ``kill-timeout``, etc.) are preserved.
+
+    Suite-level ``backends:`` lists are also updated so that any reference to
+    a virtual backend name is replaced with the corresponding concrete name.
+    This prevents suites from accidentally running on the wrong backend when
+    both virtual backends are declared in the same ``spread.yaml``.
 
     Args:
         spread_data: Parsed spread.yaml (mutated in place on a deep copy).
         ci: Force CI mode if True, local if False, auto-detect if None.
 
     Returns:
-        New dict with the backend replaced.
+        New dict with the backends replaced.
+
+    Raises:
+        ConfigurationError: If no known virtual backend is found.
     """
     data = deepcopy(spread_data)
     backends = data.get("backends")
@@ -312,37 +394,37 @@ def _expand_backend(
         msg = "spread.yaml has no 'backends' section"
         raise ConfigurationError(msg)
 
-    virtual = backends.pop(_VIRTUAL_BACKEND, None)
-    if virtual is None:
+    use_ci = ci if ci is not None else _is_ci()
+    found_any = False
+
+    for virtual_name, (
+        concrete_local,
+        concrete_ci,
+        local_prepare,
+        ci_prepare,
+    ) in _BACKEND_CONFIGS.items():
+        virtual = backends.pop(virtual_name, None)
+        if virtual is None:
+            continue
+        found_any = True
+
+        concrete_name = concrete_ci if use_ci else concrete_local
+        backends[concrete_name] = _build_concrete_backend(
+            virtual,
+            use_ci=use_ci,
+            local_prepare=local_prepare,
+            ci_prepare=ci_prepare,
+        )
+        _replace_suite_backend_name(data, virtual_name, concrete_name)
+
+    if not found_any:
+        known = ", ".join(f"'{n}'" for n in _BACKEND_CONFIGS)
         msg = (
-            f"spread.yaml has no '{_VIRTUAL_BACKEND}' virtual backend. "
+            f"spread.yaml contains no known virtual backend ({known}). "
             "Nothing to expand."
         )
         raise ConfigurationError(msg)
 
-    # Start from a copy of the virtual backend to preserve user fields.
-    backend_def: dict[str, object] = (
-        deepcopy(virtual) if isinstance(virtual, dict) else {}
-    )
-
-    use_ci = ci if ci is not None else _is_ci()
-
-    backend_def["type"] = "adhoc"
-    if use_ci:
-        backend_def["allocate"] = "ADDRESS localhost"
-        backend_def["prepare"] = _CI_PREPARE
-    else:
-        backend_def["allocate"] = _LOCAL_ALLOCATE
-        backend_def["discard"] = _LOCAL_DISCARD
-        backend_def["prepare"] = _LOCAL_PREPARE
-
-        # Inject username: ubuntu into system definitions for the local backend
-        systems = backend_def.get("systems")
-        if isinstance(systems, list):
-            backend_def["systems"] = _inject_username(systems, "ubuntu")
-
-    backend_name = "ci" if use_ci else "local"
-    backends[backend_name] = backend_def
     data["backends"] = backends
     return data
 

--- a/src/opcli/core/tutorial.py
+++ b/src/opcli/core/tutorial.py
@@ -1,0 +1,281 @@
+"""Core logic for ``opcli tutorial expand``.
+
+Extracts shell commands from Markdown and reStructuredText tutorial files
+and returns them as a shell script suitable for use with ``eval`` in spread
+task.yaml:
+
+    eval "$(opcli tutorial expand "$TUTORIAL")"
+
+Ported and adapted from
+https://github.com/canonical/operator-workflows/blob/main/spread/create_spread_task_file.py
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from opcli.core.exceptions import ValidationError
+
+# ---------------------------------------------------------------------------
+# Common helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_paired_markers(
+    content: str,
+    start_pattern: str,
+    end_pattern: str,
+    marker_name: str,
+    flags: int = 0,
+) -> list[tuple[int, int]]:
+    """Validate that markers are properly paired using a stack-based approach.
+
+    Returns:
+        List of ``(start_pos, end_pos)`` for valid marker pairs.
+
+    Raises:
+        ValidationError: If markers are not properly paired or ordered.
+    """
+    starts = [(m.start(), "start") for m in re.finditer(start_pattern, content, flags)]
+    ends = [(m.start(), "end") for m in re.finditer(end_pattern, content, flags)]
+
+    all_markers = sorted(starts + ends, key=lambda x: x[0])
+    stack: list[int] = []
+    pairs: list[tuple[int, int]] = []
+
+    for pos, marker_type in all_markers:
+        if marker_type == "start":
+            stack.append(pos)
+        else:
+            if not stack:
+                msg = (
+                    f"Found closing {marker_name} marker without corresponding "
+                    f"opening marker at position {pos}"
+                )
+                raise ValidationError(msg)
+            start_pos = stack.pop()
+            pairs.append((start_pos, pos))
+
+    if stack:
+        msg = f"Unclosed {marker_name} marker found at position {stack[0]}"
+        raise ValidationError(msg)
+
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Markdown extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_markdown_spread_comments(content: str) -> list[tuple[int, str]]:
+    """Return ``(position, command_string)`` tuples for ``<!-- SPREAD -->`` blocks."""
+    pattern = r"<!-- SPREAD(?! SKIP)\s*\n(.*?)-->"
+
+    spread_starts = [
+        m.start() for m in re.finditer(r"<!-- SPREAD(?! SKIP)\s*", content)
+    ]
+    for start_pos in spread_starts:
+        remaining = content[start_pos:]
+        if "-->" not in remaining:
+            msg = f"Unclosed SPREAD comment block found at position {start_pos}"
+            raise ValidationError(msg)
+        next_spread = remaining.find("<!-- SPREAD", 1)
+        closing_pos = remaining.find("-->")
+        if next_spread != -1 and closing_pos > next_spread:
+            msg = f"Unclosed SPREAD comment block found at position {start_pos}"
+            raise ValidationError(msg)
+
+    result: list[tuple[int, str]] = []
+    for match in re.finditer(pattern, content, re.DOTALL):
+        text = match.group(1).strip()
+        if text:
+            result.append((match.start(), text))
+    return result
+
+
+def _extract_markdown_skip_ranges(content: str) -> list[tuple[int, int]]:
+    """Return ``(start, end)`` byte ranges for ``<!-- SPREAD SKIP -->`` blocks."""
+    pairs = _validate_paired_markers(
+        content,
+        r"<!-- SPREAD SKIP -->",
+        r"<!-- SPREAD SKIP END -->",
+        "SPREAD SKIP",
+    )
+    end_marker_re = re.compile(r"<!-- SPREAD SKIP END -->")
+    ranges: list[tuple[int, int]] = []
+    for start_pos, end_pos in pairs:
+        m = end_marker_re.search(content, end_pos)
+        if m:
+            ranges.append((start_pos, m.end()))
+    return ranges
+
+
+def _extract_commands_from_markdown(file_path: Path) -> list[str]:
+    """Extract shell commands from a Markdown tutorial file."""
+    content = file_path.read_text(encoding="utf-8")
+
+    spread_blocks = _extract_markdown_spread_comments(content)
+    skip_ranges = _extract_markdown_skip_ranges(content)
+
+    # 4+ backtick fences are excluded (they contain meta-docs, not commands)
+    excluded: list[tuple[int, int]] = []
+    for m in re.finditer(r"````+[^\n]*\n(.*?)````+", content, re.DOTALL):
+        excluded.append((m.start(), m.end()))
+    excluded.extend(skip_ranges)
+
+    # Exactly 3 backticks (not more, not fewer)
+    code_blocks: list[tuple[int, str]] = []
+    for m in re.finditer(
+        r"(?<!`)```(?!`)([^\n]*)\n(.*?)(?<!`)```(?!`)", content, re.DOTALL
+    ):
+        lang = m.group(1)
+        code = m.group(2)
+        start = m.start()
+        end = m.end()
+
+        if lang.strip().startswith("{"):
+            continue
+
+        is_excluded = any(s <= start < e2 and end <= e2 for s, e2 in excluded)
+        if is_excluded:
+            continue
+
+        stripped = code.strip()
+        if stripped:
+            code_blocks.append((start, stripped))
+
+    filtered_spread: list[tuple[int, str]] = [
+        (pos, cmd)
+        for pos, cmd in spread_blocks
+        if not any(s <= pos < e for s, e in skip_ranges)
+    ]
+
+    all_blocks = sorted(code_blocks + filtered_spread, key=lambda x: x[0])
+    return [cmd for _, cmd in all_blocks]
+
+
+# ---------------------------------------------------------------------------
+# RST extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_rst_spread_comments(content: str) -> list[tuple[int, str]]:
+    """Return ``(position, command_string)`` tuples for ``.. SPREAD`` blocks."""
+    _validate_paired_markers(
+        content,
+        r"^\.\. SPREAD\s*$",
+        r"^\.\. SPREAD END\s*$",
+        "SPREAD",
+        re.MULTILINE,
+    )
+
+    result: list[tuple[int, str]] = []
+    pattern = r"^\.\. SPREAD\s*\n(.*?)^\.\. SPREAD END\s*$"
+    for m in re.finditer(pattern, content, re.MULTILINE | re.DOTALL):
+        raw = m.group(1)
+        lines = raw.split("\n")
+        stripped = []
+        for line in lines:
+            if line.startswith(".. "):
+                stripped.append(line[3:])
+            elif line.startswith(".."):
+                stripped.append(line[2:])
+            else:
+                stripped.append(line)
+
+        non_empty = [ln for ln in stripped if ln.strip()]
+        if not non_empty:
+            continue
+
+        min_indent = min(len(ln) - len(ln.lstrip()) for ln in non_empty)
+        dedented = [ln[min_indent:] if ln.strip() else "" for ln in stripped]
+        text = "\n".join(dedented).strip()
+        if text:
+            result.append((m.start(), text))
+    return result
+
+
+def _extract_rst_skip_ranges(content: str) -> list[tuple[int, int]]:
+    """Return ``(start, end)`` byte ranges for ``.. SPREAD SKIP`` blocks."""
+    _validate_paired_markers(
+        content,
+        r"^\.\. SPREAD SKIP\s*$",
+        r"^\.\. SPREAD SKIP END\s*$",
+        "SPREAD SKIP",
+        re.MULTILINE,
+    )
+
+    ranges: list[tuple[int, int]] = []
+    pattern = r"^\.\. SPREAD SKIP\s*\n(.*?)^\.\. SPREAD SKIP END\s*$"
+    for m in re.finditer(pattern, content, re.MULTILINE | re.DOTALL):
+        ranges.append((m.start(), m.end()))
+    return ranges
+
+
+def _extract_commands_from_rst(file_path: Path) -> list[str]:
+    """Extract shell commands from a reStructuredText tutorial file."""
+    content = file_path.read_text(encoding="utf-8")
+
+    spread_blocks = _extract_rst_spread_comments(content)
+    skip_ranges = _extract_rst_skip_ranges(content)
+
+    # .. code-block:: directive; allow one optional blank line after directive
+    pattern = r"^\.\. code-block::[^\n]*\n(?:\n)?((?:[ \t]+.+(?:\n|$))+)"
+    code_blocks: list[tuple[int, str]] = []
+    for m in re.finditer(pattern, content, re.MULTILINE):
+        start = m.start()
+        if any(s <= start < e for s, e in skip_ranges):
+            continue
+
+        indented = m.group(1)
+        lines = indented.split("\n")
+        non_empty = [ln for ln in lines if ln.strip()]
+        if not non_empty:
+            continue
+
+        min_indent = min(len(ln) - len(ln.lstrip()) for ln in non_empty)
+        dedented = [ln[min_indent:] if ln.strip() else "" for ln in lines]
+        text = "\n".join(dedented).strip()
+        if text:
+            code_blocks.append((start, text))
+
+    filtered_spread: list[tuple[int, str]] = [
+        (pos, cmd)
+        for pos, cmd in spread_blocks
+        if not any(s <= pos < e for s, e in skip_ranges)
+    ]
+
+    all_blocks = sorted(code_blocks + filtered_spread, key=lambda x: x[0])
+    return [cmd for _, cmd in all_blocks]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def expand_tutorial(file_path: Path) -> str:
+    """Extract shell commands from *file_path* and return them as a shell script.
+
+    The returned string is suitable for use with ``eval`` in a spread task:
+
+        eval "$(opcli tutorial expand "$TUTORIAL")"
+
+    Supports ``.md``/``.markdown`` (Markdown) and ``.rst``/``.rest``
+    (reStructuredText) files.
+
+    Raises:
+        ValidationError: If the file type is unsupported or markers are malformed.
+    """
+    ext = file_path.suffix.lower()
+    if ext in (".rst", ".rest"):
+        commands = _extract_commands_from_rst(file_path)
+    elif ext in (".md", ".markdown"):
+        commands = _extract_commands_from_markdown(file_path)
+    else:
+        msg = f"Unsupported file type '{ext}'. Supported: .md, .markdown, .rst, .rest"
+        raise ValidationError(msg)
+
+    return "\n".join(commands)

--- a/src/opcli/core/tutorial.py
+++ b/src/opcli/core/tutorial.py
@@ -138,7 +138,7 @@ def _extract_commands_from_markdown(file_path: Path) -> list[str]:
         if lang.strip().startswith("{"):
             continue
 
-        is_excluded = any(s <= start < e2 and end <= e2 for s, e2 in excluded)
+        is_excluded = any(start < e2 and end > s for s, e2 in excluded)
         if is_excluded:
             continue
 

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -32,6 +32,8 @@ environment:
 suites:
   tests/integration/:
     summary: integration tests
+    backends:
+      - integration-test
     environment:
       MODULE/test_charm: test_charm
 """
@@ -250,7 +252,8 @@ suites:
         cloudinit_pos = allocate.index("cloud-init status --wait")
         assert agent_pos < cloudinit_pos
 
-    def test_no_virtual_backend_raises(self, tmp_path: Path) -> None:
+    def test_auto_detects_ci_env_var(self, tmp_path: Path) -> None:
+        """CI env var toggles between ci/local backend expansion."""
         _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
 
         with patch.dict("os.environ", {"CI": "true"}):
@@ -497,3 +500,159 @@ class TestSpreadRun:
     def test_missing_spread_yaml_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ConfigurationError, match="not found"):
             spread_run(tmp_path)
+
+
+_MINIMAL_SPREAD_WITH_BOTH_BACKENDS = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04
+  tutorial-test:
+    systems:
+      - ubuntu-24.04
+suites:
+  tests/integration/:
+    summary: integration tests
+    backends:
+      - integration-test
+    environment:
+      MODULE/test_charm: test_charm
+  tests/tutorial/:
+    summary: tutorial tests
+    backends:
+      - tutorial-test
+    environment:
+      TUTORIAL/tutorial1: docs/tutorial1.rst
+"""
+
+
+class TestTutorialBackend:
+    """Tests for tutorial-test virtual backend expansion."""
+
+    def test_expand_tutorial_local(self, tmp_path: Path) -> None:
+        """tutorial-test expands to local-tutorial with minimal prepare."""
+        spread = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  tutorial-test:
+    systems:
+      - ubuntu-24.04
+suites:
+  tests/tutorial/: {}
+"""
+        _write(tmp_path / "spread.yaml", spread)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+
+        assert "tutorial-test" not in result
+        backend = parsed["backends"]["local-tutorial"]
+        assert backend["type"] == "adhoc"
+        assert "lxc launch --vm" in backend["allocate"]
+        assert "lxc delete" in backend["discard"]
+        assert "pip install" in backend["prepare"]
+        # No concierge/provision in tutorial prepare
+        assert "concierge" not in backend["prepare"]
+        assert "opcli provision load" not in backend["prepare"]
+
+    def test_expand_tutorial_ci(self, tmp_path: Path) -> None:
+        """tutorial-test CI expansion has no prepare."""
+        spread = """\
+project: test-project
+backends:
+  tutorial-test:
+    systems:
+      - ubuntu-24.04
+suites:
+  tests/tutorial/: {}
+"""
+        _write(tmp_path / "spread.yaml", spread)
+
+        result = spread_expand(tmp_path, ci=True)
+        parsed = _yaml.load(StringIO(result))
+
+        backend = parsed["backends"]["ci-tutorial"]
+        assert backend["type"] == "adhoc"
+        assert backend["allocate"] == "ADDRESS localhost"
+        assert "prepare" not in backend
+
+    def test_tutorial_username_injected_local(self, tmp_path: Path) -> None:
+        """Ubuntu user is injected into tutorial backend systems for local."""
+        spread = """\
+project: test-project
+backends:
+  tutorial-test:
+    systems:
+      - ubuntu-24.04
+suites:
+  tests/tutorial/: {}
+"""
+        _write(tmp_path / "spread.yaml", spread)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        systems = parsed["backends"]["local-tutorial"]["systems"]
+        assert systems[0]["ubuntu-24.04"]["username"] == "ubuntu"
+
+    def test_suite_backend_scoping_replaces_virtual_names(self, tmp_path: Path) -> None:
+        """Suite backends lists are updated from virtual to concrete names."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD_WITH_BOTH_BACKENDS)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+
+        assert "integration-test" not in result
+        assert "tutorial-test" not in result
+        assert parsed["suites"]["tests/integration/"]["backends"] == ["local"]
+        assert parsed["suites"]["tests/tutorial/"]["backends"] == ["local-tutorial"]
+
+    def test_both_backends_coexist(self, tmp_path: Path) -> None:
+        """Both virtual backends can be expanded from the same spread.yaml."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD_WITH_BOTH_BACKENDS)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+
+        assert "local" in parsed["backends"]
+        assert "local-tutorial" in parsed["backends"]
+
+    def test_no_known_virtual_backend_raises(self, tmp_path: Path) -> None:
+        """Raises ConfigurationError when no known virtual backend is found."""
+        spread = """\
+project: test-project
+backends:
+  custom-backend:
+    type: adhoc
+suites:
+  tests/: {}
+"""
+        _write(tmp_path / "spread.yaml", spread)
+
+        with pytest.raises(ConfigurationError, match="no known virtual backend"):
+            spread_expand(tmp_path)
+
+    def test_generated_suite_has_backends_key(self, tmp_path: Path) -> None:
+        """spread_init generates suite with backends: [integration-test] for scoping."""
+        _write(tmp_path / "tests" / "integration" / "test_charm.py", "")
+        spread_path, _ = spread_init(tmp_path)
+
+        parsed = _yaml.load(StringIO(spread_path.read_text()))
+        suite = parsed["suites"]["tests/integration/"]
+        assert "backends" in suite
+        assert "integration-test" in suite["backends"]
+
+    def test_generated_suite_backends_replaced_after_expand(
+        self, tmp_path: Path
+    ) -> None:
+        """After expansion, suite backends reference the concrete backend name."""
+        _, _ = spread_init(tmp_path)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+
+        suite = parsed["suites"]["tests/integration/"]
+        assert "integration-test" not in suite.get("backends", [])
+        assert "local" in suite["backends"]

--- a/tests/unit/test_tutorial.py
+++ b/tests/unit/test_tutorial.py
@@ -86,6 +86,24 @@ class TestMarkdownExtraction:
         assert "skipped command" not in result
         assert "after skip" in result
 
+    def test_spread_skip_overlap_excluded(self, tmp_path: Path) -> None:
+        """A code block that overlaps a SPREAD SKIP range is excluded.
+
+        This covers the case where the code block starts inside the skip
+        region — regardless of whether it ends inside or outside.
+        """
+        # The code block starts inside the SPREAD SKIP region.
+        # The overlap detection (start < e and end > s) must catch it.
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "<!-- SPREAD SKIP -->\n"
+            "```\noverlapping block\n```\n"
+            "<!-- SPREAD SKIP END -->\n",
+        )
+        result = expand_tutorial(doc)
+        assert "overlapping block" not in result
+
     def test_four_backtick_fence_excluded(self, tmp_path: Path) -> None:
         doc = tmp_path / "tutorial.md"
         _write(

--- a/tests/unit/test_tutorial.py
+++ b/tests/unit/test_tutorial.py
@@ -1,0 +1,242 @@
+"""Tests for ``opcli tutorial expand``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opcli.core.exceptions import ValidationError
+from opcli.core.tutorial import expand_tutorial
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+# ---------------------------------------------------------------------------
+# Markdown extraction
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownExtraction:
+    """Tests for Markdown command extraction."""
+
+    def test_extracts_simple_code_block(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "Some text\n```\necho hello\n```\n",
+        )
+        result = expand_tutorial(doc)
+        assert "echo hello" in result
+
+    def test_extracts_multiple_blocks_in_order(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "```\nfirst\n```\n\nSome prose\n\n```\nsecond\n```\n",
+        )
+        result = expand_tutorial(doc)
+        lines = result.splitlines()
+        assert lines.index("first") < lines.index("second")
+
+    def test_excludes_note_blocks(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "```{note}\nThis is a note.\n```\n\n```\nreal command\n```\n",
+        )
+        result = expand_tutorial(doc)
+        assert "This is a note." not in result
+        assert "real command" in result
+
+    def test_excludes_tip_blocks(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "```{tip}\nA tip.\n```\n\n```\nmy command\n```\n",
+        )
+        result = expand_tutorial(doc)
+        assert "A tip." not in result
+        assert "my command" in result
+
+    def test_includes_spread_comment_block(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "<!-- SPREAD\necho from spread\n-->\n",
+        )
+        result = expand_tutorial(doc)
+        assert "echo from spread" in result
+
+    def test_spread_skip_excludes_range(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "```\nbefore skip\n```\n"
+            "<!-- SPREAD SKIP -->\n"
+            "```\nskipped command\n```\n"
+            "<!-- SPREAD SKIP END -->\n"
+            "```\nafter skip\n```\n",
+        )
+        result = expand_tutorial(doc)
+        assert "before skip" in result
+        assert "skipped command" not in result
+        assert "after skip" in result
+
+    def test_four_backtick_fence_excluded(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "````\n```\nnested\n```\n````\n\n```\nreal\n```\n",
+        )
+        result = expand_tutorial(doc)
+        assert "nested" not in result
+        assert "real" in result
+
+    def test_language_identifier_preserved_command(self, tmp_path: Path) -> None:
+        """Code blocks with a language hint (not starting with {) are included."""
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "```bash\necho bash\n```\n",
+        )
+        result = expand_tutorial(doc)
+        assert "echo bash" in result
+
+    def test_spread_skip_on_spread_comment(self, tmp_path: Path) -> None:
+        """SPREAD blocks inside SPREAD SKIP are also excluded."""
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "<!-- SPREAD SKIP -->\n"
+            "<!-- SPREAD\nskipped spread\n-->\n"
+            "<!-- SPREAD SKIP END -->\n"
+            "<!-- SPREAD\nkept spread\n-->\n",
+        )
+        result = expand_tutorial(doc)
+        assert "skipped spread" not in result
+        assert "kept spread" in result
+
+    def test_unclosed_spread_skip_raises(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.md"
+        _write(
+            doc,
+            "<!-- SPREAD SKIP -->\n```\nnot closed\n```\n",
+        )
+        with pytest.raises(ValidationError):
+            expand_tutorial(doc)
+
+    def test_empty_file_returns_empty(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.md"
+        _write(doc, "")
+        assert expand_tutorial(doc) == ""
+
+
+# ---------------------------------------------------------------------------
+# RST extraction
+# ---------------------------------------------------------------------------
+
+
+class TestRstExtraction:
+    """Tests for reStructuredText command extraction."""
+
+    def test_extracts_code_block(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.rst"
+        _write(
+            doc,
+            "Some text\n\n.. code-block:: bash\n\n   echo hello\n\n",
+        )
+        result = expand_tutorial(doc)
+        assert "echo hello" in result
+
+    def test_extracts_multiple_blocks_in_order(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.rst"
+        _write(
+            doc,
+            ".. code-block::\n\n   first\n\nProse\n\n.. code-block::\n\n   second\n\n",
+        )
+        result = expand_tutorial(doc)
+        lines = result.splitlines()
+        assert lines.index("first") < lines.index("second")
+
+    def test_includes_spread_block(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.rst"
+        _write(
+            doc,
+            ".. SPREAD\n.. echo from spread\n.. SPREAD END\n",
+        )
+        result = expand_tutorial(doc)
+        assert "echo from spread" in result
+
+    def test_spread_skip_excludes_range(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.rst"
+        _write(
+            doc,
+            ".. code-block::\n\n   before\n\n"
+            ".. SPREAD SKIP\n"
+            ".. code-block::\n\n   skipped\n\n"
+            ".. SPREAD SKIP END\n"
+            ".. code-block::\n\n   after\n\n",
+        )
+        result = expand_tutorial(doc)
+        assert "before" in result
+        assert "skipped" not in result
+        assert "after" in result
+
+    def test_unclosed_spread_marker_raises(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.rst"
+        _write(
+            doc,
+            ".. SPREAD\n.. echo unclosed\n",
+        )
+        with pytest.raises(ValidationError):
+            expand_tutorial(doc)
+
+    def test_dedents_code_block_content(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.rst"
+        _write(
+            doc,
+            ".. code-block::\n\n"
+            "   sudo apt-get install foo\n"
+            "   sudo apt-get install bar\n\n",
+        )
+        result = expand_tutorial(doc)
+        assert "sudo apt-get install foo" in result
+        assert "sudo apt-get install bar" in result
+        # No leading whitespace after dedent
+        for line in result.splitlines():
+            if line.strip():
+                assert not line.startswith(" ")
+
+    def test_rest_extension_supported(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.rest"
+        _write(
+            doc,
+            ".. code-block::\n\n   echo rest\n\n",
+        )
+        result = expand_tutorial(doc)
+        assert "echo rest" in result
+
+
+# ---------------------------------------------------------------------------
+# File type detection
+# ---------------------------------------------------------------------------
+
+
+class TestFileTypeDetection:
+    """Tests for file type dispatch."""
+
+    def test_unsupported_extension_raises(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.txt"
+        _write(doc, "echo hello\n")
+        with pytest.raises(ValidationError, match="Unsupported file type"):
+            expand_tutorial(doc)
+
+    def test_markdown_extension(self, tmp_path: Path) -> None:
+        doc = tmp_path / "tutorial.markdown"
+        _write(doc, "```\necho ok\n```\n")
+        result = expand_tutorial(doc)
+        assert "echo ok" in result


### PR DESCRIPTION
## Summary

Implements the tutorial testing feature from the spec.

### `opcli tutorial expand <file>`
- Extracts shell commands from Markdown (.md) and reStructuredText (.rst/.rest) tutorial files
- Prints them as a shell script to stdout for use with `eval` in spread task.yaml:
  ```yaml
  execute: |
      eval "$(opcli tutorial expand "$TUTORIAL")"
  ```
- Validates marker pairing (raises on unclosed/mismatched markers)

### `tutorial-test:` virtual backend
- New virtual backend that expands like `integration-test` but without concierge/provision load in prepare
- Local: `local-tutorial` backend with minimal prepare (`pip install /home/ubuntu/proj` so `opcli tutorial expand` is available in the VM)
- CI: `ci-tutorial` backend with no prepare (workflow installs opcli before spread)

### Suite backend scoping
- `spread init` now adds `backends: [integration-test]` to generated suites
- `_expand_backend` updates suite `backends:` lists from virtual to concrete names during expansion
- Prevents suites from running on the wrong backend when both `integration-test` and `tutorial-test` coexist in the same `spread.yaml`

### Design notes
- Spec uses `$(opcli tutorial expand $TUTORIAL)` — this is wrong for multi-line scripts (command substitution without eval). Using `eval "$(...)"\ instead.
- Both backends expand the same LXD VM allocate/discard scripts; only prepare differs
- 28 new unit tests (151 total)
