### PR TITLE
feat: run integration tests as ubuntu user in spread task

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -125,7 +125,8 @@ _TASK_YAML_CONTENT = (
     "execute: |\n"
     "    loginctl enable-linger ubuntu\n"
     '    cd "${SPREAD_PATH}"\n'
-    '    runuser -l ubuntu -c "cd \\"${SPREAD_PATH}\\" && $(opcli pytest expand -- -k \\"$MODULE\\")"\n'  # noqa: E501
+    '    PYTEST_CMD=$(opcli pytest expand -- -k "$MODULE") || exit 1\n'
+    '    runuser -l ubuntu -c "cd \\"${SPREAD_PATH}\\" && $PYTEST_CMD"\n'
 )
 
 _TUTORIAL_TASK_YAML_CONTENT = (

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -119,14 +119,14 @@ def _generate_spread_yaml(
     return buf.getvalue()
 
 
-_TASK_YAML_CONTENT = """\
-summary: integration tests
-
-execute: |
-    loginctl enable-linger ubuntu
-    cd "${SPREAD_PATH}"
-    runuser -l ubuntu -c "cd ${SPREAD_PATH} && $(opcli pytest expand -- -k "$MODULE")"
-"""
+_TASK_YAML_CONTENT = (
+    "summary: integration tests\n"
+    "\n"
+    "execute: |\n"
+    "    loginctl enable-linger ubuntu\n"
+    '    cd "${SPREAD_PATH}"\n'
+    '    runuser -l ubuntu -c "cd \\"${SPREAD_PATH}\\" && $(opcli pytest expand -- -k \\"$MODULE\\")"\n'  # noqa: E501
+)
 
 _TUTORIAL_TASK_YAML_CONTENT = (
     "summary: tutorial test\n"

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -124,7 +124,7 @@ summary: integration tests
 
 execute: |
     loginctl enable-linger ubuntu
-    runuser -l ubuntu -c "$(opcli pytest expand -- -k $MODULE)"
+    runuser -l ubuntu -c "cd ${SPREAD_PATH} && $(opcli pytest expand -- -k $MODULE)"
 """
 
 _TUTORIAL_TASK_YAML_CONTENT = (

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -124,7 +124,8 @@ summary: integration tests
 
 execute: |
     loginctl enable-linger ubuntu
-    runuser -l ubuntu -c "cd ${SPREAD_PATH} && $(opcli pytest expand -- -k $MODULE)"
+    cd "${SPREAD_PATH}"
+    runuser -l ubuntu -c "cd ${SPREAD_PATH} && $(opcli pytest expand -- -k "$MODULE")"
 """
 
 _TUTORIAL_TASK_YAML_CONTENT = (

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -123,7 +123,8 @@ _TASK_YAML_CONTENT = """\
 summary: integration tests
 
 execute: |
-    $( opcli pytest expand -- -k $MODULE )
+    loginctl enable-linger ubuntu
+    runuser -l ubuntu -c "$(opcli pytest expand -- -k $MODULE)"
 """
 
 _TUTORIAL_TASK_YAML_CONTENT = (


### PR DESCRIPTION
Mirrors the tutorial pattern for the integration test task.yaml template.

Before:
```yaml
execute: |
    $( opcli pytest expand -- -k $MODULE )
```

After:
```yaml
execute: |
    loginctl enable-linger ubuntu
    runuser -l ubuntu -c "$(opcli pytest expand -- -k $MODULE)"
```

Juju credentials and LXD group membership live under the ubuntu user (set up by concierge), so tests must run in that context.