### PR TITLE
feat: support cpu/memory/disk/runner in virtual backend system entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,30 @@ opcli pytest expand -- -k test_charm
 | `spread.yaml` | Spread configuration with a virtual `integration-test` backend expanded by opcli. |
 | `tests/integration/run/task.yaml` | Spread task that runs integration tests via `opcli pytest expand`. |
 
+## Virtual backend system entry fields
+
+System entries under the virtual `integration-test` (or `tutorial-test`) backend accept opcli-specific fields alongside standard spread fields:
+
+```yaml
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04:
+          runner: [self-hosted, noble]   # GitHub Actions runner labels (CI only)
+          cpu: 4                         # LXD VM vCPUs (local only, default 4)
+          memory: 8                      # LXD VM RAM in GiB (local only, default 8)
+          disk: 20                       # LXD VM disk in GiB (local only, default 20)
+```
+
+**How they are handled:**
+
+| Field | Local backend | CI backend |
+|---|---|---|
+| `runner` | Stripped (not applicable to LXD) | Preserved for GitHub runner selection |
+| `cpu` / `memory` / `disk` | Used in LXD `lxc launch --vm` arguments, then stripped | Stripped (not applicable to cloud runners) |
+
+Resource values are injected as per-system defaults in the allocate script using `${CPU:-N}` semantics so that an explicit environment variable override (e.g. `CPU=2 opcli spread run`) still takes precedence.
+
 ## CI vs local
 
 The `CI` environment variable controls backend expansion:

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -151,3 +151,40 @@ would be wrong inside the VM; relative paths remain valid after rsync.
 
 **Implementation:** Also supports `--snap <name>` for filtering snap builds,
 consistent with the snap support in `artifacts.yaml`.
+
+---
+
+## 8. System entry resource fields (`cpu`, `memory`, `disk`) — opcli extension
+
+**Spec:** System entries in the virtual `integration-test` backend may carry a
+`runner:` list for GitHub Actions runner label selection (used in CI expansion):
+
+```yaml
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04:
+          runner: [self-hosted, noble]
+```
+
+**Implementation:** opcli extends this to also support `cpu`, `memory`, and
+`disk` integer fields for controlling LXD VM resources in local expansion:
+
+```yaml
+      - ubuntu-24.04:
+          runner: [self-hosted, noble]   # CI: runner label selection
+          cpu: 4                         # local: LXD VM vCPUs
+          memory: 8                      # local: LXD VM RAM (GiB)
+          disk: 20                       # local: LXD VM disk (GiB)
+```
+
+These fields are stripped before the YAML is passed to spread — they are
+opcli-only metadata. During local expansion, they are injected into the
+`allocate` script as per-system `case` arms using `${VAR:-N}` semantics
+so that explicit env-var overrides still take precedence. During CI expansion,
+`runner` is kept (real spread field) while `cpu`/`memory`/`disk` are stripped.
+
+**Rationale:** Declaring VM size alongside the system name keeps all
+per-system configuration in one place, avoids managing separate env vars, and
+makes the resource intent visible in version control without requiring changes
+to any other file.

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -346,7 +346,7 @@ def _extract_system_resources(
                 val = props.get(field)
                 if val is None:
                     continue
-                if not isinstance(val, int) or val <= 0:
+                if isinstance(val, bool) or not isinstance(val, int) or val <= 0:
                     msg = (
                         f"System '{name}': '{field}' must be a positive integer, "
                         f"got {val!r}"
@@ -374,7 +374,8 @@ def _make_resource_preamble(resources: dict[str, dict[str, int]]) -> str:
             if field in res
         ]
         if parts:
-            lines.append(f"  {sys_name}) {'; '.join(parts)} ;;\n")
+            # Quote the pattern to prevent shell glob expansion (e.g. ubuntu-*)
+            lines.append(f'  "{sys_name}") {"; ".join(parts)} ;;\n')
     lines.append("esac\n\n")
     return "".join(lines)
 

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -27,7 +27,7 @@ from typing import Any
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import LiteralScalarString
 
-from opcli.core.exceptions import ConfigurationError
+from opcli.core.exceptions import ConfigurationError, ValidationError
 from opcli.core.subprocess import run_command
 
 logger = logging.getLogger(__name__)
@@ -308,38 +308,135 @@ _BACKEND_CONFIGS: dict[str, tuple[str, str, str, str]] = {
     _TUTORIAL_BACKEND: ("local-tutorial", "ci-tutorial", _TUTORIAL_LOCAL_PREPARE, ""),
 }
 
+# Keys in system entries that are opcli-specific and must be stripped before
+# passing to spread.  ``runner`` is a GitHub Actions runner-label field only
+# meaningful to the CI backend; resource fields are used by the local allocate
+# script and have no meaning in spread's own backend model.
+_LOCAL_STRIP_KEYS: frozenset[str] = frozenset({"cpu", "memory", "disk", "runner"})
+_CI_STRIP_KEYS: frozenset[str] = frozenset({"cpu", "memory", "disk"})
+
+# Names of resource fields and their corresponding shell variable names.
+_RESOURCE_FIELDS: dict[str, str] = {"cpu": "CPU", "memory": "MEM", "disk": "DISK"}
+
 
 def _is_ci() -> bool:
     """Return True when running inside CI (truthy ``CI`` env var)."""
     return bool(os.environ.get("CI"))
 
 
-def _inject_username(
+def _extract_system_resources(
     systems: list[object],
-    username: str,
-) -> list[object]:
-    """Deep-merge ``username`` into each system entry.
+) -> dict[str, dict[str, int]]:
+    """Return ``{system_name: {cpu/memory/disk: value}}`` from system entries.
 
-    Handles both scalar entries (``"ubuntu-24.04"``) and mapping entries
-    (``{"ubuntu-24.04": {"runner": [...]}}``) without dropping user-defined
-    fields.
+    Only positive integer values are accepted.
+
+    Raises:
+        ValidationError: If a resource value is not a positive integer.
+    """
+    result: dict[str, dict[str, int]] = {}
+    for entry in systems:
+        if not isinstance(entry, dict):
+            continue
+        for name, props in entry.items():
+            if not isinstance(props, dict):
+                continue
+            res: dict[str, int] = {}
+            for field in _RESOURCE_FIELDS:
+                val = props.get(field)
+                if val is None:
+                    continue
+                if not isinstance(val, int) or val <= 0:
+                    msg = (
+                        f"System '{name}': '{field}' must be a positive integer, "
+                        f"got {val!r}"
+                    )
+                    raise ValidationError(msg)
+                res[field] = val
+            if res:
+                result[name] = res
+    return result
+
+
+def _make_resource_preamble(resources: dict[str, dict[str, int]]) -> str:
+    """Return a bash ``case`` snippet that sets CPU/MEM/DISK per ``$SPREAD_SYSTEM``.
+
+    Each arm uses ``${VAR:-N}`` so that an explicit env-var override still wins.
+    Returns an empty string when *resources* is empty.
+    """
+    if not resources:
+        return ""
+    lines = ['case "$SPREAD_SYSTEM" in\n']
+    for sys_name, res in resources.items():
+        parts = [
+            f'{shell_var}="${{{shell_var}:-{res[field]}}}"'
+            for field, shell_var in _RESOURCE_FIELDS.items()
+            if field in res
+        ]
+        if parts:
+            lines.append(f"  {sys_name}) {'; '.join(parts)} ;;\n")
+    lines.append("esac\n\n")
+    return "".join(lines)
+
+
+def _transform_system_props(
+    name: str,
+    props: object,
+    *,
+    strip_keys: frozenset[str],
+    inject_username: str | None,
+) -> object:
+    """Return the transformed props for a single system name→props pair."""
+    if isinstance(props, dict):
+        new_props = {k: v for k, v in props.items() if k not in strip_keys}
+        if inject_username:
+            new_props.setdefault("username", inject_username)
+        return new_props if new_props else None
+    if props is None:
+        if inject_username:
+            return {"username": inject_username}
+        return None
+    return props
+
+
+def _transform_systems(
+    systems: list[object],
+    *,
+    strip_keys: frozenset[str],
+    inject_username: str | None = None,
+) -> list[object]:
+    """Strip opcli-specific keys from system entries and optionally inject ``username``.
+
+    For each system entry:
+    - Plain strings: converted to a dict if username injection is needed.
+    - Dict entries: ``strip_keys`` are removed from the props mapping; ``username``
+      is set via ``setdefault`` if *inject_username* is given.
+    - If all props are removed and no username is injected, collapses back to a
+      plain string (avoids ``{"ubuntu-24.04": {}}`` noise in the output).
     """
     result: list[object] = []
     for entry in systems:
         if isinstance(entry, str):
-            result.append({entry: {"username": username}})
+            if inject_username:
+                result.append({entry: {"username": inject_username}})
+            else:
+                result.append(entry)
         elif isinstance(entry, dict):
-            merged: dict[str, object] = {}
-            for name, props in entry.items():
-                if isinstance(props, dict):
-                    new_props = dict(props)
-                    new_props.setdefault("username", username)
-                    merged[name] = new_props
-                elif props is None:
-                    merged[name] = {"username": username}
-                else:
-                    merged[name] = props
-            result.append(merged)
+            merged: dict[str, object] = {
+                name: _transform_system_props(
+                    name, props, strip_keys=strip_keys, inject_username=inject_username
+                )
+                for name, props in entry.items()
+            }
+            # If a single-key mapping collapsed to {name: None}, emit plain string
+            if (
+                len(merged) == 1
+                and next(iter(merged.values())) is None
+                and not inject_username
+            ):
+                result.append(next(iter(merged)))
+            else:
+                result.append(merged)
         else:
             result.append(entry)
     return result
@@ -358,19 +455,32 @@ def _build_concrete_backend(
     )
     backend_def["type"] = "adhoc"
 
+    systems = backend_def.get("systems")
+
     if use_ci:
         backend_def["allocate"] = "ADDRESS localhost"
         if ci_prepare:
             backend_def["prepare"] = ci_prepare
+        if isinstance(systems, list):
+            backend_def["systems"] = _transform_systems(
+                systems, strip_keys=_CI_STRIP_KEYS
+            )
     else:
-        backend_def["allocate"] = _LOCAL_ALLOCATE
+        # Extract per-system resource overrides before stripping the fields.
+        resources: dict[str, dict[str, int]] = {}
+        if isinstance(systems, list):
+            resources = _extract_system_resources(systems)
+
+        preamble = _make_resource_preamble(resources)
+        backend_def["allocate"] = preamble + _LOCAL_ALLOCATE
         backend_def["discard"] = _LOCAL_DISCARD
         if local_prepare:
             backend_def["prepare"] = local_prepare
 
-        systems = backend_def.get("systems")
         if isinstance(systems, list):
-            backend_def["systems"] = _inject_username(systems, "ubuntu")
+            backend_def["systems"] = _transform_systems(
+                systems, strip_keys=_LOCAL_STRIP_KEYS, inject_username="ubuntu"
+            )
 
     return backend_def
 

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 import pytest
 from ruamel.yaml import YAML
 
-from opcli.core.exceptions import ConfigurationError, SubprocessError
+from opcli.core.exceptions import ConfigurationError, SubprocessError, ValidationError
 from opcli.core.spread import spread_expand, spread_init, spread_run
 
 _yaml = YAML()
@@ -311,7 +311,7 @@ suites:
         assert '[ -f "$CONCIERGE" ]' in prepare
 
     def test_local_username_injection_mapping_systems(self, tmp_path: Path) -> None:
-        """Username injection deep-merges with existing system properties."""
+        """Username injection deep-merges; runner is stripped; native fields kept."""
         spread_with_mapping = """\
 project: test-project
 path: /home/ubuntu/proj
@@ -336,7 +336,9 @@ suites:
         assert len(systems) == 1
         sys_def = systems[0]["ubuntu-24.04"]
         assert sys_def["username"] == "ubuntu"
-        assert sys_def["runner"] == ["self-hosted", "noble"]
+        # runner is CI-only; stripped from local expansion
+        assert "runner" not in sys_def
+        # spread-native fields like workers survive
         _EXPECTED_WORKERS = 2
         assert sys_def["workers"] == _EXPECTED_WORKERS
 
@@ -365,7 +367,194 @@ suites:
         assert systems[0]["ubuntu-24.04"]["username"] == "custom-user"
 
 
-class TestSpreadRun:
+class TestSystemResourceFields:
+    """Tests for cpu/memory/disk/runner handling in virtual backend system entries."""
+
+    _SPREAD_WITH_RESOURCES = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04:
+          cpu: 2
+          memory: 4
+          disk: 30
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/integration/:
+    summary: integration tests
+    backends:
+      - integration-test
+"""
+
+    def test_resources_appear_in_local_allocate(self, tmp_path: Path) -> None:
+        """cpu/memory/disk from system entry appear as case-arm in local allocate."""
+        _write(tmp_path / "spread.yaml", self._SPREAD_WITH_RESOURCES)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        allocate = parsed["backends"]["local"]["allocate"]
+
+        assert "ubuntu-24.04" in allocate
+        assert 'CPU="${CPU:-2}"' in allocate
+        assert 'MEM="${MEM:-4}"' in allocate
+        assert 'DISK="${DISK:-30}"' in allocate
+
+    def test_resources_stripped_from_local_systems(self, tmp_path: Path) -> None:
+        """cpu/memory/disk are removed from system entries in local expansion."""
+        _write(tmp_path / "spread.yaml", self._SPREAD_WITH_RESOURCES)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        sys_def = parsed["backends"]["local"]["systems"][0]["ubuntu-24.04"]
+
+        assert "cpu" not in sys_def
+        assert "memory" not in sys_def
+        assert "disk" not in sys_def
+        assert sys_def["username"] == "ubuntu"
+
+    def test_resources_stripped_from_ci_systems(self, tmp_path: Path) -> None:
+        """cpu/memory/disk are removed from system entries in CI expansion."""
+        _write(tmp_path / "spread.yaml", self._SPREAD_WITH_RESOURCES)
+
+        result = spread_expand(tmp_path, ci=True)
+        parsed = _yaml.load(StringIO(result))
+        # After stripping the only keys, entry collapses to plain string
+        systems = parsed["backends"]["ci"]["systems"]
+        assert systems == ["ubuntu-24.04"]
+
+    def test_runner_stripped_from_local_systems(self, tmp_path: Path) -> None:
+        """runner label is stripped from local system entries (CI-only field)."""
+        spread = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04:
+          runner: [self-hosted, noble]
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/integration/:
+    summary: integration tests
+"""
+        _write(tmp_path / "spread.yaml", spread)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        sys_def = parsed["backends"]["local"]["systems"][0]["ubuntu-24.04"]
+
+        assert "runner" not in sys_def
+        assert sys_def["username"] == "ubuntu"
+
+    def test_runner_preserved_in_ci_systems(self, tmp_path: Path) -> None:
+        """runner label is preserved in CI system entries."""
+        spread = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04:
+          runner: [self-hosted, noble]
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/integration/:
+    summary: integration tests
+"""
+        _write(tmp_path / "spread.yaml", spread)
+
+        result = spread_expand(tmp_path, ci=True)
+        parsed = _yaml.load(StringIO(result))
+        systems = parsed["backends"]["ci"]["systems"]
+
+        assert len(systems) == 1
+        sys_def = systems[0]["ubuntu-24.04"]
+        assert sys_def["runner"] == ["self-hosted", "noble"]
+
+    def test_multiple_systems_with_different_resources(self, tmp_path: Path) -> None:
+        """Each system gets its own case arm in the allocate preamble."""
+        spread = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    systems:
+      - ubuntu-22.04:
+          cpu: 2
+          memory: 4
+          disk: 20
+      - ubuntu-24.04:
+          cpu: 8
+          memory: 16
+          disk: 50
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/integration/:
+    summary: integration tests
+"""
+        _write(tmp_path / "spread.yaml", spread)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        allocate = parsed["backends"]["local"]["allocate"]
+
+        assert "ubuntu-22.04" in allocate
+        assert "ubuntu-24.04" in allocate
+        assert 'CPU="${CPU:-2}"' in allocate
+        assert 'CPU="${CPU:-8}"' in allocate
+
+    def test_env_var_overrides_system_resource(self, tmp_path: Path) -> None:
+        """Per-system case arms use :- so explicit env vars still win."""
+        _write(tmp_path / "spread.yaml", self._SPREAD_WITH_RESOURCES)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        allocate = parsed["backends"]["local"]["allocate"]
+
+        # Each arm must use ${VAR:-value} not bare assignment
+        assert 'CPU="${CPU:-' in allocate
+        assert 'MEM="${MEM:-' in allocate
+        assert 'DISK="${DISK:-' in allocate
+
+    def test_invalid_resource_value_raises(self, tmp_path: Path) -> None:
+        """Non-positive-integer resource value raises ValidationError at expand time."""
+        spread = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04:
+          cpu: -1
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/integration/:
+    summary: integration tests
+"""
+        _write(tmp_path / "spread.yaml", spread)
+
+        with pytest.raises(ValidationError, match="positive integer"):
+            spread_expand(tmp_path, ci=False)
+
+    def test_no_resources_no_preamble(self, tmp_path: Path) -> None:
+        """When no resources are declared, no case statement is prepended."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        allocate = parsed["backends"]["local"]["allocate"]
+
+        assert "case" not in allocate
+        # Fallback defaults still present
+        assert 'DISK="${DISK:-20}"' in allocate
+
     """Tests for spread_run()."""
 
     def test_runs_spread_from_temp_dir(self, tmp_path: Path) -> None:

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -555,8 +555,40 @@ suites:
         # Fallback defaults still present
         assert 'DISK="${DISK:-20}"' in allocate
 
-    """Tests for spread_run()."""
+    def test_boolean_resource_value_raises(self, tmp_path: Path) -> None:
+        """Boolean values must be rejected (bool is a subclass of int in Python)."""
+        spread = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04:
+          cpu: true
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/integration/:
+    summary: integration tests
+"""
+        _write(tmp_path / "spread.yaml", spread)
 
+        with pytest.raises(ValidationError, match="positive integer"):
+            spread_expand(tmp_path, ci=False)
+
+    def test_case_pattern_is_quoted(self, tmp_path: Path) -> None:
+        """Case arm patterns must be quoted to prevent shell glob expansion."""
+        _write(tmp_path / "spread.yaml", self._SPREAD_WITH_RESOURCES)
+
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        allocate = parsed["backends"]["local"]["allocate"]
+
+        # Pattern must be quoted: "ubuntu-24.04") not ubuntu-24.04)
+        assert '"ubuntu-24.04")' in allocate
+
+
+class TestSpreadRun:
     def test_runs_spread_from_temp_dir(self, tmp_path: Path) -> None:
         _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
 


### PR DESCRIPTION
## Summary

Implements opcli-specific system entry fields for the virtual `integration-test` (and `tutorial-test`) backend.

### New fields

```yaml
backends:
  integration-test:
    systems:
      - ubuntu-24.04:
          runner: [self-hosted, noble]   # CI: GitHub runner label selection
          cpu: 4                         # local: LXD VM vCPUs  (default 4)
          memory: 8                      # local: LXD VM RAM GiB (default 8)
          disk: 20                       # local: LXD VM disk GiB (default 20)
```

### How expansion works

| Field | Local | CI |
|---|---|---|
| `runner` | Stripped (CI-only) | Preserved |
| `cpu`/`memory`/`disk` | Injected into allocate script as `case` arms using `${VAR:-N}` (env-var overrides still win), then stripped | Stripped |

### Notes

- Invalid resource values (non-positive integers) raise `ValidationError` at expand time with a clear message
- System entries that have only opcli-specific fields (e.g. `runner` only for CI) collapse back to a plain string after stripping — no empty-dict noise
- Refactored `_inject_username` into `_transform_system_props` + `_transform_systems` for cleaner single-pass handling

### Tests added (9 new)

- resources appear in allocate case statement
- resources stripped from local/CI systems  
- runner stripped from local / preserved in CI
- multiple systems with different resources
- env-var override still wins (`${VAR:-N}` semantics)
- invalid resource raises ValidationError
- no case statement when no resources declared

### Docs

- README: new _Virtual backend system entry fields_ section
- `docs/divergences.md`: new divergence #8