### PR TITLE
fix: update test and lint for node-wait and skip-registry changes

### DIFF
--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -227,7 +227,9 @@ def provision_registry(
     if gen_path.exists():
         generated = load_artifacts_generated(gen_path)
         if not generated.rocks:
-            logger.info("No rocks in %s, skipping registry setup.", _ARTIFACTS_GENERATED_YAML)
+            logger.info(
+                "No rocks in %s, skipping registry setup.", _ARTIFACTS_GENERATED_YAML
+            )
             return "skipped"
 
     # Quick TCP probe — skip if something is already listening.

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -295,12 +295,14 @@ class TestProvisionRegistry:
         ):
             result = provision_registry(tmp_path)
         assert result == "deployed"
-        # Two calls: kubectl apply + kubectl rollout status
-        call_count = 2
-        assert mock_run.call_count == call_count
-        apply_cmd = mock_run.call_args_list[0][0][0]
+        # Three calls: kubectl wait (node Ready) + kubectl apply + rollout status
+        assert mock_run.call_count == 3  # noqa: PLR2004
+        wait_cmd = mock_run.call_args_list[0][0][0]
+        assert wait_cmd[:2] == ["kubectl", "wait"]
+        assert "--for=condition=Ready" in wait_cmd
+        apply_cmd = mock_run.call_args_list[1][0][0]
         assert apply_cmd[:3] == ["kubectl", "apply", "-f"]
-        rollout_cmd = mock_run.call_args_list[1][0][0]
+        rollout_cmd = mock_run.call_args_list[2][0][0]
         assert "rollout" in rollout_cmd
         assert "status" in rollout_cmd
         assert "deployment/registry" in rollout_cmd


### PR DESCRIPTION
Fixes two CI failures introduced by recent commits on main:

**Lint failure** (commit `bdc844f`):
`provision.py:230` — `logger.info` line exceeded 88 chars. Wrapped to two lines.

**Test failure** (commit `8d96d2f`):
`test_k8s_provider_applies_manifest_and_waits` expected 2 `run_command` calls but got 3 after a `kubectl wait --for=condition=Ready node --all` call was added before the manifest apply. Updated the test to expect 3 calls and assert each one.