### PR TITLE
feat: propagate resources into artifacts-generated.yaml (schema v2)

### DIFF
--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -112,9 +112,10 @@ The spec implies opcli participates in producing these (build collection step).
 
 **Implementation:**
 
-- The `ArtifactsGenerated` model correctly parses CI-format files.
-- `opcli pytest expand` emits `--<resource-name>=<image>` for rocks whose
-  output has an `image:` field.
+- The `ArtifactsGenerated` model (v2) correctly parses CI-format files.
+- `opcli pytest expand` emits `--<resource-name>=<image>` for charm resources
+  whose embedded `image:` field is set (resolved at build time from the rock's
+  CI output).
 - `opcli pytest expand` does **not** emit `--charm-file=` flags for charms
   whose output is `artifact: + run-id:` (CI-built charms); those are skipped.
 - `opcli artifacts build` only produces local `output.file` paths; there is no

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -28,6 +28,7 @@ from opcli.models.artifacts_generated import (
     ArtifactOutput,
     ArtifactsGenerated,
     GeneratedCharm,
+    GeneratedResource,
     GeneratedRock,
     GeneratedSnap,
 )
@@ -109,14 +110,35 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
     )
 
 
-def _build_charm(charm: CharmArtifact, root: Path) -> GeneratedCharm:
+def _build_charm(
+    charm: CharmArtifact,
+    root: Path,
+    all_rocks: dict[str, GeneratedRock],
+) -> GeneratedCharm:
     source_dir = root / charm.source
     run_command([*_PACK_COMMANDS["charm"]], cwd=str(source_dir))
     output_file = _find_output_file(source_dir, "charm", root)
+
+    resources: dict[str, GeneratedResource] = {}
+    for res_name, res_def in charm.resources.items():
+        file_val: str | None = None
+        image_val: str | None = None
+        if res_def.rock and res_def.rock in all_rocks:
+            rock_out = all_rocks[res_def.rock].output
+            file_val = rock_out.file
+            image_val = rock_out.image
+        resources[res_name] = GeneratedResource(
+            type=res_def.type,
+            rock=res_def.rock,
+            file=file_val,
+            image=image_val,
+        )
+
     return GeneratedCharm(
         name=charm.name,
         source=charm.source,
         output=ArtifactOutput(file=output_file),
+        resources=resources if resources else None,
     )
 
 
@@ -161,7 +183,8 @@ def artifacts_build(
     snaps_to_build = _filter_by_name(plan.snaps, snap_names, "snap")
 
     gen_rocks = [_build_rock(r, root) for r in rocks_to_build]
-    gen_charms = [_build_charm(c, root) for c in charms_to_build]
+    all_rocks = {r.name: r for r in gen_rocks}
+    gen_charms = [_build_charm(c, root, all_rocks) for c in charms_to_build]
     gen_snaps = [_build_snap(s, root) for s in snaps_to_build]
 
     generated = ArtifactsGenerated(

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -1,7 +1,10 @@
 """Core logic for ``opcli pytest expand``.
 
-Reads ``artifacts-generated.yaml`` and assembles the flags that tox/pytest
-need to locate built charms and their OCI-image resources.
+Reads ``artifacts-generated.yaml`` (schema v2) and assembles the flags that
+tox/pytest need to locate built charms and their OCI-image resources.
+
+``artifacts-generated.yaml`` v2 carries resolved resource paths inside each
+charm entry, so this module no longer needs to read ``artifacts.yaml``.
 
 Convention (matching operator-workflows):
     --charm-file=<path>          for each locally built charm
@@ -20,27 +23,11 @@ import logging
 from pathlib import Path
 
 from opcli.core.exceptions import ConfigurationError
-from opcli.core.yaml_io import load_artifacts_generated, load_artifacts_plan
-from opcli.models.artifacts import ArtifactsPlan
-from opcli.models.artifacts_generated import ArtifactsGenerated
+from opcli.core.yaml_io import load_artifacts_generated
 
 logger = logging.getLogger(__name__)
 
-_ARTIFACTS_YAML = "artifacts.yaml"
 _ARTIFACTS_GENERATED_YAML = "artifacts-generated.yaml"
-
-
-def _resolve_resource_value(
-    resource_rock: str | None,
-    generated: ArtifactsGenerated,
-) -> str | None:
-    """Find the output value for a rock linked to a charm resource."""
-    if resource_rock is None:
-        return None
-    for rock in generated.rocks:
-        if rock.name == resource_rock:
-            return rock.output.file or rock.output.image
-    return None
 
 
 def assemble_pytest_args(
@@ -53,7 +40,7 @@ def assemble_pytest_args(
         ``["--charm-file=path.charm", "--img=path.rock"]``.
 
     Raises:
-        ConfigurationError: If required YAML files are missing.
+        ConfigurationError: If ``artifacts-generated.yaml`` is missing.
     """
     gen_path = root / _ARTIFACTS_GENERATED_YAML
     if not gen_path.exists():
@@ -64,26 +51,14 @@ def assemble_pytest_args(
 
     generated = load_artifacts_generated(gen_path)
 
-    # Load the plan to get resource definitions (rock links).
-    plan_path = root / _ARTIFACTS_YAML
-    plan: ArtifactsPlan | None = None
-    if plan_path.exists():
-        plan = load_artifacts_plan(plan_path)
-
     args: list[str] = []
 
     for charm in generated.charms:
         if charm.output.file:
             args.append(f"--charm-file={charm.output.file}")
 
-        # Resolve resource flags from the plan's resource definitions.
-        if plan is None:
-            continue
-        plan_charm = next((c for c in plan.charms if c.name == charm.name), None)
-        if plan_charm is None:
-            continue
-        for res_name, res_def in plan_charm.resources.items():
-            value = _resolve_resource_value(res_def.rock, generated)
+        for res_name, res in (charm.resources or {}).items():
+            value = res.file or res.image
             if value:
                 args.append(f"--{res_name}={value}")
 

--- a/src/opcli/models/artifacts_generated.py
+++ b/src/opcli/models/artifacts_generated.py
@@ -1,6 +1,13 @@
 """Pydantic models for artifacts-generated.yaml.
 
 Extends the build plan with paths/references of the built artifacts.
+
+Schema version history
+----------------------
+v1 — initial release (charm resources not included)
+v2 — charm entries carry a ``resources`` mapping with resolved output paths,
+     making ``artifacts-generated.yaml`` self-contained (no need to also read
+     ``artifacts.yaml`` when assembling pytest flags).
 """
 
 from __future__ import annotations
@@ -31,6 +38,22 @@ class ArtifactOutput(BaseModel):
         return self
 
 
+class GeneratedResource(BaseModel):
+    """A charm resource with its resolved output path or image reference.
+
+    The ``file`` and ``image`` fields mirror the linked rock's ``output.file``
+    and ``output.image`` at build time.  Either may be ``None`` if the rock was
+    not built in the same ``opcli artifacts build`` invocation.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["oci-image"]
+    rock: str | None = None
+    file: str | None = None
+    image: str | None = None
+
+
 class GeneratedRock(BaseModel):
     """A rock with its build output."""
 
@@ -42,13 +65,14 @@ class GeneratedRock(BaseModel):
 
 
 class GeneratedCharm(BaseModel):
-    """A charm with its build output."""
+    """A charm with its build output and resolved resource paths."""
 
     model_config = ConfigDict(extra="forbid")
 
     name: str
     source: str
     output: ArtifactOutput
+    resources: dict[str, GeneratedResource] | None = None
 
 
 class GeneratedSnap(BaseModel):
@@ -62,11 +86,15 @@ class GeneratedSnap(BaseModel):
 
 
 class ArtifactsGenerated(BaseModel):
-    """Top-level schema for ``artifacts-generated.yaml``."""
+    """Top-level schema for ``artifacts-generated.yaml`` (schema version 2).
+
+    Version 2 adds resolved ``resources`` to charm entries so that
+    ``opcli pytest expand`` only needs this file (not ``artifacts.yaml``).
+    """
 
     model_config = ConfigDict(extra="forbid")
 
-    version: Literal[1] = 1
+    version: Literal[2] = 2
     rocks: list[GeneratedRock] = []
     charms: list[GeneratedCharm] = []
     snaps: list[GeneratedSnap] = []

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -175,3 +175,64 @@ class TestArtifactsBuild:
         gen = load_artifacts_generated(result)
         assert len(gen.rocks) == 1
         assert len(gen.charms) == 1
+
+    def test_build_propagates_resources_to_generated(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "rocks:\n- name: myrock\n  source: rock_dir\n"
+            "charms:\n- name: mycharm\n  source: .\n"
+            "  resources:\n"
+            "    myrock-image:\n"
+            "      type: oci-image\n"
+            "      rock: myrock\n",
+        )
+        (tmp_path / "rock_dir").mkdir()
+        _write(tmp_path / "rock_dir" / "myrock_1.0_amd64.rock", "fake")
+        _write(tmp_path / "mycharm_amd64.charm", "fake")
+
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path)
+
+        gen = load_artifacts_generated(result)
+        charm = gen.charms[0]
+        assert charm.resources is not None
+        assert "myrock-image" in charm.resources
+        res = charm.resources["myrock-image"]
+        assert res.type == "oci-image"
+        assert res.rock == "myrock"
+        assert res.file is not None
+        assert "myrock_1.0_amd64.rock" in res.file
+        assert not Path(res.file).is_absolute()
+
+    def test_resource_unresolved_when_rock_not_built(self, tmp_path: Path) -> None:
+        """Resource referencing a rock not in artifacts.yaml has unresolved output."""
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "charms:\n- name: mycharm\n  source: .\n"
+            "  resources:\n"
+            "    myrock-image:\n"
+            "      type: oci-image\n"
+            "      rock: nonexistent-rock\n",
+        )
+        _write(tmp_path / "mycharm_amd64.charm", "fake")
+
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path)
+
+        gen = load_artifacts_generated(result)
+        charm = gen.charms[0]
+        assert charm.resources is not None
+        res = charm.resources["myrock-image"]
+        assert res.file is None
+        assert res.image is None
+
+    def test_version_1_generated_is_rejected(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            "version: 1\ncharms:\n- name: c\n  source: .\n"
+            "  output:\n    file: ./c.charm\n",
+        )
+        with pytest.raises(Exception, match="validation error"):
+            load_artifacts_generated(tmp_path / "artifacts-generated.yaml")

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -17,7 +17,7 @@ def _write(path: Path, content: str) -> None:
 
 
 _GENERATED_WITH_ROCKS = """\
-version: 1
+version: 2
 rocks:
 - name: myrock
   source: rock_dir
@@ -98,7 +98,7 @@ class TestProvisionLoad:
     def test_no_local_rocks_returns_empty(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 1\n"
+            "version: 2\n"
             "rocks:\n- name: r1\n  source: rd\n"
             "  output:\n    image: ghcr.io/r1:v1\n",
         )
@@ -110,7 +110,7 @@ class TestProvisionLoad:
         mock_run.assert_not_called()
 
     def test_empty_generated_returns_empty(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
 
         with patch("opcli.core.provision.run_command") as mock_run:
             pushed = provision_load(tmp_path)

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -9,28 +9,20 @@ import pytest
 from opcli.core.exceptions import ConfigurationError
 from opcli.core.pytest_args import assemble_pytest_args, assemble_tox_argv
 
+_V1_ERROR_MATCH = "validation error"
+
 
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content)
 
 
-_PLAN_WITH_RESOURCES = """\
-version: 1
-rocks:
-- name: myrock
-  source: rock_dir
-charms:
-- name: mycharm
-  source: .
-  resources:
-    myrock-image:
-      type: oci-image
-      rock: myrock
-"""
+# ---------------------------------------------------------------------------
+# Fixtures — all version 2 (resources embedded in charm entries)
+# ---------------------------------------------------------------------------
 
 _GENERATED_LOCAL = """\
-version: 1
+version: 2
 rocks:
 - name: myrock
   source: rock_dir
@@ -41,10 +33,15 @@ charms:
   source: .
   output:
     file: ./mycharm.charm
+  resources:
+    myrock-image:
+      type: oci-image
+      rock: myrock
+      file: ./rock_dir/myrock.rock
 """
 
 _GENERATED_CI = """\
-version: 1
+version: 2
 rocks:
 - name: myrock
   source: rock_dir
@@ -56,6 +53,20 @@ charms:
   output:
     artifact: charm-mycharm
     run-id: "999"
+  resources:
+    myrock-image:
+      type: oci-image
+      rock: myrock
+      image: ghcr.io/canonical/myrock:abc123
+"""
+
+_GENERATED_NO_RESOURCES = """\
+version: 2
+charms:
+- name: simple
+  source: .
+  output:
+    file: ./simple.charm
 """
 
 
@@ -66,8 +77,16 @@ class TestAssemblePytestArgs:
         with pytest.raises(ConfigurationError, match="not found"):
             assemble_pytest_args(tmp_path)
 
-    def test_local_charm_with_rock_resource(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts.yaml", _PLAN_WITH_RESOURCES)
+    def test_version_1_generated_raises(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            "version: 1\ncharms:\n- name: c\n  source: .\n"
+            "  output:\n    file: ./c.charm\n",
+        )
+        with pytest.raises(Exception, match=_V1_ERROR_MATCH):
+            assemble_pytest_args(tmp_path)
+
+    def test_local_charm_with_embedded_rock_resource(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts-generated.yaml", _GENERATED_LOCAL)
 
         args = assemble_pytest_args(tmp_path)
@@ -75,53 +94,51 @@ class TestAssemblePytestArgs:
         assert "--charm-file=./mycharm.charm" in args
         assert "--myrock-image=./rock_dir/myrock.rock" in args
 
-    def test_ci_charm_with_image_resource(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts.yaml", _PLAN_WITH_RESOURCES)
+    def test_ci_scenario_only_generated_file(self, tmp_path: Path) -> None:
+        """pytest expand works with only artifacts-generated.yaml (no repo checkout)."""
         _write(tmp_path / "artifacts-generated.yaml", _GENERATED_CI)
+        # Intentionally no artifacts.yaml present
 
         args = assemble_pytest_args(tmp_path)
 
         # CI charm has artifact output, not file — no --charm-file
         assert not any(a.startswith("--charm-file=") for a in args)
-        # Rock has image output
+        # Rock image ref is embedded in the charm resources
         assert "--myrock-image=ghcr.io/canonical/myrock:abc123" in args
 
-    def test_no_plan_still_produces_charm_file(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_LOCAL)
-        # No artifacts.yaml → no resource linking, but charm-file still works
-
-        args = assemble_pytest_args(tmp_path)
-
-        assert "--charm-file=./mycharm.charm" in args
-        assert not any(a.startswith("--myrock-image=") for a in args)
-
     def test_charm_without_resources(self, tmp_path: Path) -> None:
-        _write(
-            tmp_path / "artifacts.yaml",
-            "version: 1\ncharms:\n- name: simple\n  source: .\n",
-        )
-        _write(
-            tmp_path / "artifacts-generated.yaml",
-            "version: 1\ncharms:\n- name: simple\n  source: .\n"
-            "  output:\n    file: ./simple.charm\n",
-        )
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_NO_RESOURCES)
 
         args = assemble_pytest_args(tmp_path)
 
         assert args == ["--charm-file=./simple.charm"]
 
     def test_empty_generated(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
 
         args = assemble_pytest_args(tmp_path)
         assert args == []
+
+    def test_unresolved_resource_produces_no_flag(self, tmp_path: Path) -> None:
+        """Resource with no file or image (rock not built) emits no flag."""
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            "version: 2\ncharms:\n- name: c\n  source: .\n"
+            "  output:\n    file: ./c.charm\n"
+            "  resources:\n    img:\n      type: oci-image\n      rock: myrock\n",
+        )
+
+        args = assemble_pytest_args(tmp_path)
+
+        assert args == ["--charm-file=./c.charm"]
+        assert not any(a.startswith("--img=") for a in args)
 
 
 class TestAssembleToxArgv:
     """Tests for assemble_tox_argv()."""
 
     def test_no_flags_no_extra_omits_separator(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
 
         argv = assemble_tox_argv(tmp_path)
 
@@ -129,7 +146,6 @@ class TestAssembleToxArgv:
         assert "--" not in argv
 
     def test_assembled_flags_include_separator(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts.yaml", _PLAN_WITH_RESOURCES)
         _write(tmp_path / "artifacts-generated.yaml", _GENERATED_LOCAL)
 
         argv = assemble_tox_argv(tmp_path)
@@ -139,7 +155,7 @@ class TestAssembleToxArgv:
         assert "--charm-file=./mycharm.charm" in argv
 
     def test_extra_args_only_include_separator(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
 
         argv = assemble_tox_argv(tmp_path, extra_args=["-k", "test_foo"])
 
@@ -148,14 +164,13 @@ class TestAssembleToxArgv:
         assert "test_foo" in argv
 
     def test_custom_tox_env(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
 
         argv = assemble_tox_argv(tmp_path, tox_env="e2e")
 
         assert argv[2] == "e2e"
 
     def test_extra_args_appended_after_assembled(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts.yaml", _PLAN_WITH_RESOURCES)
         _write(tmp_path / "artifacts-generated.yaml", _GENERATED_LOCAL)
 
         argv = assemble_tox_argv(tmp_path, extra_args=["-v", "-k", "test_charm"])


### PR DESCRIPTION
Closes #35

## Changes

### New `GeneratedResource` model
Charm entries in `artifacts-generated.yaml` now carry a `resources` mapping with resolved output paths:
```yaml
charms:
- name: indico
  source: .
  output:
    file: indico_ubuntu-22.04-amd64.charm
  resources:
    indico-image:
      type: oci-image
      rock: indico
      file: indico_rock/indico_1.0_amd64.rock
```

### Schema bumped to version 2
Old `version: 1` files fail validation with a clear error, so users can't accidentally get silent wrong behavior with stale manifests.

### `opcli pytest expand` now only reads `artifacts-generated.yaml`
The `artifacts.yaml` fallback read is removed. In CI, a test job can download only `artifacts-generated.yaml` (no repo checkout) and get correct `--resource-name=` flags.

### Unresolved resources
If a rock wasn't built in the same `opcli artifacts build` run, its resource `file`/`image` is `null`. `pytest expand` skips flags for unresolved resources.