### PR TITLE
fix: use jq to find LXD VM by IP in discard script

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -238,8 +238,10 @@ done
 
 _LOCAL_DISCARD = """\
 instance_name=$(lxc ls --format json \
-  | jq -r --arg addr "$SPREAD_SYSTEM_ADDRESS" \
-    '[.[] | select(.state.network // {} | to_entries[]?.value.addresses[]? | .address == $addr)] | .[0].name // ""')
+  | jq -r --arg a "$SPREAD_SYSTEM_ADDRESS" \
+    '.[] | select(any(
+      .state.network[]?.addresses[]?; .address == $a
+    )) | .name' | head -1)
 if [ -n "$instance_name" ]; then
   lxc delete --force "$instance_name"
 fi

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -237,9 +237,9 @@ done
 """
 
 _LOCAL_DISCARD = """\
-instance_name=$(lxc ls --format csv --columns n4 \\
-  | awk -F, -v addr="$SPREAD_SYSTEM_ADDRESS" \\
-    '{split($2,a," "); if(a[1]==addr) {print $1; exit}}')
+instance_name=$(lxc ls --format json \
+  | jq -r --arg addr "$SPREAD_SYSTEM_ADDRESS" \
+    '[.[] | select(.state.network // {} | to_entries[]?.value.addresses[]? | .address == $addr)] | .[0].name // ""')
 if [ -n "$instance_name" ]; then
   lxc delete --force "$instance_name"
 fi


### PR DESCRIPTION
## Problem

The discard script used `lxc ls --format csv --columns n4` + awk to find the VM by IP. When a VM has multiple IPs (e.g., bridge interface + enp5s0), the CSV output puts them on separate lines:

```
spread-ubuntu-24-04-33277-21050,"10.84.23.1 (lxdbr0)
10.27.109.201 (enp5s0)"
```

The awk `split($2,...)` only saw the first IP (`10.84.23.1`), missed the spread system address (`10.27.109.201`), returned empty, and the VM was never deleted.

## Fix

Use `lxc --format json` + `jq` to search across all network interfaces and addresses robustly.