### PR TITLE
fix: code quality improvements and symlink bug fixes

### DIFF
--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -112,7 +112,7 @@ The spec implies opcli participates in producing these (build collection step).
 
 **Implementation:**
 
-- The `ArtifactsGenerated` model (v2) correctly parses CI-format files.
+- The `ArtifactsGenerated` model (v1) correctly parses CI-format files.
 - `opcli pytest expand` emits `--<resource-name>=<image>` for charm resources
   whose embedded `image:` field is set (resolved at build time from the rock's
   CI output).
@@ -264,7 +264,7 @@ because their unit tests depend on `Harness` reading `metadata.yaml`).
 path to the craft YAML file:
 
 ```yaml
-version: 2
+version: 1
 rocks:
   - name: my-rock
     rockcraft-yaml: rocks/my-rock/rockcraft.yaml

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -85,23 +85,43 @@ def _snapshot_outputs(pack_dir: Path, kind: str) -> set[str]:
 def _pick_new_output(
     before: set[str], after: set[str], kind: str, pack_dir: Path
 ) -> str:
-    """Return the new output file produced by pack, relative to repo root."""
+    """Return the new output file produced by pack, relative to repo root.
+
+    Three cases:
+    1. New files appeared (``after - before`` non-empty) — use those.
+    2. No files at all — raise error.
+    3. Same files before and after — the build overwrote an existing file in
+       place.  Unambiguous only when there is exactly one file; otherwise we
+       cannot determine which file was just produced.
+    """
     new_files = sorted(after - before)
-    if not new_files:
-        # Fallback: use all files (handles edge case where pre-existing file
-        # was overwritten in place rather than written as a new path).
-        new_files = sorted(after)
-    if not new_files:
+    if new_files:
+        if len(new_files) > 1:
+            logger.warning(
+                "Multiple new %s files in %s; using %s",
+                _OUTPUT_GLOBS[kind],
+                pack_dir,
+                new_files[0],
+            )
+        return new_files[0]
+
+    # No new files — check overwrite-in-place case.
+    if not after:
         msg = f"No {_OUTPUT_GLOBS[kind]} found in {pack_dir} after pack"
         raise OpcliError(msg)
-    if len(new_files) > 1:
-        logger.warning(
-            "Multiple new %s files in %s; using %s",
-            _OUTPUT_GLOBS[kind],
-            pack_dir,
-            new_files[0],
-        )
-    return new_files[0]
+
+    if len(after) == 1:
+        # Exactly one pre-existing file; the build overwrote it in place.
+        return next(iter(after))
+
+    # Multiple pre-existing files, none added — cannot determine which was built.
+    msg = (
+        f"Cannot determine which {_OUTPUT_GLOBS[kind]} in {pack_dir} was just "
+        "built: the pack tool overwrote an existing file but multiple "
+        f"{_OUTPUT_GLOBS[kind]} files already exist. "
+        "Use a dedicated pack-dir that does not contain pre-existing output files."
+    )
+    raise OpcliError(msg)
 
 
 def _relative_to_root(path_str: str, root: Path) -> str:
@@ -125,7 +145,13 @@ def _with_rock_symlink(
     yaml_path: Path,
     pack_dir: Path,
 ) -> tuple[Path | None, bool]:
-    """Prepare a rockcraft.yaml symlink in *pack_dir* if needed.
+    """Prepare a ``rockcraft.yaml`` symlink in *pack_dir* if needed.
+
+    Rockcraft always looks for a file literally named ``rockcraft.yaml`` in
+    the working directory, regardless of the actual filename of the craft YAML.
+    This function creates ``<pack_dir>/rockcraft.yaml → yaml_path`` when the
+    source file is not already named ``rockcraft.yaml`` and located in
+    ``pack_dir``.
 
     Returns ``(symlink_path, created)`` where *created* is ``True`` when this
     call created the symlink (and the caller must remove it afterwards).
@@ -134,10 +160,11 @@ def _with_rock_symlink(
         ConfigurationError: If a real (non-symlink) file already exists at the
             target location.
     """
-    if pack_dir == yaml_path.parent:
+    target = pack_dir / "rockcraft.yaml"  # always the standard name
+    if target == yaml_path:
+        # Already named rockcraft.yaml and already in pack_dir — no symlink needed.
         return None, False
 
-    target = pack_dir / yaml_path.name  # e.g. pack_dir/rockcraft.yaml
     if target.exists() and not target.is_symlink():
         msg = (
             f"A regular file already exists at {target}. "
@@ -146,13 +173,19 @@ def _with_rock_symlink(
         raise ConfigurationError(msg)
     if target.is_symlink():
         target.unlink()
-    target.symlink_to(yaml_path.resolve())
+    target.symlink_to(yaml_path)
     return target, True
 
 
 def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
     yaml_path = (root / rock.rockcraft_yaml).resolve()
+    if not yaml_path.is_file():
+        msg = f"rockcraft-yaml not found: {rock.rockcraft_yaml}"
+        raise ConfigurationError(msg)
     pack_dir = _resolve_pack_dir(yaml_path, rock.pack_dir, root)
+    if not pack_dir.is_dir():
+        msg = f"pack-dir not found: {rock.pack_dir}"
+        raise ConfigurationError(msg)
 
     before = _snapshot_outputs(pack_dir, "rock")
 
@@ -179,7 +212,13 @@ def _build_charm(
     all_rocks: dict[str, GeneratedRock],
 ) -> GeneratedCharm:
     yaml_path = (root / charm.charmcraft_yaml).resolve()
+    if not yaml_path.is_file():
+        msg = f"charmcraft-yaml not found: {charm.charmcraft_yaml}"
+        raise ConfigurationError(msg)
     pack_dir = _resolve_pack_dir(yaml_path, charm.pack_dir, root)
+    if not pack_dir.is_dir():
+        msg = f"pack-dir not found: {charm.pack_dir}"
+        raise ConfigurationError(msg)
 
     before = _snapshot_outputs(pack_dir, "charm")
     run_command([*_PACK_COMMANDS["charm"]], cwd=str(pack_dir))
@@ -212,7 +251,13 @@ def _build_charm(
 
 def _build_snap(snap: SnapArtifact, root: Path) -> GeneratedSnap:
     yaml_path = (root / snap.snapcraft_yaml).resolve()
+    if not yaml_path.is_file():
+        msg = f"snapcraft-yaml not found: {snap.snapcraft_yaml}"
+        raise ConfigurationError(msg)
     pack_dir = _resolve_pack_dir(yaml_path, snap.pack_dir, root)
+    if not pack_dir.is_dir():
+        msg = f"pack-dir not found: {snap.pack_dir}"
+        raise ConfigurationError(msg)
 
     before = _snapshot_outputs(pack_dir, "snap")
     run_command([*_PACK_COMMANDS["snap"]], cwd=str(pack_dir))

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -1,9 +1,9 @@
 """Core logic for ``opcli pytest expand``.
 
-Reads ``artifacts-generated.yaml`` (schema v2) and assembles the flags that
+Reads ``artifacts-generated.yaml`` (schema v1) and assembles the flags that
 tox/pytest need to locate built charms and their OCI-image resources.
 
-``artifacts-generated.yaml`` v2 carries resolved resource paths inside each
+``artifacts-generated.yaml`` carries resolved resource paths inside each
 charm entry, so this module no longer needs to read ``artifacts.yaml``.
 
 Convention (matching operator-workflows):
@@ -56,6 +56,13 @@ def assemble_pytest_args(
     for charm in generated.charms:
         if charm.output.file:
             args.append(f"--charm-file={charm.output.file}")
+        elif charm.output.artifact:
+            logger.warning(
+                "Skipping --charm-file for charm '%s': output is a CI artifact "
+                "(%s). Run 'opcli artifacts build' locally to get a local file.",
+                charm.name,
+                charm.output.artifact,
+            )
 
         for res_name, res in (charm.resources or {}).items():
             value = res.image or res.file

--- a/src/opcli/models/artifacts.py
+++ b/src/opcli/models/artifacts.py
@@ -3,13 +3,13 @@
 This schema declares the charms, rocks, and snaps in a repository, and
 the links between charms and their OCI-image resources (rocks).
 
-Schema version history
-----------------------
-v1 — initial release (``source`` directory field)
-v2 — ``source`` replaced by explicit ``<tool>-yaml`` file path; optional
-     ``pack-dir`` added to run the build tool from a different directory
-     (e.g. a Go monorepo where ``go.mod`` lives at the repo root but
-     ``rockcraft.yaml`` lives in a subdirectory).
+Schema version: 1
+- Each artifact carries an explicit path to its craft YAML file
+  (``rockcraft-yaml``, ``charmcraft-yaml``, ``snapcraft-yaml``) rather than
+  a source directory.
+- An optional ``pack-dir`` field controls the working directory for the build
+  tool (e.g. run ``rockcraft pack`` from the repo root when ``go.mod`` lives
+  there but ``rockcraft.yaml`` is in a subdirectory).
 """
 
 from __future__ import annotations
@@ -60,7 +60,7 @@ class SnapArtifact(BaseModel):
 
 
 class ArtifactsPlan(BaseModel):
-    """Top-level schema for ``artifacts.yaml`` (schema version 2)."""
+    """Top-level schema for ``artifacts.yaml`` (schema version 1)."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/src/opcli/models/artifacts_generated.py
+++ b/src/opcli/models/artifacts_generated.py
@@ -2,14 +2,12 @@
 
 Extends the build plan with paths/references of the built artifacts.
 
-Schema version history
-----------------------
-v1 — initial release (charm resources not included)
-v2 — charm entries carry a ``resources`` mapping with resolved output paths,
-     making ``artifacts-generated.yaml`` self-contained (no need to also read
-     ``artifacts.yaml`` when assembling pytest flags).
-v3 — ``source`` renamed to ``<tool>-yaml`` (explicit path to the craft YAML
-     file) to align with the v2 ``artifacts.yaml`` schema change.
+Schema version: 1
+- Each artifact carries an explicit path to its craft YAML file
+  (``rockcraft-yaml``, ``charmcraft-yaml``, ``snapcraft-yaml``).
+- Charm entries include a ``resources`` mapping with resolved output paths
+  (file or image), making ``artifacts-generated.yaml`` self-contained for
+  pytest flag assembly without needing to also read ``artifacts.yaml``.
 """
 
 from __future__ import annotations
@@ -88,11 +86,7 @@ class GeneratedSnap(BaseModel):
 
 
 class ArtifactsGenerated(BaseModel):
-    """Top-level schema for ``artifacts-generated.yaml`` (schema version 3).
-
-    Version 3 renames ``source`` to ``<tool>-yaml`` in all artifact entries
-    to align with the explicit yaml-file-path convention in ``artifacts.yaml``.
-    """
+    """Top-level schema for ``artifacts-generated.yaml`` (schema version 1)."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -70,6 +70,7 @@ class TestArtifactsBuild:
             "version: 1\ncharms:\n- name: mycharm\n"
             "  charmcraft-yaml: charmcraft.yaml\n",
         )
+        _write(tmp_path / "charmcraft.yaml", "name: mycharm\n")
         # Simulate charmcraft pack producing a .charm file
         _write(tmp_path / "mycharm_amd64.charm", "fake charm")
 
@@ -93,6 +94,7 @@ class TestArtifactsBuild:
         )
         rock_dir = tmp_path / "rock_dir"
         rock_dir.mkdir()
+        _write(rock_dir / "rockcraft.yaml", "name: myrock\n")
         _write(rock_dir / "myrock_1.0_amd64.rock", "fake rock")
 
         with patch("opcli.core.artifacts.run_command") as mock_run:
@@ -113,6 +115,7 @@ class TestArtifactsBuild:
         )
         snap_dir = tmp_path / "snap_dir"
         snap_dir.mkdir()
+        _write(snap_dir / "snapcraft.yaml", "name: mysnap\n")
         _write(snap_dir / "mysnap_1.0_amd64.snap", "fake snap")
 
         with patch("opcli.core.artifacts.run_command") as mock_run:
@@ -131,6 +134,7 @@ class TestArtifactsBuild:
             "- name: charm-b\n  charmcraft-yaml: b/charmcraft.yaml\n",
         )
         (tmp_path / "a").mkdir()
+        _write(tmp_path / "a" / "charmcraft.yaml", "name: charm-a\n")
         _write(tmp_path / "a" / "charm-a.charm", "fake")
 
         with patch("opcli.core.artifacts.run_command"):
@@ -154,7 +158,9 @@ class TestArtifactsBuild:
             "version: 1\nrocks:\n- name: myrock\n"
             "  rockcraft-yaml: rock_dir/rockcraft.yaml\n",
         )
-        (tmp_path / "rock_dir").mkdir()
+        rock_dir = tmp_path / "rock_dir"
+        rock_dir.mkdir()
+        _write(rock_dir / "rockcraft.yaml", "name: myrock\n")
 
         with (
             patch("opcli.core.artifacts.run_command"),
@@ -170,7 +176,9 @@ class TestArtifactsBuild:
             "charms:\n- name: mycharm\n  charmcraft-yaml: charmcraft.yaml\n",
         )
         (tmp_path / "rock_dir").mkdir()
+        _write(tmp_path / "rock_dir" / "rockcraft.yaml", "name: myrock\n")
         _write(tmp_path / "rock_dir" / "myrock.rock", "fake")
+        _write(tmp_path / "charmcraft.yaml", "name: mycharm\n")
         _write(tmp_path / "mycharm.charm", "fake")
 
         with patch("opcli.core.artifacts.run_command"):
@@ -192,7 +200,9 @@ class TestArtifactsBuild:
             "      rock: myrock\n",
         )
         (tmp_path / "rock_dir").mkdir()
+        _write(tmp_path / "rock_dir" / "rockcraft.yaml", "name: myrock\n")
         _write(tmp_path / "rock_dir" / "myrock_1.0_amd64.rock", "fake")
+        _write(tmp_path / "charmcraft.yaml", "name: mycharm\n")
         _write(tmp_path / "mycharm_amd64.charm", "fake")
 
         with patch("opcli.core.artifacts.run_command"):
@@ -220,6 +230,7 @@ class TestArtifactsBuild:
             "      type: oci-image\n"
             "      rock: nonexistent-rock\n",
         )
+        _write(tmp_path / "charmcraft.yaml", "name: mycharm\n")
         _write(tmp_path / "mycharm_amd64.charm", "fake")
 
         with patch("opcli.core.artifacts.run_command"):
@@ -323,3 +334,113 @@ class TestArtifactsBuild:
         assert not existing_symlink.exists()
         gen = load_artifacts_generated(result)
         assert gen.rocks[0].output.file is not None
+
+    def test_build_rock_nonstandard_yaml_name_creates_symlink(
+        self, tmp_path: Path
+    ) -> None:
+        """Non-standard yaml name (e.g. planner-rockcraft.yaml) always gets a symlink.
+
+        Even when pack-dir == dirname(yaml), rockcraft needs a file named
+        'rockcraft.yaml'. A non-standard name must be symlinked.
+        """
+        _write(tmp_path / "planner-rockcraft.yaml", "name: planner\n")
+        _write(tmp_path / "planner_1.0_amd64.rock", "fake rock")
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "rocks:\n- name: planner\n"
+            "  rockcraft-yaml: planner-rockcraft.yaml\n"
+            "  pack-dir: .\n",
+        )
+
+        symlink_seen: list[bool] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> None:
+            symlink = tmp_path / "rockcraft.yaml"
+            symlink_seen.append(symlink.is_symlink())
+
+        with patch("opcli.core.artifacts.run_command", side_effect=fake_run):
+            result = artifacts_build(tmp_path)
+
+        assert symlink_seen == [True], "symlink must exist while pack runs"
+        assert not (tmp_path / "rockcraft.yaml").exists(), "symlink removed after build"
+        gen = load_artifacts_generated(result)
+        assert gen.rocks[0].output.file is not None
+
+    def test_build_rock_standard_yaml_name_no_symlink(self, tmp_path: Path) -> None:
+        """When yaml is already named rockcraft.yaml in pack-dir, no symlink needed."""
+        _write(tmp_path / "rockcraft.yaml", "name: myrock\n")
+        _write(tmp_path / "myrock_1.0_amd64.rock", "fake rock")
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "rocks:\n- name: myrock\n"
+            "  rockcraft-yaml: rockcraft.yaml\n"
+            "  pack-dir: .\n",
+        )
+
+        symlink_created: list[bool] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> None:
+            symlink = tmp_path / "rockcraft.yaml"
+            symlink_created.append(symlink.is_symlink())
+
+        with patch("opcli.core.artifacts.run_command", side_effect=fake_run):
+            artifacts_build(tmp_path)
+
+        assert symlink_created == [False], "no symlink should be created"
+
+    def test_build_missing_yaml_raises(self, tmp_path: Path) -> None:
+        """Missing yaml file raises ConfigurationError before running pack."""
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\nrocks:\n- name: myrock\n"
+            "  rockcraft-yaml: nonexistent/rockcraft.yaml\n",
+        )
+
+        with (
+            patch("opcli.core.artifacts.run_command") as mock_run,
+            pytest.raises(ConfigurationError, match="rockcraft-yaml not found"),
+        ):
+            artifacts_build(tmp_path)
+
+        mock_run.assert_not_called()
+
+    def test_build_missing_pack_dir_raises(self, tmp_path: Path) -> None:
+        """Missing pack-dir raises ConfigurationError before running pack."""
+        _write(tmp_path / "rockcraft.yaml", "name: myrock\n")
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\nrocks:\n- name: myrock\n"
+            "  rockcraft-yaml: rockcraft.yaml\n"
+            "  pack-dir: nonexistent-dir\n",
+        )
+
+        with (
+            patch("opcli.core.artifacts.run_command") as mock_run,
+            pytest.raises(ConfigurationError, match="pack-dir not found"),
+        ):
+            artifacts_build(tmp_path)
+
+        mock_run.assert_not_called()
+
+    def test_pick_new_output_ambiguous_overwrite_raises(self, tmp_path: Path) -> None:
+        """Overwrite-in-place with multiple pre-existing files raises OpcliError."""
+        _write(tmp_path / "charmcraft.yaml", "name: mycharm\n")
+        # Pre-existing output files — build overwrites one but we can't tell which
+        _write(tmp_path / "mycharm_v1.charm", "old1")
+        _write(tmp_path / "mycharm_v2.charm", "old2")
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n- name: mycharm\n"
+            "  charmcraft-yaml: charmcraft.yaml\n",
+        )
+
+        with (
+            patch("opcli.core.artifacts.run_command"),
+            pytest.raises(OpcliError, match="Cannot determine which"),
+        ):
+            artifacts_build(tmp_path)

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -105,6 +106,20 @@ class TestAssemblePytestArgs:
         assert not any(a.startswith("--charm-file=") for a in args)
         # Rock image ref is embedded in the charm resources
         assert "--myrock-image=ghcr.io/canonical/myrock:abc123" in args
+
+    def test_ci_charm_logs_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """CI-format charm (artifact output only) emits a warning, no --charm-file."""
+        _write(tmp_path / "artifacts-generated.yaml", _GENERATED_CI)
+
+        with caplog.at_level(logging.WARNING, logger="opcli.core.pytest_args"):
+            args = assemble_pytest_args(tmp_path)
+
+        assert not any(a.startswith("--charm-file=") for a in args)
+        assert any("charm-mycharm" in msg for msg in caplog.messages), (
+            "expected warning mentioning the artifact name"
+        )
 
     def test_charm_without_resources(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts-generated.yaml", _GENERATED_NO_RESOURCES)


### PR DESCRIPTION
Fixes #54 and #55.

## Changes

- **Docstrings**: Remove stale v2/v3 references; all schemas are v1
- **`_with_rock_symlink` bug fix** (closes #54, #55): Always target `rockcraft.yaml` as the symlink name, regardless of the source yaml filename. Also fix early-exit condition: previously compared parent directories, now compares resolved target path to source path.
- **`_pick_new_output` logic**: Replaced ambiguous fallback with explicit 4-case logic: new files found → use them; empty result → error; single overwrite → accept; multiple ambiguous overwrites → raise `OpcliError`
- **yaml/pack-dir validation**: Check existence of both before invoking build tools, raising `ConfigurationError` with a clear message
- **CI-charm warning**: When `assemble_pytest_args` encounters a charm with only `artifact` output (CI format), emit a warning and skip it
- **`divergences.md`**: Fix stale v2/v1 version references