### PR TITLE
fix: push rocks directly from oci-archive to registry (no docker-daemon)

### DIFF
--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -84,20 +84,8 @@ def provision_load(
         rock_path = Path(rock.output.file)
         image_ref = f"{registry}/{rock.name}:latest"
 
-        # rockcraft.load converts a .rock archive to a local Docker image
-        run_command(
-            [
-                "sudo",
-                "rockcraft.skopeo",
-                "--insecure-policy",
-                "copy",
-                f"oci-archive:{rock_path}",
-                f"docker-daemon:{rock.name}:latest",
-            ],
-            cwd=str(root),
-        )
-
-        # Push to the target registry
+        # Push directly from .rock archive to registry in one step — no Docker
+        # daemon needed (avoids failures in MicroK8s-only environments).
         run_command(
             [
                 "sudo",
@@ -105,7 +93,7 @@ def provision_load(
                 "--insecure-policy",
                 "copy",
                 "--dest-tls-verify=false",
-                f"docker-daemon:{rock.name}:latest",
+                f"oci-archive:{rock_path}",
                 f"docker://{image_ref}",
             ],
             cwd=str(root),

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -81,8 +81,8 @@ class TestProvisionLoad:
         assert len(pushed) == 1
         assert "myrock" in pushed[0]
         assert "localhost:32000" in pushed[0]
-        # Two skopeo calls: copy to docker-daemon, then push to registry
-        assert mock_run.call_count == 2  # noqa: PLR2004
+        # Single skopeo call: direct oci-archive → registry
+        assert mock_run.call_count == 1
 
     def test_custom_registry(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts-generated.yaml", _GENERATED_WITH_ROCKS)
@@ -91,8 +91,8 @@ class TestProvisionLoad:
             pushed = provision_load(tmp_path, registry="myregistry:5000")
 
         assert "myregistry:5000" in pushed[0]
-        # Verify the push command uses the custom registry
-        push_cmd = mock_run.call_args_list[1][0][0]
+        # Verify the single push command uses the custom registry
+        push_cmd = mock_run.call_args_list[0][0][0]
         assert any("myregistry:5000" in arg for arg in push_cmd)
 
     def test_no_local_rocks_returns_empty(self, tmp_path: Path) -> None:
@@ -124,13 +124,11 @@ class TestProvisionLoad:
         with patch("opcli.core.provision.run_command") as mock_run:
             provision_load(tmp_path)
 
-        # First call: copy rock archive to docker daemon
-        copy_cmd = mock_run.call_args_list[0][0][0]
-        assert "rockcraft.skopeo" in copy_cmd
-        assert any("oci-archive:" in arg for arg in copy_cmd)
-        assert any("docker-daemon:" in arg for arg in copy_cmd)
-
-        # Second call: push from docker daemon to registry
-        push_cmd = mock_run.call_args_list[1][0][0]
-        assert "rockcraft.skopeo" in push_cmd
-        assert any("docker://" in arg for arg in push_cmd)
+        # Single call: direct oci-archive → registry (no docker-daemon step)
+        assert mock_run.call_count == 1
+        cmd = mock_run.call_args_list[0][0][0]
+        assert "rockcraft.skopeo" in cmd
+        assert any("oci-archive:" in arg for arg in cmd)
+        assert any("docker://" in arg for arg in cmd)
+        assert not any("docker-daemon:" in arg for arg in cmd)
+        assert "--dest-tls-verify=false" in cmd


### PR DESCRIPTION
Fixes #37.

## Problem
`opcli provision load` used a two-step skopeo copy:
1. `oci-archive:` → `docker-daemon:`
2. `docker-daemon:` → `docker://registry`

This fails in MicroK8s-only environments (no Docker daemon) with:
```
level=fatal msg="writing blob: io: read/write on closed pipe"
```

## Fix
Single-step direct copy:
```
rockcraft.skopeo copy --insecure-policy --dest-tls-verify=false oci-archive:<path> docker://<registry>/<name>:latest
```

Simpler, faster, and no Docker daemon required.

## Tests
- Updated `test_skopeo_commands_correct` to assert single call with no `docker-daemon:`
- Updated call-count assertions (2 → 1)
- Removed stale `# noqa: PLR2004` directives (1 is no longer a magic number)