### PR TITLE
feat: replace pytest run/args with pytest expand

### DIFF
--- a/src/opcli/commands/pytest_cmd.py
+++ b/src/opcli/commands/pytest_cmd.py
@@ -1,10 +1,11 @@
 """CLI commands for pytest/tox integration test execution."""
 
+import shlex
 from pathlib import Path
 
 import typer
 
-from opcli.core.pytest_args import assemble_pytest_args, run_pytest
+from opcli.core.pytest_args import assemble_tox_argv
 
 app = typer.Typer(
     help="Assemble pytest flags from build output and run integration tests.",
@@ -15,20 +16,14 @@ app = typer.Typer(
 @app.command(
     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
 )
-def run(
+def expand(
     ctx: typer.Context,
     *,
     tox_env: str = typer.Option("integration", "-e", help="Tox environment name."),
 ) -> None:
-    """Run integration tests via tox. Extra args after -- are forwarded to pytest."""
-    run_pytest(Path.cwd(), tox_env=tox_env, extra_args=ctx.args or None)
+    """Print the full tox command assembled from artifacts-generated.yaml.
 
-
-@app.command()
-def args() -> None:
-    """Print assembled tox/pytest flags from artifacts-generated.yaml."""
-    flags = assemble_pytest_args(Path.cwd())
-    if flags:
-        typer.echo(" ".join(flags))
-    else:
-        typer.echo("# No flags assembled (no charms/resources found)")
+    Extra args after -- are forwarded into the printed command.
+    """
+    argv = assemble_tox_argv(Path.cwd(), tox_env=tox_env, extra_args=ctx.args or None)
+    typer.echo(shlex.join(argv))

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -1,4 +1,4 @@
-"""Core logic for ``opcli pytest args`` and ``opcli pytest run``.
+"""Core logic for ``opcli pytest expand``.
 
 Reads ``artifacts-generated.yaml`` and assembles the flags that tox/pytest
 need to locate built charms and their OCI-image resources.
@@ -15,7 +15,6 @@ import logging
 from pathlib import Path
 
 from opcli.core.exceptions import ConfigurationError
-from opcli.core.subprocess import run_command
 from opcli.core.yaml_io import load_artifacts_generated, load_artifacts_plan
 from opcli.models.artifacts import ArtifactsPlan
 from opcli.models.artifacts_generated import ArtifactsGenerated
@@ -86,21 +85,25 @@ def assemble_pytest_args(
     return args
 
 
-def run_pytest(
+def assemble_tox_argv(
     root: Path,
     *,
     tox_env: str = "integration",
     extra_args: list[str] | None = None,
-) -> None:
-    """Assemble flags and run ``tox -e <env> -- <flags> <extra>``.
+) -> list[str]:
+    """Build the full tox argv for running integration tests.
+
+    Returns a list of tokens suitable for shell execution or display via
+    ``shlex.join()``.  The ``--`` separator is included only when there are
+    pytest flags or forwarded extra args to pass.
 
     Raises:
         ConfigurationError: If required YAML files are missing.
-        SubprocessError: If tox exits non-zero.
     """
     assembled = assemble_pytest_args(root)
-    cmd = ["tox", "-e", tox_env, "--"]
-    cmd.extend(assembled)
-    if extra_args:
-        cmd.extend(extra_args)
-    run_command(cmd, cwd=str(root))
+    pytest_args = assembled + (extra_args or [])
+
+    cmd: list[str] = ["tox", "-e", tox_env]
+    if pytest_args:
+        cmd += ["--", *pytest_args]
+    return cmd

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -123,7 +123,7 @@ _TASK_YAML_CONTENT = """\
 summary: integration tests
 
 execute: |
-    $( opcli pytest run -- -k $MODULE )
+    $( opcli pytest expand -- -k $MODULE )
 """
 
 _TUTORIAL_TASK_YAML_CONTENT = (

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -1,14 +1,13 @@
-"""Tests for ``opcli pytest args`` and ``opcli pytest run``."""
+"""Tests for ``opcli pytest expand``."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
 from opcli.core.exceptions import ConfigurationError
-from opcli.core.pytest_args import assemble_pytest_args, run_pytest
+from opcli.core.pytest_args import assemble_pytest_args, assemble_tox_argv
 
 
 def _write(path: Path, content: str) -> None:
@@ -121,41 +120,57 @@ class TestAssemblePytestArgs:
         assert args == []
 
 
-class TestRunPytest:
-    """Tests for run_pytest()."""
+class TestAssembleToxArgv:
+    """Tests for assemble_tox_argv()."""
 
-    def test_runs_tox_with_assembled_args(self, tmp_path: Path) -> None:
+    def test_no_flags_no_extra_omits_separator(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+
+        argv = assemble_tox_argv(tmp_path)
+
+        assert argv == ["tox", "-e", "integration"]
+        assert "--" not in argv
+
+    def test_assembled_flags_include_separator(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts.yaml", _PLAN_WITH_RESOURCES)
         _write(tmp_path / "artifacts-generated.yaml", _GENERATED_LOCAL)
 
-        with patch("opcli.core.pytest_args.run_command") as mock_run:
-            run_pytest(tmp_path)
+        argv = assemble_tox_argv(tmp_path)
 
-        cmd = mock_run.call_args[0][0]
-        assert cmd[:4] == ["tox", "-e", "integration", "--"]
-        assert "--charm-file" in cmd
-        assert "./mycharm.charm" in cmd
+        assert argv[:3] == ["tox", "-e", "integration"]
+        assert "--" in argv
+        assert "--charm-file" in argv
+        assert "./mycharm.charm" in argv
+
+    def test_extra_args_only_include_separator(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+
+        argv = assemble_tox_argv(tmp_path, extra_args=["-k", "test_foo"])
+
+        assert "--" in argv
+        assert "-k" in argv
+        assert "test_foo" in argv
 
     def test_custom_tox_env(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
 
-        with patch("opcli.core.pytest_args.run_command") as mock_run:
-            run_pytest(tmp_path, tox_env="e2e")
+        argv = assemble_tox_argv(tmp_path, tox_env="e2e")
 
-        cmd = mock_run.call_args[0][0]
-        assert cmd[2] == "e2e"
+        assert argv[2] == "e2e"
 
-    def test_extra_args_forwarded(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+    def test_extra_args_appended_after_assembled(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts.yaml", _PLAN_WITH_RESOURCES)
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_LOCAL)
 
-        with patch("opcli.core.pytest_args.run_command") as mock_run:
-            run_pytest(tmp_path, extra_args=["-k", "test_foo", "-v"])
+        argv = assemble_tox_argv(tmp_path, extra_args=["-v", "-k", "test_charm"])
 
-        cmd = mock_run.call_args[0][0]
-        assert "-k" in cmd
-        assert "test_foo" in cmd
-        assert "-v" in cmd
+        sep_idx = argv.index("--")
+        tail = argv[sep_idx + 1 :]
+        assert "--charm-file" in tail
+        assert "-v" in tail
+        assert "-k" in tail
+        assert "test_charm" in tail
 
     def test_missing_generated_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ConfigurationError, match="not found"):
-            run_pytest(tmp_path)
+            assemble_tox_argv(tmp_path)

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -53,7 +53,7 @@ class TestSpreadInit:
         assert "integration-test" in content
 
         task_content = task_path.read_text()
-        assert "opcli pytest run" in task_content
+        assert "opcli pytest expand" in task_content
 
     def test_generates_required_fields(self, tmp_path: Path) -> None:
         spread_path, _ = spread_init(tmp_path)
@@ -128,7 +128,7 @@ class TestSpreadInit:
 
         spread_path, task_path = spread_init(tmp_path, force=True)
         assert "integration-test" in spread_path.read_text()
-        assert "opcli pytest run" in task_path.read_text()
+        assert "opcli pytest expand" in task_path.read_text()
 
     def test_project_name_from_directory(self, tmp_path: Path) -> None:
         spread_path, _ = spread_init(tmp_path)


### PR DESCRIPTION
Replaces `opcli pytest run` and `opcli pytest args` with a single `opcli pytest expand` command.

## Changes
- **Drop `opcli pytest run`** — no subprocess wrapper needed; CI/users run the output directly
- **Rename `opcli pytest args` → `opcli pytest expand`** — now prints the full shlex-quoted tox command (copy-pasteable)
- `--` separator included only when there are pytest flags or forwarded extra args
- Generated spread task.yaml template updated: `opcli pytest run` → `opcli pytest expand`
- All tests updated