### PR TITLE
fix: install pip and opcli in tutorial backend prepare

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -259,10 +259,11 @@ if [ -f "$CONCIERGE" ]; then
 fi
 """
 
-# Tutorial backend: install opcli from the synced project so that
-# ``opcli tutorial expand`` is available inside the VM.
+# Tutorial backend: install pip then opcli from the GitHub repo main branch so
+# that ``opcli tutorial expand`` is available inside the VM.
 _TUTORIAL_LOCAL_PREPARE = """\
-pip install /home/ubuntu/proj --quiet
+sudo apt-get install -y python3-pip --quiet
+pip install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 """
 
 

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -554,6 +554,8 @@ suites:
         assert "lxc launch --vm" in backend["allocate"]
         assert "lxc delete" in backend["discard"]
         assert "pip install" in backend["prepare"]
+        assert "apt-get install" in backend["prepare"]
+        assert "operator-ci-poc" in backend["prepare"]
         # No concierge/provision in tutorial prepare
         assert "concierge" not in backend["prepare"]
         assert "opcli provision load" not in backend["prepare"]


### PR DESCRIPTION
The previous prepare used `pip install` but `pip` is not installed by default on Ubuntu 24.04 cloud images.

Fix: install `python3-pip` via apt first, then install opcli from the GitHub repo main branch.