### PR TITLE
fix: add apt-get update and install opcli to /usr/local/bin in tutorial prepare

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -262,8 +262,9 @@ fi
 # Tutorial backend: install pip then opcli from the GitHub repo main branch so
 # that ``opcli tutorial expand`` is available inside the VM.
 _TUTORIAL_LOCAL_PREPARE = """\
+sudo apt-get update --quiet
 sudo apt-get install -y pipx --quiet
-pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
+sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 """
 
 

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -264,7 +264,8 @@ fi
 _TUTORIAL_LOCAL_PREPARE = """\
 sudo apt-get update --quiet
 sudo apt-get install -y pipx --quiet
-sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
+sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
+    pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 """
 
 


### PR DESCRIPTION
Two fixes for the tutorial backend prepare script:
1. Add `apt-get update` so package lists are fresh on cloud images
2. Use `PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin` so opcli lands in `/usr/local/bin` (on PATH in all SSH sessions, not just login shells)