### PR TITLE
feat: support interactive spread commands (spread -shell)

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -548,4 +548,4 @@ def spread_run(
         cmd = ["spread"]
         if extra_args:
             cmd.extend(extra_args)
-        run_command(cmd, cwd=str(temp_dir_path))
+        run_command(cmd, cwd=str(temp_dir_path), interactive=True)

--- a/src/opcli/core/subprocess.py
+++ b/src/opcli/core/subprocess.py
@@ -112,7 +112,7 @@ def _run_interactive(
         raise SubprocessError(
             cmd=cmd,
             returncode=result.returncode,
-            stderr="",
+            stderr="(output not captured in interactive mode)",
         )
 
     return result

--- a/src/opcli/core/subprocess.py
+++ b/src/opcli/core/subprocess.py
@@ -45,13 +45,14 @@ def _stream_pipe(
         dest.flush()
 
 
-def run_command(
+def run_command(  # noqa: PLR0913
     cmd: list[str],
     *,
     cwd: str | None = None,
     timeout: int = _DEFAULT_TIMEOUT_SECONDS,
     check: bool = True,
     stream: bool = True,
+    interactive: bool = False,
 ) -> SubprocessResult:
     """Execute *cmd* and return captured output.
 
@@ -59,17 +60,23 @@ def run_command(
         cmd: Command and arguments.
         cwd: Working directory for the subprocess.
         timeout: Maximum wall-clock seconds before the process is killed.
+            Ignored when *interactive* is ``True``.
         check: If ``True`` (default), raise :class:`SubprocessError` on
             non-zero exit codes.
         stream: If ``True`` (default), echo stdout/stderr to the terminal
             in real time while still capturing them. If ``False``, buffer
             all output silently (useful for commands whose stdout is
             consumed programmatically, like ``opcli pytest args``).
+        interactive: If ``True``, inherit the parent's stdin/stdout/stderr
+            so the subprocess has full TTY access. Required for commands
+            like ``spread -shell``. Output is not captured in this mode.
 
     Raises:
         SubprocessError: If the command fails and *check* is ``True``.
 
     """
+    if interactive:
+        return _run_interactive(cmd, cwd=cwd, check=check)
     if stream:
         return _run_streaming(cmd, cwd=cwd, timeout=timeout, check=check)
     return _run_captured(cmd, cwd=cwd, timeout=timeout, check=check)
@@ -80,6 +87,35 @@ def _log_command(cmd: list[str], cwd: str | None) -> None:
     typer.echo(f"$ {shlex.join(cmd)}")
     if cwd:
         typer.echo(f"  cwd: {cwd}")
+
+
+def _run_interactive(
+    cmd: list[str],
+    *,
+    cwd: str | None = None,
+    check: bool = True,
+) -> SubprocessResult:
+    """Run *cmd* with inherited stdin/stdout/stderr for full TTY access."""
+    _log_command(cmd, cwd)
+    try:
+        proc = subprocess.run(cmd, cwd=cwd, check=False)
+    except OSError as exc:
+        raise SubprocessError(
+            cmd=cmd,
+            returncode=127 if isinstance(exc, FileNotFoundError) else -1,
+            stderr=str(exc),
+        ) from exc
+
+    result = SubprocessResult(stdout="", stderr="", returncode=proc.returncode)
+
+    if check and result.returncode != 0:
+        raise SubprocessError(
+            cmd=cmd,
+            returncode=result.returncode,
+            stderr="",
+        )
+
+    return result
 
 
 def _run_streaming(

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -186,3 +186,55 @@ class TestSubprocessWrapper:
         captured = capsys.readouterr().out
         assert "$ echo hello" in captured
         assert "cwd:" not in captured
+
+    # --- Interactive mode ---
+
+    def test_interactive_success(self) -> None:
+        with patch("opcli.core.subprocess.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+
+            result = run_command(["spread", "-shell"], interactive=True)
+
+            assert result.returncode == 0
+            assert result.stdout == ""
+            assert result.stderr == ""
+            mock_run.assert_called_once_with(
+                ["spread", "-shell"], cwd=None, check=False
+            )
+
+    def test_interactive_failure_raises(self) -> None:
+        with patch("opcli.core.subprocess.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+
+            with pytest.raises(SubprocessError) as exc_info:
+                run_command(["spread", "-shell"], interactive=True)
+
+            assert exc_info.value.returncode == 1
+            assert "interactive mode" in exc_info.value.stderr
+
+    def test_interactive_no_check(self) -> None:
+        with patch("opcli.core.subprocess.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1
+
+            result = run_command(["spread"], check=False, interactive=True)
+            assert result.returncode == 1
+
+    def test_interactive_file_not_found(self) -> None:
+        with patch("opcli.core.subprocess.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("No such file")
+
+            with pytest.raises(SubprocessError) as exc_info:
+                run_command(["spread"], interactive=True)
+
+            assert exc_info.value.returncode == 127  # noqa: PLR2004
+            assert "No such file" in exc_info.value.stderr
+
+    def test_interactive_other_oserror(self) -> None:
+        with patch("opcli.core.subprocess.subprocess.run") as mock_run:
+            mock_run.side_effect = OSError("permission denied")
+
+            with pytest.raises(SubprocessError) as exc_info:
+                run_command(["spread"], interactive=True)
+
+            assert exc_info.value.returncode == -1
+            assert "permission denied" in exc_info.value.stderr


### PR DESCRIPTION
Adds `interactive=True` to `run_command` which inherits stdin/stdout/stderr from the parent process, giving the subprocess full TTY access. `opcli spread run` now uses this mode so `spread -shell` works correctly.