### PR TITLE
fix: run concierge as ubuntu user so Juju credentials land in ubuntu's home

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -275,7 +275,7 @@ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
     pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 runuser -l ubuntu -c "uv tool install tox --with tox-uv"
 if [ -f "$CONCIERGE" ]; then
-  sudo concierge prepare -c "$CONCIERGE"
+  runuser -l ubuntu -c "concierge prepare -c \"$CONCIERGE\""
   opcli provision registry -c "$CONCIERGE"
 fi
 if [ -f artifacts-generated.yaml ]; then

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -156,6 +156,8 @@ class TestSpreadExpand:
         assert "SPREAD_PASSWORD" in local["allocate"]
         assert "lxc delete --force" in local["discard"]
         assert "concierge" in local["prepare"]
+        assert "runuser" in local["prepare"]
+        assert "sudo concierge" not in local["prepare"]
         assert "opcli provision load" in local["prepare"]
 
         # Systems should have username: ubuntu injected


### PR DESCRIPTION
Fixes #43

## Root cause

`sudo concierge prepare` bootstrapped Juju as root → credentials in `/root/.local/share/juju`. Integration tests run via `runuser -l ubuntu` couldn't find them.

## Fix

Change the one-liner in `_LOCAL_PREPARE`:

```bash
# Before
sudo concierge prepare -c "$CONCIERGE"

# After  
runuser -l ubuntu -c "concierge prepare -c \"$CONCIERGE\""
```

concierge is designed to be invoked by a normal user — it uses sudo internally for privileged ops (snap installs, LXD setup) but runs Juju operations as the calling user. With ubuntu as the caller, `juju bootstrap` writes credentials directly to `/home/ubuntu/.local/share/juju`.

This is consistent with the existing pattern: `runuser -l ubuntu` is already used just above for `uv tool install tox`.