### PR TITLE
fix: chown SPREAD_PATH to ubuntu after rsync

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -274,6 +274,7 @@ sudo apt-get install -y pipx --quiet
 sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
     pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 runuser -l ubuntu -c "uv tool install tox --with tox-uv"
+chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 if [ -f "$CONCIERGE" ]; then
   sudo concierge prepare -c "$CONCIERGE"
 fi

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -274,13 +274,13 @@ sudo apt-get install -y pipx --quiet
 sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
     pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 runuser -l ubuntu -c "uv tool install tox --with tox-uv"
-chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 if [ -f "$CONCIERGE" ]; then
   sudo concierge prepare -c "$CONCIERGE"
 fi
 if [ -f artifacts-generated.yaml ]; then
   opcli provision load
 fi
+chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 """
 
 _CI_PREPARE = """\


### PR DESCRIPTION
spread rsyncs as root so the project directory is owned by root. Tests run as ubuntu and tox needs write access to create `.tox/`.