### PR TITLE
fix: use relative symlink in _with_rock_symlink

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import glob as globmod
 import logging
+import os
 from pathlib import Path
 
 from opcli.core.discovery import discover_artifacts
@@ -149,9 +150,13 @@ def _with_rock_symlink(
 
     Rockcraft always looks for a file literally named ``rockcraft.yaml`` in
     the working directory, regardless of the actual filename of the craft YAML.
-    This function creates ``<pack_dir>/rockcraft.yaml → yaml_path`` when the
-    source file is not already named ``rockcraft.yaml`` and located in
+    This function creates ``<pack_dir>/rockcraft.yaml → <relative-path>`` when
+    the source file is not already named ``rockcraft.yaml`` and located in
     ``pack_dir``.
+
+    The symlink target is always **relative** so that it remains valid when
+    rockcraft copies the pack-dir into a managed LXC container (where the
+    host absolute path does not exist).
 
     Returns ``(symlink_path, created)`` where *created* is ``True`` when this
     call created the symlink (and the caller must remove it afterwards).
@@ -173,7 +178,7 @@ def _with_rock_symlink(
         raise ConfigurationError(msg)
     if target.is_symlink():
         target.unlink()
-    target.symlink_to(yaml_path)
+    target.symlink_to(os.path.relpath(yaml_path, pack_dir))
     return target, True
 
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -355,15 +356,21 @@ class TestArtifactsBuild:
         )
 
         symlink_seen: list[bool] = []
+        symlink_target: list[str] = []
 
         def fake_run(cmd: list[str], **kwargs: object) -> None:
             symlink = tmp_path / "rockcraft.yaml"
             symlink_seen.append(symlink.is_symlink())
+            if symlink.is_symlink():
+                symlink_target.append(str(os.readlink(symlink)))
 
         with patch("opcli.core.artifacts.run_command", side_effect=fake_run):
             result = artifacts_build(tmp_path)
 
         assert symlink_seen == [True], "symlink must exist while pack runs"
+        assert symlink_target == ["planner-rockcraft.yaml"], (
+            "symlink target must be relative"
+        )
         assert not (tmp_path / "rockcraft.yaml").exists(), "symlink removed after build"
         gen = load_artifacts_generated(result)
         assert gen.rocks[0].output.file is not None


### PR DESCRIPTION
Closes #57. Also closes #55 (already fixed in #56 but not auto-closed).

## Problem

The symlink created by `_with_rock_symlink` used an absolute path as its target:

```
rockcraft.yaml -> /home/ubuntu/github-runner-operators/planner-rockcraft.yaml
```

When rockcraft runs in **managed mode**, it copies the pack-dir into the container at `/root/project`. The symlink is carried across but its absolute target doesn't exist inside the container, so rockcraft fails with:

```
Project file 'rockcraft.yaml' not found in '/root/project'.
```

## Fix

Use `os.path.relpath(yaml_path, pack_dir)` so the symlink target is relative:

```
rockcraft.yaml -> planner-rockcraft.yaml
```

This resolves correctly on the host and inside the container.