### PR TITLE
fix: store artifact paths relative to repo root in artifacts-generated.yaml

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -76,8 +76,8 @@ def artifacts_init(root: Path, *, force: bool = False) -> Path:
     return dest
 
 
-def _find_output_file(source_dir: Path, kind: str) -> str:
-    """Glob for the built artifact in *source_dir*."""
+def _find_output_file(source_dir: Path, kind: str, root: Path) -> str:
+    """Glob for the built artifact in *source_dir*, returning a relative path."""
     pattern = _OUTPUT_GLOBS[kind]
     matches = sorted(globmod.glob(str(source_dir / pattern)))
     if not matches:
@@ -90,13 +90,13 @@ def _find_output_file(source_dir: Path, kind: str) -> str:
             source_dir,
             matches[0],
         )
-    return matches[0]
+    return str(Path(matches[0]).relative_to(root))
 
 
 def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
     source_dir = root / rock.source
     run_command([*_PACK_COMMANDS["rock"]], cwd=str(source_dir))
-    output_file = _find_output_file(source_dir, "rock")
+    output_file = _find_output_file(source_dir, "rock", root)
     return GeneratedRock(
         name=rock.name,
         source=rock.source,
@@ -107,7 +107,7 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
 def _build_charm(charm: CharmArtifact, root: Path) -> GeneratedCharm:
     source_dir = root / charm.source
     run_command([*_PACK_COMMANDS["charm"]], cwd=str(source_dir))
-    output_file = _find_output_file(source_dir, "charm")
+    output_file = _find_output_file(source_dir, "charm", root)
     return GeneratedCharm(
         name=charm.name,
         source=charm.source,
@@ -118,7 +118,7 @@ def _build_charm(charm: CharmArtifact, root: Path) -> GeneratedCharm:
 def _build_snap(snap: SnapArtifact, root: Path) -> GeneratedSnap:
     source_dir = root / snap.source
     run_command([*_PACK_COMMANDS["snap"]], cwd=str(source_dir))
-    output_file = _find_output_file(source_dir, "snap")
+    output_file = _find_output_file(source_dir, "snap", root)
     return GeneratedSnap(
         name=snap.name,
         source=snap.source,

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -90,7 +90,12 @@ def _find_output_file(source_dir: Path, kind: str, root: Path) -> str:
             source_dir,
             matches[0],
         )
-    return str(Path(matches[0]).relative_to(root))
+    resolved = Path(matches[0]).resolve()
+    try:
+        return str(resolved.relative_to(root.resolve()))
+    except ValueError as exc:
+        msg = f"Built artifact {resolved} is outside repository root {root}"
+        raise OpcliError(msg) from exc
 
 
 def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -82,6 +82,7 @@ class TestArtifactsBuild:
         assert gen.charms[0].name == "mycharm"
         assert gen.charms[0].output.file is not None
         assert gen.charms[0].output.file.endswith(".charm")
+        assert not Path(gen.charms[0].output.file).is_absolute()
 
     def test_build_single_rock(self, tmp_path: Path) -> None:
         _write(
@@ -100,6 +101,7 @@ class TestArtifactsBuild:
         gen = load_artifacts_generated(result)
         assert len(gen.rocks) == 1
         assert gen.rocks[0].output.file is not None
+        assert not Path(gen.rocks[0].output.file).is_absolute()
 
     def test_build_single_snap(self, tmp_path: Path) -> None:
         _write(


### PR DESCRIPTION
Absolute paths in `artifacts-generated.yaml` break spread because the VM mounts the repo at a different path than the host (e.g. `/home/ubuntu/proj` vs `/home/user/myrepo`).

`_find_output_file` now takes `root` and calls `Path.relative_to(root)` before storing, so paths like `rock_dir/myrock_1.0_amd64.rock` are stored instead of `/tmp/pytest-xxx/.../rock_dir/myrock_1.0_amd64.rock`.

Also adds explicit `is_absolute()` assertions to the build tests.