### PR TITLE
fix: support legacy split format in artifacts init (metadata.yaml fallback)

### DIFF
--- a/src/opcli/core/discovery.py
+++ b/src/opcli/core/discovery.py
@@ -50,13 +50,26 @@ _MARKER_FILES: dict[str, str] = {
 
 
 def _read_yaml_name(path: Path) -> str:
-    """Read the ``name`` field from a craft YAML file."""
+    """Read the ``name`` field from a craft YAML file.
+
+    For charmcraft.yaml, falls back to ``metadata.yaml`` in the same
+    directory when ``name`` is absent (legacy split format where build
+    config lives in ``charmcraft.yaml`` and charm identity lives in
+    ``metadata.yaml``).
+    """
     with path.open() as fh:
         data = _yaml.load(fh)
     if not isinstance(data, dict):
         msg = f"{path} does not contain a YAML mapping"
         raise DiscoveryError(msg)
     name = data.get("name")
+    if (not isinstance(name, str) or not name) and path.name == "charmcraft.yaml":
+        metadata_path = path.parent / "metadata.yaml"
+        if metadata_path.exists():
+            with metadata_path.open() as fh:
+                meta = _yaml.load(fh)
+            if isinstance(meta, dict):
+                name = meta.get("name")
     if not isinstance(name, str) or not name:
         msg = f"{path} is missing a valid 'name' field"
         raise DiscoveryError(msg)
@@ -64,12 +77,24 @@ def _read_yaml_name(path: Path) -> str:
 
 
 def _read_charm_resources(path: Path) -> dict[str, dict[str, Any]]:
-    """Read the ``resources`` section from a charmcraft.yaml file."""
+    """Read the ``resources`` section from a charmcraft.yaml file.
+
+    Falls back to ``metadata.yaml`` in the same directory when the
+    ``resources`` section is absent from ``charmcraft.yaml`` (legacy
+    split format).
+    """
     with path.open() as fh:
         data = _yaml.load(fh)
     if not isinstance(data, dict):
         return {}
     resources = data.get("resources")
+    if not isinstance(resources, dict):
+        metadata_path = path.parent / "metadata.yaml"
+        if metadata_path.exists():
+            with metadata_path.open() as fh:
+                meta = _yaml.load(fh)
+            if isinstance(meta, dict):
+                resources = meta.get("resources")
     if not isinstance(resources, dict):
         return {}
     return dict(resources)

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -129,6 +129,58 @@ class TestDiscovery:
         with pytest.raises(DiscoveryError, match="missing a valid 'name'"):
             discover_artifacts(tmp_path)
 
+    def test_charm_split_format_name_from_metadata_yaml(self, tmp_path: Path) -> None:
+        """Legacy split format: name in metadata.yaml, not charmcraft.yaml."""
+        _write(
+            tmp_path / "charmcraft.yaml",
+            "type: charm\nbases:\n  - run-on:\n    - name: ubuntu\n",
+        )
+        _write(tmp_path / "metadata.yaml", "name: indico\nsummary: An indico charm\n")
+        plan = discover_artifacts(tmp_path)
+        assert len(plan.charms) == 1
+        assert plan.charms[0].name == "indico"
+
+    def test_charm_split_format_resources_from_metadata_yaml(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy split format: resources in metadata.yaml, not charmcraft.yaml."""
+        _write(tmp_path / "rock_dir" / "rockcraft.yaml", "name: indico-rock\n")
+        _write(
+            tmp_path / "charmcraft.yaml",
+            "type: charm\nbases:\n  - run-on:\n    - name: ubuntu\n",
+        )
+        _write(
+            tmp_path / "metadata.yaml",
+            "name: indico\n"
+            "resources:\n"
+            "  indico-image:\n"
+            "    type: oci-image\n"
+            "    upstream-source: indico-rock\n",
+        )
+        plan = discover_artifacts(tmp_path)
+        assert len(plan.charms) == 1
+        assert plan.charms[0].name == "indico"
+        assert "indico-image" in plan.charms[0].resources
+        assert plan.charms[0].resources["indico-image"].rock == "indico-rock"
+
+    def test_charm_unified_format_takes_precedence_over_metadata_yaml(
+        self, tmp_path: Path
+    ) -> None:
+        """Unified format: name in charmcraft.yaml wins even if metadata.yaml exists."""
+        _write(
+            tmp_path / "charmcraft.yaml",
+            "name: charm-from-charmcraft\ntype: charm\n",
+        )
+        _write(tmp_path / "metadata.yaml", "name: charm-from-metadata\n")
+        plan = discover_artifacts(tmp_path)
+        assert plan.charms[0].name == "charm-from-charmcraft"
+
+    def test_charm_split_format_no_metadata_yaml_raises(self, tmp_path: Path) -> None:
+        """No name in charmcraft.yaml and no metadata.yaml → DiscoveryError."""
+        _write(tmp_path / "charmcraft.yaml", "type: charm\n")
+        with pytest.raises(DiscoveryError, match="missing a valid 'name'"):
+            discover_artifacts(tmp_path)
+
 
 class TestYamlIO:
     """Tests for YAML round-trip helpers."""


### PR DESCRIPTION
Fixes #41

## Problem

`opcli artifacts init` fails with `DiscoveryError` for charms using the legacy split format where `name` (and `resources`) live in `metadata.yaml` rather than `charmcraft.yaml`.

## Fix

- `_read_yaml_name()`: for `charmcraft.yaml` only, falls back to `metadata.yaml` in the same directory when `name` is absent
- `_read_charm_resources()`: falls back to `metadata.yaml` when `resources` is absent from `charmcraft.yaml`
- Unified format (name in `charmcraft.yaml`) takes precedence — no behaviour change for existing repos
- Non-charm craft files (`rockcraft.yaml`, `snapcraft.yaml`) unaffected

## Tests added

- `test_charm_split_format_name_from_metadata_yaml`
- `test_charm_split_format_resources_from_metadata_yaml`
- `test_charm_unified_format_takes_precedence_over_metadata_yaml`
- `test_charm_split_format_no_metadata_yaml_raises`