### PR TITLE
fix: run tutorial commands as ubuntu user via runuser

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -110,12 +110,14 @@ execute: |
     $( opcli pytest run -- -k $MODULE )
 """
 
-_TUTORIAL_TASK_YAML_CONTENT = """\
-summary: tutorial test
-
-execute: |
-    eval "$(opcli tutorial expand "$TUTORIAL")"
-"""
+_TUTORIAL_TASK_YAML_CONTENT = (
+    "summary: tutorial test\n"
+    "\n"
+    "execute: |\n"
+    "    loginctl enable-linger ubuntu\n"
+    '    runuser -l ubuntu -c "eval \\"\\$(opcli tutorial expand \\"${SPREAD_PATH}${TUTORIAL}\\")\\""'  # noqa: E501
+    "\n"
+)
 
 
 def spread_init(root: Path, *, force: bool = False) -> tuple[Path, Path]:

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -115,8 +115,7 @@ _TUTORIAL_TASK_YAML_CONTENT = (
     "\n"
     "execute: |\n"
     "    loginctl enable-linger ubuntu\n"
-    '    runuser -l ubuntu -c "eval \\"\\$(opcli tutorial expand \\"${SPREAD_PATH}${TUTORIAL}\\")\\""'  # noqa: E501
-    "\n"
+    '    runuser -l ubuntu -c "eval \\"\\$(opcli tutorial expand ${SPREAD_PATH}${TUTORIAL})\\""\n'  # noqa: E501
 )
 
 


### PR DESCRIPTION
Spread always runs scripts as root via `sudo -i`. Tutorial commands need a real user environment. Use `loginctl enable-linger` + `runuser -l ubuntu` to run as ubuntu with a proper login shell. Tested on a real LXD VM — `uid=1000(ubuntu)` confirmed, `opcli` found, tutorial commands executed.