### PR TITLE
feat: install uv and tox in local integration-test prepare

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -268,10 +268,12 @@ fi
 
 _LOCAL_PREPARE = """\
 sudo snap install concierge --classic
+sudo snap install astral-uv --classic
 sudo apt-get update --quiet
 sudo apt-get install -y pipx --quiet
 sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
     pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
+runuser -l ubuntu -c "uv tool install tox --with tox-uv"
 if [ -f "$CONCIERGE" ]; then
   sudo concierge prepare -c "$CONCIERGE"
 fi


### PR DESCRIPTION
Without tox, the integration tests can't run. Installs uv via snap (system-wide) then tox with tox-uv as the ubuntu user so it is available in ubuntu's PATH when spread runs the test.