### PR TITLE
feat: install concierge and opcli in local integration-test prepare

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -267,6 +267,11 @@ fi
 """
 
 _LOCAL_PREPARE = """\
+sudo snap install concierge
+sudo apt-get update --quiet
+sudo apt-get install -y pipx --quiet
+sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
+    pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 if [ -f "$CONCIERGE" ]; then
   sudo concierge prepare -c "$CONCIERGE"
 fi


### PR DESCRIPTION
The local `integration-test:` backend prepare now installs tools before provisioning:

```bash
sudo snap install concierge
sudo apt-get install -y pipx
pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main
# then concierge prepare + opcli provision load as before
```

Mirrors the tutorial backend pattern. CI prepare is unchanged — workflows install tools before invoking spread.