### PR TITLE
feat: rename source to explicit yaml-file path, add pack-dir for Go monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,47 @@ Different suites can each declare their own `TOX_ENV` value.
 | `spread.yaml` | Spread configuration with a virtual `integration-test` backend expanded by opcli. |
 | `tests/integration/run/task.yaml` | Spread task that runs integration tests via `opcli pytest expand`. |
 
+## `artifacts.yaml` schema (v2)
+
+Each artifact entry uses an explicit path to its craft YAML file rather than a directory:
+
+```yaml
+version: 2
+rocks:
+  - name: my-rock
+    rockcraft-yaml: rocks/my-rock/rockcraft.yaml
+charms:
+  - name: my-charm
+    charmcraft-yaml: charmcraft.yaml
+    resources:
+      my-rock-image:
+        type: oci-image
+        rock: my-rock
+snaps:
+  - name: my-snap
+    snapcraft-yaml: snap/snapcraft.yaml
+    pack-dir: .        # run snapcraft pack from the repo root
+```
+
+### `pack-dir` (rocks and snaps)
+
+By default `opcli artifacts build` runs the pack tool from the directory that contains
+the craft YAML file. Set `pack-dir` to run from a different directory. This is required
+for Go monorepos where `go.mod` lives at the repository root but `rockcraft.yaml` lives
+in a subdirectory:
+
+```yaml
+rocks:
+  - name: my-go-rock
+    rockcraft-yaml: rocks/my-go-rock/rockcraft.yaml
+    pack-dir: .    # rockcraft pack runs from the repo root where go.mod lives
+```
+
+When `pack-dir` differs from the directory containing the craft YAML, opcli creates a
+temporary symlink `<pack-dir>/rockcraft.yaml → <rockcraft-yaml>` before running
+`rockcraft pack`, then removes it afterwards. If a real (non-symlink) file already
+exists at that path, the build fails with an error.
+
 ## Virtual backend system entry fields
 
 System entries under the virtual `integration-test` (or `tutorial-test`) backend accept opcli-specific fields alongside standard spread fields:

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -252,3 +252,41 @@ unified format.
 **Rationale:** Treating the split format as an error would block `opcli`
 adoption in repositories that cannot yet migrate to the unified format (e.g.
 because their unit tests depend on `Harness` reading `metadata.yaml`).
+
+---
+
+## 11. `artifacts.yaml` uses explicit yaml-file paths instead of source directories
+
+**Spec:** The `artifacts.yaml` schema uses a `source` field containing the
+**directory** that contains the craft YAML file (e.g. `source: rocks/my-rock`).
+
+**Implementation (v2 schema):** The `source` field is replaced by an explicit
+path to the craft YAML file:
+
+```yaml
+version: 2
+rocks:
+  - name: my-rock
+    rockcraft-yaml: rocks/my-rock/rockcraft.yaml
+charms:
+  - name: my-charm
+    charmcraft-yaml: charmcraft.yaml
+snaps:
+  - name: my-snap
+    snapcraft-yaml: snap/snapcraft.yaml
+    pack-dir: .
+```
+
+An optional `pack-dir` field is added to all artifact types. When set, the
+build tool (`rockcraft pack`, `charmcraft pack`, `snapcraft pack`) is invoked
+from `pack-dir` instead of from the directory containing the craft YAML. For
+rocks, opcli creates a temporary `rockcraft.yaml` symlink in `pack-dir` before
+running the build and removes it afterwards.
+
+**Rationale:** Go monorepos place `go.mod` at the repository root but
+`rockcraft.yaml` in a subdirectory. Rockcraft's managed LXC container does not
+follow symlinks, so the go-framework extension fails to find `go.mod` unless
+`rockcraft pack` runs from the repo root. The `pack-dir` field enables this
+without requiring a manual workaround. The explicit yaml-file path (rather than
+directory) makes the configuration unambiguous and consistent across all
+artifact types.

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -77,21 +77,36 @@ def artifacts_init(root: Path, *, force: bool = False) -> Path:
     return dest
 
 
-def _find_output_file(source_dir: Path, kind: str, root: Path) -> str:
-    """Glob for the built artifact in *source_dir*, returning a relative path."""
-    pattern = _OUTPUT_GLOBS[kind]
-    matches = sorted(globmod.glob(str(source_dir / pattern)))
-    if not matches:
-        msg = f"No {pattern} found in {source_dir} after pack"
+def _snapshot_outputs(pack_dir: Path, kind: str) -> set[str]:
+    """Return the set of existing output files in *pack_dir* for *kind*."""
+    return set(globmod.glob(str(pack_dir / _OUTPUT_GLOBS[kind])))
+
+
+def _pick_new_output(
+    before: set[str], after: set[str], kind: str, pack_dir: Path
+) -> str:
+    """Return the new output file produced by pack, relative to repo root."""
+    new_files = sorted(after - before)
+    if not new_files:
+        # Fallback: use all files (handles edge case where pre-existing file
+        # was overwritten in place rather than written as a new path).
+        new_files = sorted(after)
+    if not new_files:
+        msg = f"No {_OUTPUT_GLOBS[kind]} found in {pack_dir} after pack"
         raise OpcliError(msg)
-    if len(matches) > 1:
+    if len(new_files) > 1:
         logger.warning(
-            "Multiple %s files in %s; using %s",
-            pattern,
-            source_dir,
-            matches[0],
+            "Multiple new %s files in %s; using %s",
+            _OUTPUT_GLOBS[kind],
+            pack_dir,
+            new_files[0],
         )
-    resolved = Path(matches[0]).resolve()
+    return new_files[0]
+
+
+def _relative_to_root(path_str: str, root: Path) -> str:
+    """Return *path_str* as a relative path from *root*."""
+    resolved = Path(path_str).resolve()
     try:
         return str(resolved.relative_to(root.resolve()))
     except ValueError as exc:
@@ -99,13 +114,61 @@ def _find_output_file(source_dir: Path, kind: str, root: Path) -> str:
         raise OpcliError(msg) from exc
 
 
+def _resolve_pack_dir(yaml_path: Path, pack_dir_str: str | None, root: Path) -> Path:
+    """Resolve the directory from which the pack command should run."""
+    if pack_dir_str:
+        return (root / pack_dir_str).resolve()
+    return yaml_path.parent.resolve()
+
+
+def _with_rock_symlink(
+    yaml_path: Path,
+    pack_dir: Path,
+) -> tuple[Path | None, bool]:
+    """Prepare a rockcraft.yaml symlink in *pack_dir* if needed.
+
+    Returns ``(symlink_path, created)`` where *created* is ``True`` when this
+    call created the symlink (and the caller must remove it afterwards).
+
+    Raises:
+        ConfigurationError: If a real (non-symlink) file already exists at the
+            target location.
+    """
+    if pack_dir == yaml_path.parent:
+        return None, False
+
+    target = pack_dir / yaml_path.name  # e.g. pack_dir/rockcraft.yaml
+    if target.exists() and not target.is_symlink():
+        msg = (
+            f"A regular file already exists at {target}. "
+            "Remove it or set pack-dir to a directory without a rockcraft.yaml."
+        )
+        raise ConfigurationError(msg)
+    if target.is_symlink():
+        target.unlink()
+    target.symlink_to(yaml_path.resolve())
+    return target, True
+
+
 def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
-    source_dir = root / rock.source
-    run_command([*_PACK_COMMANDS["rock"]], cwd=str(source_dir))
-    output_file = _find_output_file(source_dir, "rock", root)
+    yaml_path = (root / rock.rockcraft_yaml).resolve()
+    pack_dir = _resolve_pack_dir(yaml_path, rock.pack_dir, root)
+
+    before = _snapshot_outputs(pack_dir, "rock")
+
+    symlink_path, symlink_created = _with_rock_symlink(yaml_path, pack_dir)
+    try:
+        run_command([*_PACK_COMMANDS["rock"]], cwd=str(pack_dir))
+    finally:
+        if symlink_created and symlink_path and symlink_path.is_symlink():
+            symlink_path.unlink()
+
+    after = _snapshot_outputs(pack_dir, "rock")
+    new_output = _pick_new_output(before, after, "rock", pack_dir)
+    output_file = _relative_to_root(new_output, root)
     return GeneratedRock(
         name=rock.name,
-        source=rock.source,
+        **{"rockcraft-yaml": rock.rockcraft_yaml},
         output=ArtifactOutput(file=output_file),
     )
 
@@ -115,9 +178,14 @@ def _build_charm(
     root: Path,
     all_rocks: dict[str, GeneratedRock],
 ) -> GeneratedCharm:
-    source_dir = root / charm.source
-    run_command([*_PACK_COMMANDS["charm"]], cwd=str(source_dir))
-    output_file = _find_output_file(source_dir, "charm", root)
+    yaml_path = (root / charm.charmcraft_yaml).resolve()
+    pack_dir = _resolve_pack_dir(yaml_path, charm.pack_dir, root)
+
+    before = _snapshot_outputs(pack_dir, "charm")
+    run_command([*_PACK_COMMANDS["charm"]], cwd=str(pack_dir))
+    after = _snapshot_outputs(pack_dir, "charm")
+    new_output = _pick_new_output(before, after, "charm", pack_dir)
+    output_file = _relative_to_root(new_output, root)
 
     resources: dict[str, GeneratedResource] = {}
     for res_name, res_def in charm.resources.items():
@@ -136,19 +204,24 @@ def _build_charm(
 
     return GeneratedCharm(
         name=charm.name,
-        source=charm.source,
+        **{"charmcraft-yaml": charm.charmcraft_yaml},
         output=ArtifactOutput(file=output_file),
         resources=resources if resources else None,
     )
 
 
 def _build_snap(snap: SnapArtifact, root: Path) -> GeneratedSnap:
-    source_dir = root / snap.source
-    run_command([*_PACK_COMMANDS["snap"]], cwd=str(source_dir))
-    output_file = _find_output_file(source_dir, "snap", root)
+    yaml_path = (root / snap.snapcraft_yaml).resolve()
+    pack_dir = _resolve_pack_dir(yaml_path, snap.pack_dir, root)
+
+    before = _snapshot_outputs(pack_dir, "snap")
+    run_command([*_PACK_COMMANDS["snap"]], cwd=str(pack_dir))
+    after = _snapshot_outputs(pack_dir, "snap")
+    new_output = _pick_new_output(before, after, "snap", pack_dir)
+    output_file = _relative_to_root(new_output, root)
     return GeneratedSnap(
         name=snap.name,
-        source=snap.source,
+        **{"snapcraft-yaml": snap.snapcraft_yaml},
         output=ArtifactOutput(file=output_file),
     )
 

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -160,7 +160,7 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
     try:
         run_command([*_PACK_COMMANDS["rock"]], cwd=str(pack_dir))
     finally:
-        if symlink_created and symlink_path and symlink_path.is_symlink():
+        if symlink_created and symlink_path and symlink_path.exists():
             symlink_path.unlink()
 
     after = _snapshot_outputs(pack_dir, "rock")

--- a/src/opcli/core/discovery.py
+++ b/src/opcli/core/discovery.py
@@ -100,25 +100,24 @@ def _read_charm_resources(path: Path) -> dict[str, dict[str, Any]]:
     return dict(resources)
 
 
-def _source_relative(marker_path: Path, root: Path) -> str:
-    """Return the marker file's directory as a relative path from *root*."""
-    rel = marker_path.parent.relative_to(root)
-    return str(rel) if str(rel) != "." else "."
+def _yaml_relative(marker_path: Path, root: Path) -> str:
+    """Return the marker file path relative to *root*."""
+    return str(marker_path.relative_to(root))
 
 
-def _snap_source_relative(marker_path: Path, root: Path) -> str:
-    """Return the snap project root relative to *root*.
+def _snap_fields(marker_path: Path, root: Path) -> tuple[str, str | None]:
+    """Return ``(snapcraft_yaml, pack_dir)`` for a snapcraft.yaml marker.
 
-    Snapcraft supports ``snapcraft.yaml`` in the project root **or** under
-    a ``snap/`` subdirectory.  When the marker lives at ``*/snap/snapcraft.yaml``
-    the project root (where ``snapcraft pack`` should run) is the parent of
-    ``snap/``.
+    When the marker lives at ``*/snap/snapcraft.yaml`` the build tool should
+    run from the parent of ``snap/``, so ``pack_dir`` is set to that parent
+    directory.  Otherwise ``pack_dir`` is ``None`` (defaults to the yaml dir).
     """
+    yaml_rel = str(marker_path.relative_to(root))
     if marker_path.parent.name == "snap":
-        rel = marker_path.parent.parent.relative_to(root)
-    else:
-        rel = marker_path.parent.relative_to(root)
-    return str(rel) if str(rel) != "." else "."
+        parent = marker_path.parent.parent
+        pack_dir_rel = str(parent.relative_to(root)) if parent != root else "."
+        return yaml_rel, pack_dir_rel
+    return yaml_rel, None
 
 
 def _process_marker(
@@ -130,19 +129,23 @@ def _process_marker(
 ) -> None:
     """Process a single marker file found during discovery."""
     kind = _MARKER_FILES[path.name]
-    source = _source_relative(path, root)
 
     if kind == "rock":
         name = _read_yaml_name(path)
-        rocks.append(RockArtifact(name=name, source=source))
+        rocks.append(
+            RockArtifact(**{"rockcraft-yaml": _yaml_relative(path, root), "name": name})
+        )
     elif kind == "snap":
         name = _read_yaml_name(path)
-        snap_source = _snap_source_relative(path, root)
-        snaps.append(SnapArtifact(name=name, source=snap_source))
+        snap_yaml, pack_dir = _snap_fields(path, root)
+        snap = SnapArtifact(
+            **{"snapcraft-yaml": snap_yaml, "name": name, "pack-dir": pack_dir}
+        )
+        snaps.append(snap)
     elif kind == "charm":
         name = _read_yaml_name(path)
         raw_resources = _read_charm_resources(path)
-        charm_raw.append((name, source, raw_resources))
+        charm_raw.append((name, _yaml_relative(path, root), raw_resources))
 
 
 def _link_charm_resources(
@@ -205,10 +208,16 @@ def discover_artifacts(root: Path) -> ArtifactsPlan:
         _process_marker(path, root, rocks, snaps, charm_raw)
 
     rock_names = {r.name for r in rocks}
-    for charm_name, charm_source, raw_resources in charm_raw:
+    for charm_name, charm_yaml, raw_resources in charm_raw:
         resources = _link_charm_resources(charm_name, raw_resources, rock_names)
         charms.append(
-            CharmArtifact(name=charm_name, source=charm_source, resources=resources)
+            CharmArtifact(
+                **{
+                    "charmcraft-yaml": charm_yaml,
+                    "name": charm_name,
+                    "resources": resources,
+                }
+            )
         )
 
     return ArtifactsPlan(rocks=rocks, charms=charms, snaps=snaps)

--- a/src/opcli/core/discovery.py
+++ b/src/opcli/core/discovery.py
@@ -133,13 +133,15 @@ def _process_marker(
     if kind == "rock":
         name = _read_yaml_name(path)
         rocks.append(
-            RockArtifact(**{"rockcraft-yaml": _yaml_relative(path, root), "name": name})
+            RockArtifact.model_validate(
+                {"rockcraft-yaml": _yaml_relative(path, root), "name": name}
+            )
         )
     elif kind == "snap":
         name = _read_yaml_name(path)
         snap_yaml, pack_dir = _snap_fields(path, root)
-        snap = SnapArtifact(
-            **{"snapcraft-yaml": snap_yaml, "name": name, "pack-dir": pack_dir}
+        snap = SnapArtifact.model_validate(
+            {"snapcraft-yaml": snap_yaml, "name": name, "pack-dir": pack_dir}
         )
         snaps.append(snap)
     elif kind == "charm":
@@ -211,8 +213,8 @@ def discover_artifacts(root: Path) -> ArtifactsPlan:
     for charm_name, charm_yaml, raw_resources in charm_raw:
         resources = _link_charm_resources(charm_name, raw_resources, rock_names)
         charms.append(
-            CharmArtifact(
-                **{
+            CharmArtifact.model_validate(
+                {
                     "charmcraft-yaml": charm_yaml,
                     "name": charm_name,
                     "resources": resources,

--- a/src/opcli/core/yaml_io.py
+++ b/src/opcli/core/yaml_io.py
@@ -43,7 +43,7 @@ def load_artifacts_plan(path: Path) -> ArtifactsPlan:
 
 def dump_artifacts_plan(plan: ArtifactsPlan, path: Path) -> None:
     """Serialize an :class:`ArtifactsPlan` to YAML."""
-    dump_yaml(plan.model_dump(exclude_none=True), path)
+    dump_yaml(plan.model_dump(exclude_none=True, by_alias=True), path)
 
 
 def load_artifacts_generated(path: Path) -> ArtifactsGenerated:

--- a/src/opcli/models/artifacts.py
+++ b/src/opcli/models/artifacts.py
@@ -2,13 +2,21 @@
 
 This schema declares the charms, rocks, and snaps in a repository, and
 the links between charms and their OCI-image resources (rocks).
+
+Schema version history
+----------------------
+v1 — initial release (``source`` directory field)
+v2 — ``source`` replaced by explicit ``<tool>-yaml`` file path; optional
+     ``pack-dir`` added to run the build tool from a different directory
+     (e.g. a Go monorepo where ``go.mod`` lives at the repo root but
+     ``rockcraft.yaml`` lives in a subdirectory).
 """
 
 from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ArtifactResource(BaseModel):
@@ -23,37 +31,40 @@ class ArtifactResource(BaseModel):
 class CharmArtifact(BaseModel):
     """A charm declared in artifacts.yaml."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     name: str
-    source: str
+    charmcraft_yaml: str = Field(alias="charmcraft-yaml")
+    pack_dir: str | None = Field(default=None, alias="pack-dir")
     resources: dict[str, ArtifactResource] = {}
 
 
 class RockArtifact(BaseModel):
     """A rock declared in artifacts.yaml."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     name: str
-    source: str
+    rockcraft_yaml: str = Field(alias="rockcraft-yaml")
+    pack_dir: str | None = Field(default=None, alias="pack-dir")
 
 
 class SnapArtifact(BaseModel):
     """A snap declared in artifacts.yaml."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     name: str
-    source: str
+    snapcraft_yaml: str = Field(alias="snapcraft-yaml")
+    pack_dir: str | None = Field(default=None, alias="pack-dir")
 
 
 class ArtifactsPlan(BaseModel):
-    """Top-level schema for ``artifacts.yaml``."""
+    """Top-level schema for ``artifacts.yaml`` (schema version 2)."""
 
     model_config = ConfigDict(extra="forbid")
 
-    version: Literal[1] = 1
+    version: Literal[2] = 2
     rocks: list[RockArtifact] = []
     charms: list[CharmArtifact] = []
     snaps: list[SnapArtifact] = []

--- a/src/opcli/models/artifacts_generated.py
+++ b/src/opcli/models/artifacts_generated.py
@@ -8,6 +8,8 @@ v1 — initial release (charm resources not included)
 v2 — charm entries carry a ``resources`` mapping with resolved output paths,
      making ``artifacts-generated.yaml`` self-contained (no need to also read
      ``artifacts.yaml`` when assembling pytest flags).
+v3 — ``source`` renamed to ``<tool>-yaml`` (explicit path to the craft YAML
+     file) to align with the v2 ``artifacts.yaml`` schema change.
 """
 
 from __future__ import annotations
@@ -57,20 +59,20 @@ class GeneratedResource(BaseModel):
 class GeneratedRock(BaseModel):
     """A rock with its build output."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     name: str
-    source: str
+    rockcraft_yaml: str = Field(alias="rockcraft-yaml")
     output: ArtifactOutput
 
 
 class GeneratedCharm(BaseModel):
     """A charm with its build output and resolved resource paths."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     name: str
-    source: str
+    charmcraft_yaml: str = Field(alias="charmcraft-yaml")
     output: ArtifactOutput
     resources: dict[str, GeneratedResource] | None = None
 
@@ -78,23 +80,23 @@ class GeneratedCharm(BaseModel):
 class GeneratedSnap(BaseModel):
     """A snap with its build output."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     name: str
-    source: str
+    snapcraft_yaml: str = Field(alias="snapcraft-yaml")
     output: ArtifactOutput
 
 
 class ArtifactsGenerated(BaseModel):
-    """Top-level schema for ``artifacts-generated.yaml`` (schema version 2).
+    """Top-level schema for ``artifacts-generated.yaml`` (schema version 3).
 
-    Version 2 adds resolved ``resources`` to charm entries so that
-    ``opcli pytest expand`` only needs this file (not ``artifacts.yaml``).
+    Version 3 renames ``source`` to ``<tool>-yaml`` in all artifact entries
+    to align with the explicit yaml-file-path convention in ``artifacts.yaml``.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    version: Literal[2] = 2
+    version: Literal[3] = 3
     rocks: list[GeneratedRock] = []
     charms: list[GeneratedCharm] = []
     snaps: list[GeneratedSnap] = []

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -67,7 +67,8 @@ class TestArtifactsBuild:
     def test_build_single_charm(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 1\ncharms:\n- name: mycharm\n  source: .\n",
+            "version: 2\ncharms:\n- name: mycharm\n"
+            "  charmcraft-yaml: charmcraft.yaml\n",
         )
         # Simulate charmcraft pack producing a .charm file
         _write(tmp_path / "mycharm_amd64.charm", "fake charm")
@@ -87,7 +88,8 @@ class TestArtifactsBuild:
     def test_build_single_rock(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 1\nrocks:\n- name: myrock\n  source: rock_dir\n",
+            "version: 2\nrocks:\n- name: myrock\n"
+            "  rockcraft-yaml: rock_dir/rockcraft.yaml\n",
         )
         rock_dir = tmp_path / "rock_dir"
         rock_dir.mkdir()
@@ -106,7 +108,8 @@ class TestArtifactsBuild:
     def test_build_single_snap(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 1\nsnaps:\n- name: mysnap\n  source: snap_dir\n",
+            "version: 2\nsnaps:\n- name: mysnap\n"
+            "  snapcraft-yaml: snap_dir/snapcraft.yaml\n",
         )
         snap_dir = tmp_path / "snap_dir"
         snap_dir.mkdir()
@@ -123,9 +126,9 @@ class TestArtifactsBuild:
     def test_build_filtered_by_charm_name(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 1\ncharms:\n"
-            "- name: charm-a\n  source: a\n"
-            "- name: charm-b\n  source: b\n",
+            "version: 2\ncharms:\n"
+            "- name: charm-a\n  charmcraft-yaml: a/charmcraft.yaml\n"
+            "- name: charm-b\n  charmcraft-yaml: b/charmcraft.yaml\n",
         )
         (tmp_path / "a").mkdir()
         _write(tmp_path / "a" / "charm-a.charm", "fake")
@@ -140,7 +143,7 @@ class TestArtifactsBuild:
     def test_unknown_charm_name_raises(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 1\ncharms:\n- name: real\n  source: .\n",
+            "version: 2\ncharms:\n- name: real\n  charmcraft-yaml: charmcraft.yaml\n",
         )
         with pytest.raises(ConfigurationError, match="Unknown charm"):
             artifacts_build(tmp_path, charm_names=["nonexistent"])
@@ -148,7 +151,8 @@ class TestArtifactsBuild:
     def test_no_output_file_raises(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 1\nrocks:\n- name: myrock\n  source: rock_dir\n",
+            "version: 2\nrocks:\n- name: myrock\n"
+            "  rockcraft-yaml: rock_dir/rockcraft.yaml\n",
         )
         (tmp_path / "rock_dir").mkdir()
 
@@ -161,9 +165,9 @@ class TestArtifactsBuild:
     def test_build_monorepo(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 1\n"
-            "rocks:\n- name: myrock\n  source: rock_dir\n"
-            "charms:\n- name: mycharm\n  source: .\n",
+            "version: 2\n"
+            "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
+            "charms:\n- name: mycharm\n  charmcraft-yaml: charmcraft.yaml\n",
         )
         (tmp_path / "rock_dir").mkdir()
         _write(tmp_path / "rock_dir" / "myrock.rock", "fake")
@@ -179,9 +183,9 @@ class TestArtifactsBuild:
     def test_build_propagates_resources_to_generated(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 1\n"
-            "rocks:\n- name: myrock\n  source: rock_dir\n"
-            "charms:\n- name: mycharm\n  source: .\n"
+            "version: 2\n"
+            "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
+            "charms:\n- name: mycharm\n  charmcraft-yaml: charmcraft.yaml\n"
             "  resources:\n"
             "    myrock-image:\n"
             "      type: oci-image\n"
@@ -209,8 +213,8 @@ class TestArtifactsBuild:
         """Resource referencing a rock not in artifacts.yaml has unresolved output."""
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 1\n"
-            "charms:\n- name: mycharm\n  source: .\n"
+            "version: 2\n"
+            "charms:\n- name: mycharm\n  charmcraft-yaml: charmcraft.yaml\n"
             "  resources:\n"
             "    myrock-image:\n"
             "      type: oci-image\n"
@@ -228,11 +232,94 @@ class TestArtifactsBuild:
         assert res.file is None
         assert res.image is None
 
-    def test_version_1_generated_is_rejected(self, tmp_path: Path) -> None:
+    def test_version_2_generated_is_rejected(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 1\ncharms:\n- name: c\n  source: .\n"
+            "version: 2\ncharms:\n- name: c\n  source: .\n"
             "  output:\n    file: ./c.charm\n",
         )
         with pytest.raises(Exception, match="validation error"):
             load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+
+    def test_build_rock_with_pack_dir_creates_symlink(self, tmp_path: Path) -> None:
+        """pack-dir: a temporary rockcraft.yaml symlink is created and removed."""
+        rock_subdir = tmp_path / "rocks" / "myrock"
+        rock_subdir.mkdir(parents=True)
+        _write(rock_subdir / "rockcraft.yaml", "name: myrock\n")
+        # The .rock output lands in pack_dir (repo root), not rock_subdir
+        _write(tmp_path / "myrock_1.0_amd64.rock", "fake rock")
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 2\n"
+            "rocks:\n- name: myrock\n"
+            "  rockcraft-yaml: rocks/myrock/rockcraft.yaml\n"
+            "  pack-dir: .\n",
+        )
+
+        created_symlinks: list[Path] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> None:
+            # Verify symlink exists during the build
+            symlink = tmp_path / "rockcraft.yaml"
+            assert symlink.is_symlink(), "symlink should exist while pack runs"
+            created_symlinks.append(symlink)
+
+        with patch("opcli.core.artifacts.run_command", side_effect=fake_run):
+            result = artifacts_build(tmp_path)
+
+        # Symlink must be removed after build
+        assert not (tmp_path / "rockcraft.yaml").exists()
+        gen = load_artifacts_generated(result)
+        assert gen.rocks[0].output.file is not None
+
+    def test_build_rock_pack_dir_real_file_raises(self, tmp_path: Path) -> None:
+        """A real rockcraft.yaml at pack-dir raises ConfigurationError."""
+        rock_subdir = tmp_path / "rocks" / "myrock"
+        rock_subdir.mkdir(parents=True)
+        _write(rock_subdir / "rockcraft.yaml", "name: myrock\n")
+        # Real file at the pack-dir location (not a symlink)
+        _write(tmp_path / "rockcraft.yaml", "name: other\n")
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 2\n"
+            "rocks:\n- name: myrock\n"
+            "  rockcraft-yaml: rocks/myrock/rockcraft.yaml\n"
+            "  pack-dir: .\n",
+        )
+
+        with (
+            patch("opcli.core.artifacts.run_command"),
+            pytest.raises(ConfigurationError, match="regular file already exists"),
+        ):
+            artifacts_build(tmp_path)
+
+    def test_build_rock_pack_dir_existing_symlink_replaced(
+        self, tmp_path: Path
+    ) -> None:
+        """An existing symlink at pack-dir is replaced without error."""
+        rock_subdir = tmp_path / "rocks" / "myrock"
+        rock_subdir.mkdir(parents=True)
+        _write(rock_subdir / "rockcraft.yaml", "name: myrock\n")
+        _write(tmp_path / "myrock_1.0_amd64.rock", "fake rock")
+
+        # Pre-existing symlink pointing somewhere else
+        existing_symlink = tmp_path / "rockcraft.yaml"
+        existing_symlink.symlink_to("/dev/null")
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 2\n"
+            "rocks:\n- name: myrock\n"
+            "  rockcraft-yaml: rocks/myrock/rockcraft.yaml\n"
+            "  pack-dir: .\n",
+        )
+
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path)
+
+        # Symlink removed after build
+        assert not existing_symlink.exists()
+        gen = load_artifacts_generated(result)
+        assert gen.rocks[0].output.file is not None

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -41,24 +41,25 @@ class TestDiscovery:
         plan = discover_artifacts(tmp_path)
         assert len(plan.charms) == 1
         assert plan.charms[0].name == "mycharm"
-        assert plan.charms[0].source == "."
+        assert plan.charms[0].charmcraft_yaml == "charmcraft.yaml"
 
     def test_single_rock(self, tmp_path: Path) -> None:
         _write(tmp_path / "myrock" / "rockcraft.yaml", "name: myrock\n")
         plan = discover_artifacts(tmp_path)
         assert len(plan.rocks) == 1
         assert plan.rocks[0].name == "myrock"
-        assert plan.rocks[0].source == "myrock"
+        assert plan.rocks[0].rockcraft_yaml == "myrock/rockcraft.yaml"
 
     def test_single_snap(self, tmp_path: Path) -> None:
         _write(tmp_path / "snap_dir" / "snapcraft.yaml", "name: mysnap\n")
         plan = discover_artifacts(tmp_path)
         assert len(plan.snaps) == 1
         assert plan.snaps[0].name == "mysnap"
-        assert plan.snaps[0].source == "snap_dir"
+        assert plan.snaps[0].snapcraft_yaml == "snap_dir/snapcraft.yaml"
+        assert plan.snaps[0].pack_dir is None
 
     def test_snap_under_snap_subdir(self, tmp_path: Path) -> None:
-        """snapcraft.yaml under snap/ → source is the parent directory."""
+        """snapcraft.yaml under snap/ → pack_dir is the parent directory."""
         _write(
             tmp_path / "myproject" / "snap" / "snapcraft.yaml",
             "name: mysnap\n",
@@ -66,15 +67,17 @@ class TestDiscovery:
         plan = discover_artifacts(tmp_path)
         assert len(plan.snaps) == 1
         assert plan.snaps[0].name == "mysnap"
-        assert plan.snaps[0].source == "myproject"
+        assert plan.snaps[0].snapcraft_yaml == "myproject/snap/snapcraft.yaml"
+        assert plan.snaps[0].pack_dir == "myproject"
 
     def test_snap_under_snap_subdir_at_root(self, tmp_path: Path) -> None:
-        """snap/snapcraft.yaml at repo root → source is '.'."""
+        """snap/snapcraft.yaml at repo root → pack_dir is '.'."""
         _write(tmp_path / "snap" / "snapcraft.yaml", "name: mysnap\n")
         plan = discover_artifacts(tmp_path)
         assert len(plan.snaps) == 1
         assert plan.snaps[0].name == "mysnap"
-        assert plan.snaps[0].source == "."
+        assert plan.snaps[0].snapcraft_yaml == "snap/snapcraft.yaml"
+        assert plan.snaps[0].pack_dir == "."
 
     def test_monorepo(self, tmp_path: Path) -> None:
         _write(tmp_path / "charmcraft.yaml", "name: main-charm\ntype: charm\n")
@@ -90,7 +93,7 @@ class TestDiscovery:
         _write(tmp_path / "a" / "b" / "c" / "rockcraft.yaml", "name: deep-rock\n")
         plan = discover_artifacts(tmp_path)
         assert len(plan.rocks) == 1
-        assert plan.rocks[0].source == "a/b/c"
+        assert plan.rocks[0].rockcraft_yaml == "a/b/c/rockcraft.yaml"
 
     def test_pruned_directories_skipped(self, tmp_path: Path) -> None:
         _write(tmp_path / ".venv" / "rockcraft.yaml", "name: venv-rock\n")
@@ -188,13 +191,17 @@ class TestYamlIO:
     def test_artifacts_plan_round_trip(self, tmp_path: Path) -> None:
         plan = ArtifactsPlan.model_validate(
             {
-                "version": 1,
-                "rocks": [{"name": "r1", "source": "rd"}],
-                "charms": [{"name": "c1", "source": "."}],
+                "version": 2,
+                "rocks": [{"name": "r1", "rockcraft-yaml": "rd/rockcraft.yaml"}],
+                "charms": [{"name": "c1", "charmcraft-yaml": "charmcraft.yaml"}],
             }
         )
         path = tmp_path / "artifacts.yaml"
         dump_artifacts_plan(plan, path)
+        raw = path.read_text()
+        # hyphenated keys must be present in the file
+        assert "rockcraft-yaml" in raw
+        assert "charmcraft-yaml" in raw
         loaded = load_artifacts_plan(path)
         assert loaded == plan
 
@@ -203,7 +210,7 @@ class TestYamlIO:
             rocks=[
                 GeneratedRock(
                     name="r1",
-                    source="rd",
+                    rockcraft_yaml="rd/rockcraft.yaml",
                     output=ArtifactOutput(file="./r1.rock"),
                 )
             ],
@@ -218,7 +225,7 @@ class TestYamlIO:
             rocks=[
                 GeneratedRock(
                     name="r1",
-                    source="rd",
+                    rockcraft_yaml="rd/rockcraft.yaml",
                     output=ArtifactOutput(artifact="a1", run_id="42"),
                 )
             ],

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -25,7 +25,7 @@ class TestArtifactsPlan:
 
     def test_minimal_valid(self) -> None:
         plan = ArtifactsPlan()
-        assert plan.version == 1
+        assert plan.version == 2  # noqa: PLR2004
         assert plan.rocks == []
         assert plan.charms == []
         assert plan.snaps == []
@@ -33,13 +33,17 @@ class TestArtifactsPlan:
     def test_full_example(self) -> None:
         plan = ArtifactsPlan(
             rocks=[
-                RockArtifact(name="indico", source="indico_rock"),
-                RockArtifact(name="indico-nginx", source="nginx_rock"),
+                RockArtifact(
+                    name="indico", rockcraft_yaml="indico_rock/rockcraft.yaml"
+                ),
+                RockArtifact(
+                    name="indico-nginx", rockcraft_yaml="nginx_rock/rockcraft.yaml"
+                ),
             ],
             charms=[
                 CharmArtifact(
                     name="indico",
-                    source=".",
+                    charmcraft_yaml="charmcraft.yaml",
                     resources={
                         "indico-image": ArtifactResource(
                             type="oci-image", rock="indico"
@@ -56,8 +60,8 @@ class TestArtifactsPlan:
         with pytest.raises(ValidationError, match="Duplicate rock"):
             ArtifactsPlan(
                 rocks=[
-                    RockArtifact(name="myrock", source="a"),
-                    RockArtifact(name="myrock", source="b"),
+                    RockArtifact(name="myrock", rockcraft_yaml="a/rockcraft.yaml"),
+                    RockArtifact(name="myrock", rockcraft_yaml="b/rockcraft.yaml"),
                 ]
             )
 
@@ -65,43 +69,74 @@ class TestArtifactsPlan:
         with pytest.raises(ValidationError, match="Duplicate charm"):
             ArtifactsPlan(
                 charms=[
-                    CharmArtifact(name="mycharm", source="a"),
-                    CharmArtifact(name="mycharm", source="b"),
+                    CharmArtifact(name="mycharm", charmcraft_yaml="a/charmcraft.yaml"),
+                    CharmArtifact(name="mycharm", charmcraft_yaml="b/charmcraft.yaml"),
                 ]
             )
 
     def test_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError, match="Extra inputs"):
-            ArtifactsPlan.model_validate({"version": 1, "unknown_key": "val"})
+            ArtifactsPlan.model_validate({"version": 2, "unknown_key": "val"})
 
     def test_wrong_version_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            ArtifactsPlan.model_validate({"version": 2})
+            ArtifactsPlan.model_validate({"version": 1})
 
     def test_resource_wrong_type_rejected(self) -> None:
         with pytest.raises(ValidationError):
             ArtifactResource(type="file")  # type: ignore[arg-type]
 
     def test_from_yaml_dict(self) -> None:
-        """Validate a dict that mimics YAML load output."""
+        """Validate a dict that mimics YAML load output (hyphenated keys)."""
         data = {
-            "version": 1,
-            "rocks": [{"name": "myrock", "source": "rock_dir"}],
+            "version": 2,
+            "rocks": [{"name": "myrock", "rockcraft-yaml": "rock_dir/rockcraft.yaml"}],
             "charms": [
                 {
                     "name": "mycharm",
-                    "source": ".",
+                    "charmcraft-yaml": "charmcraft.yaml",
                     "resources": {
                         "img": {"type": "oci-image", "rock": "myrock"},
                     },
                 }
             ],
-            "snaps": [{"name": "mysnap", "source": "snap_dir"}],
+            "snaps": [
+                {
+                    "name": "mysnap",
+                    "snapcraft-yaml": "snap/snapcraft.yaml",
+                    "pack-dir": ".",
+                }
+            ],
         }
         plan = ArtifactsPlan.model_validate(data)
         assert plan.rocks[0].name == "myrock"
         assert plan.charms[0].resources["img"].rock == "myrock"
         assert plan.snaps[0].name == "mysnap"
+        assert plan.snaps[0].pack_dir == "."
+
+    def test_pack_dir_optional(self) -> None:
+        rock = RockArtifact(name="myrock", rockcraft_yaml="rock/rockcraft.yaml")
+        assert rock.pack_dir is None
+
+    def test_pack_dir_set(self) -> None:
+        rock = RockArtifact(
+            name="myrock", rockcraft_yaml="rock/rockcraft.yaml", pack_dir="."
+        )
+        assert rock.pack_dir == "."
+
+    def test_artifacts_yaml_serializes_with_hyphens(self) -> None:
+        """dump_artifacts_plan must emit hyphenated keys, not underscored."""
+        plan = ArtifactsPlan(
+            rocks=[
+                RockArtifact(name="r", rockcraft_yaml="r/rockcraft.yaml", pack_dir=".")
+            ],
+        )
+        dumped = plan.model_dump(by_alias=True, exclude_none=True)
+        rock = dumped["rocks"][0]
+        assert "rockcraft-yaml" in rock
+        assert "pack-dir" in rock
+        assert "rockcraft_yaml" not in rock
+        assert "pack_dir" not in rock
 
 
 class TestArtifactsGenerated:
@@ -146,14 +181,14 @@ class TestArtifactsGenerated:
             rocks=[
                 GeneratedRock(
                     name="indico",
-                    source="indico_rock",
+                    rockcraft_yaml="indico_rock/rockcraft.yaml",
                     output=ArtifactOutput(file="./indico.rock"),
                 )
             ],
             charms=[
                 GeneratedCharm(
                     name="indico",
-                    source=".",
+                    charmcraft_yaml="charmcraft.yaml",
                     output=ArtifactOutput(file="./indico.charm"),
                 )
             ],
@@ -163,14 +198,14 @@ class TestArtifactsGenerated:
 
     def test_generated_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError, match="Extra inputs"):
-            ArtifactsGenerated.model_validate({"version": 1, "junk": True})
+            ArtifactsGenerated.model_validate({"version": 3, "junk": True})
 
     def test_snap_generated(self) -> None:
         gen = ArtifactsGenerated(
             snaps=[
                 GeneratedSnap(
                     name="mysnap",
-                    source="snap_dir",
+                    snapcraft_yaml="snap/snapcraft.yaml",
                     output=ArtifactOutput(file="./mysnap.snap"),
                 )
             ],

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -19,33 +19,33 @@ def _write(path: Path, content: str) -> None:
 
 
 _GENERATED_WITH_ROCKS = """\
-version: 2
+version: 3
 rocks:
 - name: myrock
-  source: rock_dir
+  rockcraft-yaml: rock_dir/rockcraft.yaml
   output:
     file: ./rock_dir/myrock.rock
 - name: otherrock
-  source: other
+  rockcraft-yaml: other/rockcraft.yaml
   output:
     image: ghcr.io/canonical/otherrock:abc
 charms:
 - name: mycharm
-  source: .
+  charmcraft-yaml: charmcraft.yaml
   output:
     file: ./mycharm.charm
 """
 
 _GENERATED_WITH_ROCKS_AND_RESOURCES = """\
-version: 2
+version: 3
 rocks:
 - name: myrock
-  source: rock_dir
+  rockcraft-yaml: rock_dir/rockcraft.yaml
   output:
     file: ./rock_dir/myrock.rock
 charms:
 - name: mycharm
-  source: .
+  charmcraft-yaml: charmcraft.yaml
   output:
     file: ./mycharm.charm
   resources:
@@ -123,8 +123,8 @@ class TestProvisionLoad:
     def test_no_local_rocks_returns_empty(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 2\n"
-            "rocks:\n- name: r1\n  source: rd\n"
+            "version: 3\n"
+            "rocks:\n- name: r1\n  rockcraft-yaml: rd/rockcraft.yaml\n"
             "  output:\n    image: ghcr.io/r1:v1\n",
         )
 
@@ -135,7 +135,7 @@ class TestProvisionLoad:
         mock_run.assert_not_called()
 
     def test_empty_generated_returns_empty(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
 
         with patch("opcli.core.provision.run_command") as mock_run:
             pushed = provision_load(tmp_path)
@@ -193,8 +193,8 @@ class TestProvisionLoad:
         """Rock with image already set to the target ref is skipped."""
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 2\n"
-            "rocks:\n- name: myrock\n  source: rock_dir\n"
+            "version: 3\n"
+            "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
             "  output:\n    file: ./rock_dir/myrock.rock\n"
             "    image: localhost:32000/myrock:latest\n",
         )
@@ -207,7 +207,7 @@ class TestProvisionLoad:
 
     def test_no_writeback_when_nothing_pushed(self, tmp_path: Path) -> None:
         """artifacts-generated.yaml is not written when no rocks are pushed."""
-        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
         mtime_before = (tmp_path / "artifacts-generated.yaml").stat().st_mtime
 
         with patch("opcli.core.provision.run_command"):

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -22,15 +22,15 @@ def _write(path: Path, content: str) -> None:
 # ---------------------------------------------------------------------------
 
 _GENERATED_LOCAL = """\
-version: 2
+version: 3
 rocks:
 - name: myrock
-  source: rock_dir
+  rockcraft-yaml: rock_dir/rockcraft.yaml
   output:
     file: ./rock_dir/myrock.rock
 charms:
 - name: mycharm
-  source: .
+  charmcraft-yaml: charmcraft.yaml
   output:
     file: ./mycharm.charm
   resources:
@@ -41,15 +41,15 @@ charms:
 """
 
 _GENERATED_CI = """\
-version: 2
+version: 3
 rocks:
 - name: myrock
-  source: rock_dir
+  rockcraft-yaml: rock_dir/rockcraft.yaml
   output:
     image: ghcr.io/canonical/myrock:abc123
 charms:
 - name: mycharm
-  source: .
+  charmcraft-yaml: charmcraft.yaml
   output:
     artifact: charm-mycharm
     run-id: "999"
@@ -61,10 +61,10 @@ charms:
 """
 
 _GENERATED_NO_RESOURCES = """\
-version: 2
+version: 3
 charms:
 - name: simple
-  source: .
+  charmcraft-yaml: charmcraft.yaml
   output:
     file: ./simple.charm
 """
@@ -80,7 +80,7 @@ class TestAssemblePytestArgs:
     def test_version_1_generated_raises(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 1\ncharms:\n- name: c\n  source: .\n"
+            "version: 1\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
             "  output:\n    file: ./c.charm\n",
         )
         with pytest.raises(Exception, match=_V1_ERROR_MATCH):
@@ -114,7 +114,7 @@ class TestAssemblePytestArgs:
         assert args == ["--charm-file=./simple.charm"]
 
     def test_empty_generated(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
 
         args = assemble_pytest_args(tmp_path)
         assert args == []
@@ -123,7 +123,7 @@ class TestAssemblePytestArgs:
         """Resource with no file or image (rock not built) emits no flag."""
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 2\ncharms:\n- name: c\n  source: .\n"
+            "version: 3\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
             "  output:\n    file: ./c.charm\n"
             "  resources:\n    img:\n      type: oci-image\n      rock: myrock\n",
         )
@@ -137,7 +137,7 @@ class TestAssemblePytestArgs:
         """After provision load, image ref is preferred over local file path."""
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 2\ncharms:\n- name: c\n  source: .\n"
+            "version: 3\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
             "  output:\n    file: ./c.charm\n"
             "  resources:\n    myrock-image:\n      type: oci-image\n"
             "      rock: myrock\n"
@@ -155,7 +155,7 @@ class TestAssembleToxArgv:
     """Tests for assemble_tox_argv()."""
 
     def test_no_flags_no_extra_omits_separator(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
 
         argv = assemble_tox_argv(tmp_path)
 
@@ -172,7 +172,7 @@ class TestAssembleToxArgv:
         assert "--charm-file=./mycharm.charm" in argv
 
     def test_extra_args_only_include_separator(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
 
         argv = assemble_tox_argv(tmp_path, extra_args=["-k", "test_foo"])
 
@@ -181,7 +181,7 @@ class TestAssembleToxArgv:
         assert "test_foo" in argv
 
     def test_custom_tox_env(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 2\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
 
         argv = assemble_tox_argv(tmp_path, tox_env="e2e")
 


### PR DESCRIPTION
## Problem

Repositories with a Go module root at the repository root cannot use the `rocks/<name>/rockcraft.yaml` layout. Rockcraft's managed container copies only the subdirectory, so symlinks to `../go.mod` are not followed and the build fails with `missing go.mod file`.

Fixes #48.

## Solution

### Schema change (artifacts.yaml v2, artifacts-generated.yaml v3)

Replace the generic `source` directory field with explicit craft-YAML file paths:

```yaml
version: 2
rocks:
  - name: my-rock
    rockcraft-yaml: rocks/my-rock/rockcraft.yaml
charms:
  - name: my-charm
    charmcraft-yaml: charmcraft.yaml
snaps:
  - name: my-snap
    snapcraft-yaml: snap/snapcraft.yaml
    pack-dir: .
```

Add optional `pack-dir` to all artifact types. When set, the build tool runs from `pack-dir` instead of the directory containing the craft YAML.

### Build logic

For rocks: when `pack-dir != dirname(rockcraft-yaml)`, opcli:
1. Creates `<pack-dir>/rockcraft.yaml` symlink pointing to the real file
2. Runs `rockcraft pack` from `pack-dir`
3. Removes the symlink (in a `finally` block)

Fails if a real (non-symlink) file exists at the symlink target; replaces an existing symlink.

Output file detection uses a before/after snapshot to correctly identify the new artifact even when `pack-dir` is the repo root (which may contain other \*.rock files).

### Discovery

`artifacts init` now emits yaml-file paths. The `snap/snapcraft.yaml` convention auto-sets `pack-dir` to the parent directory (preserving existing behaviour).