### PR TITLE
fix: update artifacts-generated.yaml after provision load, prefer image over file

### DIFF
--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -32,7 +32,7 @@ from ruamel.yaml import YAML
 
 from opcli.core.exceptions import ConfigurationError
 from opcli.core.subprocess import run_command
-from opcli.core.yaml_io import load_artifacts_generated
+from opcli.core.yaml_io import dump_artifacts_generated, load_artifacts_generated
 
 logger = logging.getLogger(__name__)
 
@@ -151,6 +151,10 @@ def provision_load(
         rock_path = Path(rock.output.file)
         image_ref = f"{registry}/{rock.name}:latest"
 
+        if rock.output.image == image_ref:
+            logger.info("Already loaded %s, skipping", image_ref)
+            continue
+
         # Push directly from .rock archive to registry in one step — no Docker
         # daemon needed (avoids failures in MicroK8s-only environments).
         run_command(
@@ -166,8 +170,17 @@ def provision_load(
             cwd=str(root),
         )
 
+        rock.output.image = image_ref
+        for charm in generated.charms:
+            for res in (charm.resources or {}).values():
+                if res.rock == rock.name:
+                    res.image = image_ref
+
         pushed.append(image_ref)
         logger.info("Pushed %s", image_ref)
+
+    if pushed:
+        dump_artifacts_generated(generated, gen_path)
 
     return pushed
 

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -58,7 +58,7 @@ def assemble_pytest_args(
             args.append(f"--charm-file={charm.output.file}")
 
         for res_name, res in (charm.resources or {}).items():
-            value = res.file or res.image
+            value = res.image or res.file
             if value:
                 args.append(f"--{res_name}={value}")
 

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -10,6 +10,7 @@ import pytest
 
 from opcli.core.exceptions import ConfigurationError
 from opcli.core.provision import provision_load, provision_registry, provision_run
+from opcli.core.yaml_io import load_artifacts_generated
 
 
 def _write(path: Path, content: str) -> None:
@@ -33,6 +34,29 @@ charms:
   source: .
   output:
     file: ./mycharm.charm
+"""
+
+_GENERATED_WITH_ROCKS_AND_RESOURCES = """\
+version: 2
+rocks:
+- name: myrock
+  source: rock_dir
+  output:
+    file: ./rock_dir/myrock.rock
+charms:
+- name: mycharm
+  source: .
+  output:
+    file: ./mycharm.charm
+  resources:
+    myrock-image:
+      type: oci-image
+      rock: myrock
+      file: ./rock_dir/myrock.rock
+    other-res:
+      type: oci-image
+      rock: otherrock
+      image: ghcr.io/canonical/otherrock:abc
 """
 
 
@@ -133,6 +157,64 @@ class TestProvisionLoad:
         assert any("docker://" in arg for arg in cmd)
         assert not any("docker-daemon:" in arg for arg in cmd)
         assert "--dest-tls-verify=false" in cmd
+
+    def test_updates_artifacts_generated_with_image_ref(self, tmp_path: Path) -> None:
+        """After pushing, rock.output.image is set and file is preserved."""
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_WITH_ROCKS)
+
+        with patch("opcli.core.provision.run_command"):
+            provision_load(tmp_path)
+
+        updated = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        myrock = next(r for r in updated.rocks if r.name == "myrock")
+        assert myrock.output.image == "localhost:32000/myrock:latest"
+        assert myrock.output.file == "./rock_dir/myrock.rock"
+
+    def test_updates_charm_resources_for_pushed_rock(self, tmp_path: Path) -> None:
+        """Charm resources referencing a pushed rock get image ref set."""
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            _GENERATED_WITH_ROCKS_AND_RESOURCES,
+        )
+
+        with patch("opcli.core.provision.run_command"):
+            provision_load(tmp_path)
+
+        updated = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        charm = updated.charms[0]
+        myrock_res = charm.resources["myrock-image"]  # type: ignore[index]
+        assert myrock_res.image == "localhost:32000/myrock:latest"
+        assert myrock_res.file == "./rock_dir/myrock.rock"
+        # Resource referencing a different rock is not touched
+        other_res = charm.resources["other-res"]  # type: ignore[index]
+        assert other_res.image == "ghcr.io/canonical/otherrock:abc"
+
+    def test_idempotent_skips_already_loaded_rock(self, tmp_path: Path) -> None:
+        """Rock with image already set to the target ref is skipped."""
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            "version: 2\n"
+            "rocks:\n- name: myrock\n  source: rock_dir\n"
+            "  output:\n    file: ./rock_dir/myrock.rock\n"
+            "    image: localhost:32000/myrock:latest\n",
+        )
+
+        with patch("opcli.core.provision.run_command") as mock_run:
+            pushed = provision_load(tmp_path)
+
+        assert pushed == []
+        mock_run.assert_not_called()
+
+    def test_no_writeback_when_nothing_pushed(self, tmp_path: Path) -> None:
+        """artifacts-generated.yaml is not written when no rocks are pushed."""
+        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
+        mtime_before = (tmp_path / "artifacts-generated.yaml").stat().st_mtime
+
+        with patch("opcli.core.provision.run_command"):
+            provision_load(tmp_path)
+
+        mtime_after = (tmp_path / "artifacts-generated.yaml").stat().st_mtime
+        assert mtime_before == mtime_after
 
 
 _CONCIERGE_MICROK8S = """\

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -133,6 +133,23 @@ class TestAssemblePytestArgs:
         assert args == ["--charm-file=./c.charm"]
         assert not any(a.startswith("--img=") for a in args)
 
+    def test_image_takes_priority_over_file_when_both_set(self, tmp_path: Path) -> None:
+        """After provision load, image ref is preferred over local file path."""
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            "version: 2\ncharms:\n- name: c\n  source: .\n"
+            "  output:\n    file: ./c.charm\n"
+            "  resources:\n    myrock-image:\n      type: oci-image\n"
+            "      rock: myrock\n"
+            "      file: ./rock_dir/myrock.rock\n"
+            "      image: localhost:32000/myrock:latest\n",
+        )
+
+        args = assemble_pytest_args(tmp_path)
+
+        assert "--myrock-image=localhost:32000/myrock:latest" in args
+        assert not any("myrock.rock" in a for a in args)
+
 
 class TestAssembleToxArgv:
     """Tests for assemble_tox_argv()."""


### PR DESCRIPTION
## Problem

`opcli provision load` pushed rocks to the local registry but never updated `artifacts-generated.yaml`. As a result, `opcli pytest expand` read stale `file:` paths and passed `.rock` filenames to pytest/k8s → `ImagePullBackOff`.

## Fix

After pushing each rock, `provision_load()` now:
1. Sets `rock.output.image = "{registry}/{rock.name}:latest"` (keeps `output.file` for provenance)
2. Updates charm resources with `res.rock == rock.name`: sets `res.image` (keeps `res.file`)
3. Writes back to `artifacts-generated.yaml` only if at least one rock was pushed

`assemble_pytest_args()` now prefers `res.image` over `res.file` when both are set, so the registry ref is used after `provision load`.

`provision_load()` is idempotent: rocks with `output.image` already equal to the target ref are skipped.

Fixes #46.