### PR TITLE
fix: use pipx to install opcli in tutorial backend prepare

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -262,8 +262,8 @@ fi
 # Tutorial backend: install pip then opcli from the GitHub repo main branch so
 # that ``opcli tutorial expand`` is available inside the VM.
 _TUTORIAL_LOCAL_PREPARE = """\
-sudo apt-get install -y python3-pip --quiet
-pip install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
+curl -LsSf https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+uv tool install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 """
 
 

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -262,8 +262,8 @@ fi
 # Tutorial backend: install pip then opcli from the GitHub repo main branch so
 # that ``opcli tutorial expand`` is available inside the VM.
 _TUTORIAL_LOCAL_PREPARE = """\
-curl -LsSf https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
-uv tool install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
+sudo apt-get install -y pipx --quiet
+pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 """
 
 

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -553,8 +553,8 @@ suites:
         assert backend["type"] == "adhoc"
         assert "lxc launch --vm" in backend["allocate"]
         assert "lxc delete" in backend["discard"]
-        assert "uv tool install" in backend["prepare"]
-        assert "astral.sh/uv" in backend["prepare"]
+        assert "pipx install" in backend["prepare"]
+        assert "astral.sh" not in backend["prepare"]
         assert "operator-ci-poc" in backend["prepare"]
         # No concierge/provision in tutorial prepare
         assert "concierge" not in backend["prepare"]

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -553,8 +553,8 @@ suites:
         assert backend["type"] == "adhoc"
         assert "lxc launch --vm" in backend["allocate"]
         assert "lxc delete" in backend["discard"]
-        assert "pip install" in backend["prepare"]
-        assert "apt-get install" in backend["prepare"]
+        assert "uv tool install" in backend["prepare"]
+        assert "astral.sh/uv" in backend["prepare"]
         assert "operator-ci-poc" in backend["prepare"]
         # No concierge/provision in tutorial prepare
         assert "concierge" not in backend["prepare"]


### PR DESCRIPTION
PEP 668 prevents system pip installs on Ubuntu 24.04. Switch to pipx (`python3-pipx` from the main Ubuntu repo) which is the recommended way to install CLI tools.