### PR TITLE
fix: run concierge prepare via ubuntu sudo to set SUDO_USER correctly

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -275,7 +275,7 @@ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
     pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 runuser -l ubuntu -c "uv tool install tox --with tox-uv"
 if [ -f "$CONCIERGE" ]; then
-  runuser -l ubuntu -c "concierge prepare -c \"$CONCIERGE\""
+  runuser -l ubuntu -c "sudo concierge prepare -c \"$CONCIERGE\""
   opcli provision registry -c "$CONCIERGE"
 fi
 if [ -f artifacts-generated.yaml ]; then

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -275,8 +275,10 @@ sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
     pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
 runuser -l ubuntu -c "uv tool install tox --with tox-uv"
 if [ -f "$CONCIERGE" ]; then
-  runuser -l ubuntu -c "sudo concierge prepare -c \"$CONCIERGE\""
-  opcli provision registry -c "$CONCIERGE"
+  runuser -l ubuntu -c \
+    "cd \\"${SPREAD_PATH}\\" && sudo concierge prepare -c \\"$CONCIERGE\\""
+  runuser -l ubuntu -c \
+    "cd \\"${SPREAD_PATH}\\" && opcli provision registry -c \\"$CONCIERGE\\""
 fi
 if [ -f artifacts-generated.yaml ]; then
   opcli provision load

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -155,10 +155,12 @@ class TestSpreadExpand:
         assert "lxc launch --vm" in local["allocate"]
         assert "SPREAD_PASSWORD" in local["allocate"]
         assert "lxc delete --force" in local["discard"]
-        assert "concierge" in local["prepare"]
-        assert "runuser" in local["prepare"]
-        assert 'runuser -l ubuntu -c "sudo concierge prepare' in local["prepare"]
-        assert "opcli provision load" in local["prepare"]
+        prepare = local["prepare"]
+        assert "sudo concierge prepare" in prepare
+        assert "opcli provision registry" in prepare
+        assert "runuser -l ubuntu" in prepare
+        assert '"${SPREAD_PATH}"' in prepare
+        assert "opcli provision load" in prepare
 
         # Systems should have username: ubuntu injected
         systems = local["systems"]

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -157,7 +157,7 @@ class TestSpreadExpand:
         assert "lxc delete --force" in local["discard"]
         assert "concierge" in local["prepare"]
         assert "runuser" in local["prepare"]
-        assert "sudo concierge" not in local["prepare"]
+        assert 'runuser -l ubuntu -c "sudo concierge prepare' in local["prepare"]
         assert "opcli provision load" in local["prepare"]
 
         # Systems should have username: ubuntu injected


### PR DESCRIPTION
## Problem

When the spread prepare script (running as root) called `sudo concierge prepare`, `SUDO_USER` was not set because root was calling sudo to remain root. Concierge's `realUser()` function falls back to root when `SUDO_USER` is unset, so Juju credentials ended up in `/root/.local/share/juju` — unreachable by tests running as the `ubuntu` user.

## Root Cause

From [concierge source](https://raw.githubusercontent.com/canonical/concierge/main/internal/system/util.go):
```go
func realUser() (*user.User, error) {
    realUser := os.Getenv("SUDO_USER")
    if len(realUser) == 0 {
        return user.Lookup("root")
    }
    return user.Lookup(realUser)
}
```

Concierge uses `SUDO_USER` to find whose home directory should receive Juju credentials, bootstrap state, etc.

## Fix

Use `runuser -l ubuntu` to invoke `sudo concierge prepare`. This has _ubuntu_ call sudo, which causes sudo to set `SUDO_USER=ubuntu`. Concierge still runs as root (required for snap installs, LXD config) but treats ubuntu as the real user and writes Juju data to `/home/ubuntu/.local/share/juju`.

Fixes #43.