### PR TITLE
fix: keep both schemas at version 1 while still experimenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,12 +162,12 @@ Different suites can each declare their own `TOX_ENV` value.
 | `spread.yaml` | Spread configuration with a virtual `integration-test` backend expanded by opcli. |
 | `tests/integration/run/task.yaml` | Spread task that runs integration tests via `opcli pytest expand`. |
 
-## `artifacts.yaml` schema (v2)
+## `artifacts.yaml` schema
 
 Each artifact entry uses an explicit path to its craft YAML file rather than a directory:
 
 ```yaml
-version: 2
+version: 1
 rocks:
   - name: my-rock
     rockcraft-yaml: rocks/my-rock/rockcraft.yaml

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -260,7 +260,7 @@ because their unit tests depend on `Harness` reading `metadata.yaml`).
 **Spec:** The `artifacts.yaml` schema uses a `source` field containing the
 **directory** that contains the craft YAML file (e.g. `source: rocks/my-rock`).
 
-**Implementation (v2 schema):** The `source` field is replaced by an explicit
+**Implementation:** The `source` field is replaced by an explicit
 path to the craft YAML file:
 
 ```yaml

--- a/src/opcli/models/artifacts.py
+++ b/src/opcli/models/artifacts.py
@@ -64,7 +64,7 @@ class ArtifactsPlan(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    version: Literal[2] = 2
+    version: Literal[1] = 1
     rocks: list[RockArtifact] = []
     charms: list[CharmArtifact] = []
     snaps: list[SnapArtifact] = []

--- a/src/opcli/models/artifacts_generated.py
+++ b/src/opcli/models/artifacts_generated.py
@@ -96,7 +96,7 @@ class ArtifactsGenerated(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    version: Literal[3] = 3
+    version: Literal[1] = 1
     rocks: list[GeneratedRock] = []
     charms: list[GeneratedCharm] = []
     snaps: list[GeneratedSnap] = []

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -67,7 +67,7 @@ class TestArtifactsBuild:
     def test_build_single_charm(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\ncharms:\n- name: mycharm\n"
+            "version: 1\ncharms:\n- name: mycharm\n"
             "  charmcraft-yaml: charmcraft.yaml\n",
         )
         # Simulate charmcraft pack producing a .charm file
@@ -88,7 +88,7 @@ class TestArtifactsBuild:
     def test_build_single_rock(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\nrocks:\n- name: myrock\n"
+            "version: 1\nrocks:\n- name: myrock\n"
             "  rockcraft-yaml: rock_dir/rockcraft.yaml\n",
         )
         rock_dir = tmp_path / "rock_dir"
@@ -108,7 +108,7 @@ class TestArtifactsBuild:
     def test_build_single_snap(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\nsnaps:\n- name: mysnap\n"
+            "version: 1\nsnaps:\n- name: mysnap\n"
             "  snapcraft-yaml: snap_dir/snapcraft.yaml\n",
         )
         snap_dir = tmp_path / "snap_dir"
@@ -126,7 +126,7 @@ class TestArtifactsBuild:
     def test_build_filtered_by_charm_name(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\ncharms:\n"
+            "version: 1\ncharms:\n"
             "- name: charm-a\n  charmcraft-yaml: a/charmcraft.yaml\n"
             "- name: charm-b\n  charmcraft-yaml: b/charmcraft.yaml\n",
         )
@@ -143,7 +143,7 @@ class TestArtifactsBuild:
     def test_unknown_charm_name_raises(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\ncharms:\n- name: real\n  charmcraft-yaml: charmcraft.yaml\n",
+            "version: 1\ncharms:\n- name: real\n  charmcraft-yaml: charmcraft.yaml\n",
         )
         with pytest.raises(ConfigurationError, match="Unknown charm"):
             artifacts_build(tmp_path, charm_names=["nonexistent"])
@@ -151,7 +151,7 @@ class TestArtifactsBuild:
     def test_no_output_file_raises(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\nrocks:\n- name: myrock\n"
+            "version: 1\nrocks:\n- name: myrock\n"
             "  rockcraft-yaml: rock_dir/rockcraft.yaml\n",
         )
         (tmp_path / "rock_dir").mkdir()
@@ -165,7 +165,7 @@ class TestArtifactsBuild:
     def test_build_monorepo(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\n"
+            "version: 1\n"
             "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
             "charms:\n- name: mycharm\n  charmcraft-yaml: charmcraft.yaml\n",
         )
@@ -183,7 +183,7 @@ class TestArtifactsBuild:
     def test_build_propagates_resources_to_generated(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\n"
+            "version: 1\n"
             "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
             "charms:\n- name: mycharm\n  charmcraft-yaml: charmcraft.yaml\n"
             "  resources:\n"
@@ -213,7 +213,7 @@ class TestArtifactsBuild:
         """Resource referencing a rock not in artifacts.yaml has unresolved output."""
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\n"
+            "version: 1\n"
             "charms:\n- name: mycharm\n  charmcraft-yaml: charmcraft.yaml\n"
             "  resources:\n"
             "    myrock-image:\n"
@@ -232,10 +232,10 @@ class TestArtifactsBuild:
         assert res.file is None
         assert res.image is None
 
-    def test_version_2_generated_is_rejected(self, tmp_path: Path) -> None:
+    def test_invalid_generated_fields_rejected(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 2\ncharms:\n- name: c\n  source: .\n"
+            "version: 1\ncharms:\n- name: c\n  source: .\n"
             "  output:\n    file: ./c.charm\n",
         )
         with pytest.raises(Exception, match="validation error"):
@@ -251,7 +251,7 @@ class TestArtifactsBuild:
 
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\n"
+            "version: 1\n"
             "rocks:\n- name: myrock\n"
             "  rockcraft-yaml: rocks/myrock/rockcraft.yaml\n"
             "  pack-dir: .\n",
@@ -283,7 +283,7 @@ class TestArtifactsBuild:
 
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\n"
+            "version: 1\n"
             "rocks:\n- name: myrock\n"
             "  rockcraft-yaml: rocks/myrock/rockcraft.yaml\n"
             "  pack-dir: .\n",
@@ -310,7 +310,7 @@ class TestArtifactsBuild:
 
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 2\n"
+            "version: 1\n"
             "rocks:\n- name: myrock\n"
             "  rockcraft-yaml: rocks/myrock/rockcraft.yaml\n"
             "  pack-dir: .\n",

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -191,7 +191,7 @@ class TestYamlIO:
     def test_artifacts_plan_round_trip(self, tmp_path: Path) -> None:
         plan = ArtifactsPlan.model_validate(
             {
-                "version": 2,
+                "version": 1,
                 "rocks": [{"name": "r1", "rockcraft-yaml": "rd/rockcraft.yaml"}],
                 "charms": [{"name": "c1", "charmcraft-yaml": "charmcraft.yaml"}],
             }

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -25,7 +25,7 @@ class TestArtifactsPlan:
 
     def test_minimal_valid(self) -> None:
         plan = ArtifactsPlan()
-        assert plan.version == 1  # noqa: PLR2004
+        assert plan.version == 1
         assert plan.rocks == []
         assert plan.charms == []
         assert plan.snaps == []

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -25,7 +25,7 @@ class TestArtifactsPlan:
 
     def test_minimal_valid(self) -> None:
         plan = ArtifactsPlan()
-        assert plan.version == 2  # noqa: PLR2004
+        assert plan.version == 1  # noqa: PLR2004
         assert plan.rocks == []
         assert plan.charms == []
         assert plan.snaps == []
@@ -76,11 +76,11 @@ class TestArtifactsPlan:
 
     def test_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError, match="Extra inputs"):
-            ArtifactsPlan.model_validate({"version": 2, "unknown_key": "val"})
+            ArtifactsPlan.model_validate({"version": 1, "unknown_key": "val"})
 
     def test_wrong_version_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            ArtifactsPlan.model_validate({"version": 1})
+            ArtifactsPlan.model_validate({"version": 99})
 
     def test_resource_wrong_type_rejected(self) -> None:
         with pytest.raises(ValidationError):
@@ -89,7 +89,7 @@ class TestArtifactsPlan:
     def test_from_yaml_dict(self) -> None:
         """Validate a dict that mimics YAML load output (hyphenated keys)."""
         data = {
-            "version": 2,
+            "version": 1,
             "rocks": [{"name": "myrock", "rockcraft-yaml": "rock_dir/rockcraft.yaml"}],
             "charms": [
                 {
@@ -198,7 +198,7 @@ class TestArtifactsGenerated:
 
     def test_generated_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError, match="Extra inputs"):
-            ArtifactsGenerated.model_validate({"version": 3, "junk": True})
+            ArtifactsGenerated.model_validate({"version": 99, "junk": True})
 
     def test_snap_generated(self) -> None:
         gen = ArtifactsGenerated(

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -19,7 +19,7 @@ def _write(path: Path, content: str) -> None:
 
 
 _GENERATED_WITH_ROCKS = """\
-version: 3
+version: 1
 rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
@@ -37,7 +37,7 @@ charms:
 """
 
 _GENERATED_WITH_ROCKS_AND_RESOURCES = """\
-version: 3
+version: 1
 rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
@@ -123,7 +123,7 @@ class TestProvisionLoad:
     def test_no_local_rocks_returns_empty(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 3\n"
+            "version: 1\n"
             "rocks:\n- name: r1\n  rockcraft-yaml: rd/rockcraft.yaml\n"
             "  output:\n    image: ghcr.io/r1:v1\n",
         )
@@ -135,7 +135,7 @@ class TestProvisionLoad:
         mock_run.assert_not_called()
 
     def test_empty_generated_returns_empty(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
 
         with patch("opcli.core.provision.run_command") as mock_run:
             pushed = provision_load(tmp_path)
@@ -193,7 +193,7 @@ class TestProvisionLoad:
         """Rock with image already set to the target ref is skipped."""
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 3\n"
+            "version: 1\n"
             "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
             "  output:\n    file: ./rock_dir/myrock.rock\n"
             "    image: localhost:32000/myrock:latest\n",
@@ -207,7 +207,7 @@ class TestProvisionLoad:
 
     def test_no_writeback_when_nothing_pushed(self, tmp_path: Path) -> None:
         """artifacts-generated.yaml is not written when no rocks are pushed."""
-        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
         mtime_before = (tmp_path / "artifacts-generated.yaml").stat().st_mtime
 
         with patch("opcli.core.provision.run_command"):

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -22,7 +22,7 @@ def _write(path: Path, content: str) -> None:
 # ---------------------------------------------------------------------------
 
 _GENERATED_LOCAL = """\
-version: 3
+version: 1
 rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
@@ -41,7 +41,7 @@ charms:
 """
 
 _GENERATED_CI = """\
-version: 3
+version: 1
 rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
@@ -61,7 +61,7 @@ charms:
 """
 
 _GENERATED_NO_RESOURCES = """\
-version: 3
+version: 1
 charms:
 - name: simple
   charmcraft-yaml: charmcraft.yaml
@@ -77,10 +77,10 @@ class TestAssemblePytestArgs:
         with pytest.raises(ConfigurationError, match="not found"):
             assemble_pytest_args(tmp_path)
 
-    def test_version_1_generated_raises(self, tmp_path: Path) -> None:
+    def test_invalid_generated_fields_raises(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 1\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
+            "version: 1\ncharms:\n- name: c\n  source: .\n"
             "  output:\n    file: ./c.charm\n",
         )
         with pytest.raises(Exception, match=_V1_ERROR_MATCH):
@@ -114,7 +114,7 @@ class TestAssemblePytestArgs:
         assert args == ["--charm-file=./simple.charm"]
 
     def test_empty_generated(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
 
         args = assemble_pytest_args(tmp_path)
         assert args == []
@@ -123,7 +123,7 @@ class TestAssemblePytestArgs:
         """Resource with no file or image (rock not built) emits no flag."""
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 3\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
+            "version: 1\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
             "  output:\n    file: ./c.charm\n"
             "  resources:\n    img:\n      type: oci-image\n      rock: myrock\n",
         )
@@ -137,7 +137,7 @@ class TestAssemblePytestArgs:
         """After provision load, image ref is preferred over local file path."""
         _write(
             tmp_path / "artifacts-generated.yaml",
-            "version: 3\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
+            "version: 1\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
             "  output:\n    file: ./c.charm\n"
             "  resources:\n    myrock-image:\n      type: oci-image\n"
             "      rock: myrock\n"
@@ -155,7 +155,7 @@ class TestAssembleToxArgv:
     """Tests for assemble_tox_argv()."""
 
     def test_no_flags_no_extra_omits_separator(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
 
         argv = assemble_tox_argv(tmp_path)
 
@@ -172,7 +172,7 @@ class TestAssembleToxArgv:
         assert "--charm-file=./mycharm.charm" in argv
 
     def test_extra_args_only_include_separator(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
 
         argv = assemble_tox_argv(tmp_path, extra_args=["-k", "test_foo"])
 
@@ -181,7 +181,7 @@ class TestAssembleToxArgv:
         assert "test_foo" in argv
 
     def test_custom_tox_env(self, tmp_path: Path) -> None:
-        _write(tmp_path / "artifacts-generated.yaml", "version: 3\n")
+        _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
 
         argv = assemble_tox_argv(tmp_path, tox_env="e2e")
 


### PR DESCRIPTION
Both `artifacts.yaml` and `artifacts-generated.yaml` stay at version 1. The version bumps introduced in #52 were premature — we're still testing the tool.