### PR TITLE
fix: unify registry deployment via kubectl manifest for k8s and microk8s

### DIFF
--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -7,25 +7,18 @@ and ``opcli provision registry``.
 OCI images into a container image registry so that Juju / MicroK8s can
 pull them during integration tests.
 
-``registry`` deploys a local OCI registry at ``localhost:32000`` by
-reading ``concierge.yaml`` to detect whether a k8s or MicroK8s provider
-is enabled, then either running ``microk8s enable registry`` or applying
-an embedded Kubernetes manifest.  This is a local-only operation — in CI
+``registry`` deploys a local OCI registry at ``localhost:32000`` using a
+Kubernetes manifest (``src/opcli/data/registry.yaml``).  The manifest works
+identically on both canonical k8s and MicroK8s — it creates a
+``container-registry`` namespace, a ``registry:2`` deployment, and a
+NodePort Service on port 32000.  This is a local-only operation — in CI
 images are served from GHCR.
-
-.. note::
-
-    For MicroK8s, ``microk8s enable registry`` also configures containerd
-    to trust ``localhost:32000`` as an insecure registry.  For canonical
-    k8s, you may need to configure containerd's insecure-registries
-    setting separately for workloads to pull from ``localhost:32000``.
 """
 
 from __future__ import annotations
 
 import logging
 import socket
-import tempfile
 from pathlib import Path
 
 from ruamel.yaml import YAML
@@ -41,53 +34,9 @@ _ARTIFACTS_GENERATED_YAML = "artifacts-generated.yaml"
 _DEFAULT_REGISTRY = "localhost:32000"
 _REGISTRY_PORT = 32000
 
-# Embedded manifest deploying a registry:2 pod on NodePort 32000.
-# Applied by ``provision_registry`` for canonical k8s environments.
-# MicroK8s uses ``microk8s enable registry`` instead (which also
-# configures containerd).
-_REGISTRY_MANIFEST = """\
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: registry
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: registry
-  namespace: registry
-  labels:
-    app: registry
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: registry
-  template:
-    metadata:
-      labels:
-        app: registry
-    spec:
-      containers:
-      - name: registry
-        image: registry:2
-        ports:
-        - containerPort: 5000
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: registry
-  namespace: registry
-spec:
-  type: NodePort
-  selector:
-    app: registry
-  ports:
-  - port: 5000
-    targetPort: 5000
-    nodePort: 32000
-"""
+_REGISTRY_YAML = Path(__file__).parent.parent / "data" / "registry.yaml"
+_REGISTRY_DEPLOYMENT = "deployment/registry"
+_REGISTRY_NAMESPACE = "container-registry"
 
 
 def provision_run(
@@ -201,20 +150,20 @@ def provision_registry(
 ) -> str:
     """Deploy a local OCI registry at ``localhost:32000``.
 
-    Reads *concierge_file* to detect which k8s provider is active, then
-    either runs ``microk8s enable registry`` (MicroK8s) or applies an
-    embedded Kubernetes manifest (canonical k8s).
+    Reads *concierge_file* to detect whether a k8s or MicroK8s provider is
+    present, then applies ``src/opcli/data/registry.yaml`` via ``kubectl``.
+    The same manifest works on both canonical k8s and MicroK8s.
 
     Returns:
         ``"deployed"``       — the registry was just provisioned.
         ``"already_running"``— a service is already listening on port 32000;
                                nothing was changed.
-        ``"skipped"``        — no k8s provider is enabled; nothing to do.
+        ``"skipped"``        — no k8s provider is configured; nothing to do.
 
     Raises:
-        ConfigurationError: If both microk8s and k8s providers are enabled
+        ConfigurationError: If both microk8s and k8s providers are configured
             simultaneously.
-        SubprocessError: If the underlying kubectl or microk8s command fails.
+        SubprocessError: If the underlying kubectl command fails.
     """
     concierge_path = root / concierge_file
     if not concierge_path.exists():
@@ -250,7 +199,9 @@ def provision_registry(
         entry = providers.get(name)
         if not isinstance(entry, dict):
             return False
-        return bool(entry.get("enable", False))
+        # A provider listed under providers: is enabled by default;
+        # an explicit enable: false can opt it out.
+        return bool(entry.get("enable", True))
 
     microk8s_on = _provider_enabled("microk8s")
     k8s_on = _provider_enabled("k8s")
@@ -269,36 +220,29 @@ def provision_registry(
         )
         return "skipped"
 
-    if microk8s_on:
-        run_command(["microk8s", "enable", "registry"])
-    else:
-        # Wait for at least one node to be Ready before deploying — freshly
-        # bootstrapped clusters (e.g. in nested LXD) can take a while to
-        # schedule pods.
-        run_command(
-            [
-                "kubectl",
-                "wait",
-                "--for=condition=Ready",
-                "node",
-                "--all",
-                "--timeout=300s",
-            ]
-        )
-        with tempfile.TemporaryDirectory() as tmpdir:
-            manifest_path = Path(tmpdir) / "registry-manifest.yaml"
-            manifest_path.write_text(_REGISTRY_MANIFEST)
-            run_command(["kubectl", "apply", "-f", str(manifest_path)])
-        run_command(
-            [
-                "kubectl",
-                "rollout",
-                "status",
-                "deployment/registry",
-                "-n",
-                "registry",
-                "--timeout=300s",
-            ]
-        )
+    # Wait for at least one node to be Ready before deploying — freshly
+    # bootstrapped clusters (e.g. in nested LXD) can take a while.
+    run_command(
+        [
+            "kubectl",
+            "wait",
+            "--for=condition=Ready",
+            "node",
+            "--all",
+            "--timeout=300s",
+        ]
+    )
+    run_command(["kubectl", "apply", "-f", str(_REGISTRY_YAML)])
+    run_command(
+        [
+            "kubectl",
+            "rollout",
+            "status",
+            _REGISTRY_DEPLOYMENT,
+            "-n",
+            _REGISTRY_NAMESPACE,
+            "--timeout=300s",
+        ]
+    )
 
     return "deployed"

--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -220,22 +220,19 @@ def provision_registry(
         )
         return "skipped"
 
+    # Use the provider-specific kubectl — MicroK8s and canonical k8s both
+    # bundle their own kubectl rather than relying on a separate install.
+    kubectl = ["microk8s", "kubectl"] if microk8s_on else ["k8s", "kubectl"]
+
     # Wait for at least one node to be Ready before deploying — freshly
     # bootstrapped clusters (e.g. in nested LXD) can take a while.
     run_command(
-        [
-            "kubectl",
-            "wait",
-            "--for=condition=Ready",
-            "node",
-            "--all",
-            "--timeout=300s",
-        ]
+        [*kubectl, "wait", "--for=condition=Ready", "node", "--all", "--timeout=300s"]
     )
-    run_command(["kubectl", "apply", "-f", str(_REGISTRY_YAML)])
+    run_command([*kubectl, "apply", "-f", str(_REGISTRY_YAML)])
     run_command(
         [
-            "kubectl",
+            *kubectl,
             "rollout",
             "status",
             _REGISTRY_DEPLOYMENT,

--- a/src/opcli/data/registry.yaml
+++ b/src/opcli/data/registry.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: container-registry
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: registry-claim
+  namespace: container-registry
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1G
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: registry
+  name: registry
+  namespace: container-registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+        - name: registry
+          image: registry:2.8.3
+          env:
+            - name: REGISTRY_HTTP_ADDR
+              value: :5000
+            - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+              value: /var/lib/registry
+            - name: REGISTRY_STORAGE_DELETE_ENABLED
+              value: "yes"
+          ports:
+            - containerPort: 5000
+              name: registry
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /var/lib/registry
+              name: registry-data
+      volumes:
+        - name: registry-data
+          persistentVolumeClaim:
+            claimName: registry-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: registry
+  name: registry
+  namespace: container-registry
+spec:
+  type: NodePort
+  selector:
+    app: registry
+  ports:
+    - name: "registry"
+      port: 5000
+      targetPort: 5000
+      nodePort: 32000
+---
+# https://github.com/kubernetes/enhancements/issues/1755
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    help: "https://microk8s.io/docs/registry-built-in"
+    host: "localhost:32000"

--- a/src/opcli/data/registry.yaml
+++ b/src/opcli/data/registry.yaml
@@ -4,19 +4,6 @@ kind: Namespace
 metadata:
   name: container-registry
 ---
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: registry-claim
-  namespace: container-registry
-spec:
-  accessModes:
-    - ReadWriteOnce
-  volumeMode: Filesystem
-  resources:
-    requests:
-      storage: 1G
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,8 +40,7 @@ spec:
               name: registry-data
       volumes:
         - name: registry-data
-          persistentVolumeClaim:
-            claimName: registry-claim
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: Service

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -252,6 +252,13 @@ providers:
     channel: 3.6/stable
 """
 
+_CONCIERGE_MICROK8S_DISABLED = """\
+providers:
+  microk8s:
+    enable: false
+    channel: 1.34-strict/stable
+"""
+
 
 class TestProvisionRegistry:
     """Tests for provision_registry()."""
@@ -264,6 +271,17 @@ class TestProvisionRegistry:
 
     def test_skipped_when_no_k8s_provider(self, tmp_path: Path) -> None:
         _write(tmp_path / "concierge.yaml", _CONCIERGE_NEITHER)
+        with (
+            patch("opcli.core.provision._is_port_open", return_value=False),
+            patch("opcli.core.provision.run_command") as mock_run,
+        ):
+            result = provision_registry(tmp_path)
+        assert result == "skipped"
+        mock_run.assert_not_called()
+
+    def test_skipped_when_provider_explicitly_disabled(self, tmp_path: Path) -> None:
+        """enable: false in concierge.yaml opts the provider out."""
+        _write(tmp_path / "concierge.yaml", _CONCIERGE_MICROK8S_DISABLED)
         with (
             patch("opcli.core.provision._is_port_open", return_value=False),
             patch("opcli.core.provision.run_command") as mock_run,
@@ -290,11 +308,20 @@ class TestProvisionRegistry:
         ):
             result = provision_registry(tmp_path)
         assert result == "deployed"
-        # Three calls: kubectl wait + kubectl apply + rollout status
+        # Three calls: microk8s kubectl wait + apply + rollout status
         assert mock_run.call_count == 3  # noqa: PLR2004
-        assert mock_run.call_args_list[0][0][0][:2] == ["kubectl", "wait"]
-        assert mock_run.call_args_list[1][0][0][:3] == ["kubectl", "apply", "-f"]
-        assert "rollout" in mock_run.call_args_list[2][0][0]
+        assert mock_run.call_args_list[0][0][0][:3] == ["microk8s", "kubectl", "wait"]
+        assert mock_run.call_args_list[1][0][0][:4] == [
+            "microk8s",
+            "kubectl",
+            "apply",
+            "-f",
+        ]
+        assert mock_run.call_args_list[2][0][0][:3] == [
+            "microk8s",
+            "kubectl",
+            "rollout",
+        ]
 
     def test_provider_enabled_without_explicit_enable_key(self, tmp_path: Path) -> None:
         """Provider listed without enable: key should be treated as enabled."""
@@ -315,15 +342,15 @@ class TestProvisionRegistry:
         ):
             result = provision_registry(tmp_path)
         assert result == "deployed"
-        # Three calls: kubectl wait (node Ready) + kubectl apply + rollout status
+        # Three calls: k8s kubectl wait + apply + rollout status
         assert mock_run.call_count == 3  # noqa: PLR2004
         wait_cmd = mock_run.call_args_list[0][0][0]
-        assert wait_cmd[:2] == ["kubectl", "wait"]
+        assert wait_cmd[:3] == ["k8s", "kubectl", "wait"]
         assert "--for=condition=Ready" in wait_cmd
         apply_cmd = mock_run.call_args_list[1][0][0]
-        assert apply_cmd[:3] == ["kubectl", "apply", "-f"]
+        assert apply_cmd[:4] == ["k8s", "kubectl", "apply", "-f"]
         rollout_cmd = mock_run.call_args_list[2][0][0]
-        assert "rollout" in rollout_cmd
+        assert rollout_cmd[:3] == ["k8s", "kubectl", "rollout"]
         assert "status" in rollout_cmd
         assert "deployment/registry" in rollout_cmd
         assert "container-registry" in rollout_cmd

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -231,6 +231,13 @@ providers:
     channel: 1.31/stable
 """
 
+# Provider listed without explicit enable: key — should be treated as enabled.
+_CONCIERGE_MICROK8S_NO_ENABLE = """\
+providers:
+  microk8s:
+    channel: 1.34-strict/stable
+"""
+
 _CONCIERGE_BOTH = """\
 providers:
   microk8s:
@@ -275,7 +282,7 @@ class TestProvisionRegistry:
         assert result == "already_running"
         mock_run.assert_not_called()
 
-    def test_microk8s_provider_uses_microk8s_enable(self, tmp_path: Path) -> None:
+    def test_microk8s_provider_applies_manifest(self, tmp_path: Path) -> None:
         _write(tmp_path / "concierge.yaml", _CONCIERGE_MICROK8S)
         with (
             patch("opcli.core.provision._is_port_open", return_value=False),
@@ -283,9 +290,22 @@ class TestProvisionRegistry:
         ):
             result = provision_registry(tmp_path)
         assert result == "deployed"
-        assert mock_run.call_count == 1
-        cmd = mock_run.call_args[0][0]
-        assert cmd == ["microk8s", "enable", "registry"]
+        # Three calls: kubectl wait + kubectl apply + rollout status
+        assert mock_run.call_count == 3  # noqa: PLR2004
+        assert mock_run.call_args_list[0][0][0][:2] == ["kubectl", "wait"]
+        assert mock_run.call_args_list[1][0][0][:3] == ["kubectl", "apply", "-f"]
+        assert "rollout" in mock_run.call_args_list[2][0][0]
+
+    def test_provider_enabled_without_explicit_enable_key(self, tmp_path: Path) -> None:
+        """Provider listed without enable: key should be treated as enabled."""
+        _write(tmp_path / "concierge.yaml", _CONCIERGE_MICROK8S_NO_ENABLE)
+        with (
+            patch("opcli.core.provision._is_port_open", return_value=False),
+            patch("opcli.core.provision.run_command") as mock_run,
+        ):
+            result = provision_registry(tmp_path)
+        assert result == "deployed"
+        mock_run.assert_called()
 
     def test_k8s_provider_applies_manifest_and_waits(self, tmp_path: Path) -> None:
         _write(tmp_path / "concierge.yaml", _CONCIERGE_K8S)
@@ -306,6 +326,7 @@ class TestProvisionRegistry:
         assert "rollout" in rollout_cmd
         assert "status" in rollout_cmd
         assert "deployment/registry" in rollout_cmd
+        assert "container-registry" in rollout_cmd
 
     def test_both_providers_raises(self, tmp_path: Path) -> None:
         _write(tmp_path / "concierge.yaml", _CONCIERGE_BOTH)
@@ -323,17 +344,16 @@ class TestProvisionRegistry:
         ):
             result = provision_registry(tmp_path, concierge_file="my-concierge.yaml")
         assert result == "deployed"
-        mock_run.assert_called_once()
+        mock_run.assert_called()
 
     def test_k8s_manifest_contains_registry_image(self, tmp_path: Path) -> None:
-        """Verify the embedded manifest references the registry:2 image."""
+        """Verify the registry.yaml file references registry:2 on NodePort 32000."""
         _write(tmp_path / "concierge.yaml", _CONCIERGE_K8S)
-        applied_files: list[str] = []
+        applied_paths: list[str] = []
 
         def capture_apply(cmd: list[str], **_kwargs: object) -> object:
             if "apply" in cmd:
-                manifest_path = cmd[cmd.index("-f") + 1]
-                applied_files.append(Path(manifest_path).read_text())
+                applied_paths.append(cmd[cmd.index("-f") + 1])
             return None
 
         with (
@@ -342,9 +362,11 @@ class TestProvisionRegistry:
         ):
             provision_registry(tmp_path)
 
-        assert applied_files, "apply was not called"
-        assert "registry:2" in applied_files[0]
-        assert "nodePort: 32000" in applied_files[0]
+        assert applied_paths, "apply was not called"
+        content = Path(applied_paths[0]).read_text()
+        assert "registry:2" in content
+        assert "nodePort: 32000" in content
+        assert "container-registry" in content
 
     def test_malformed_providers_field_skips_gracefully(self, tmp_path: Path) -> None:
         """Non-dict providers field should not crash."""


### PR DESCRIPTION
Closes #60, #61, #62.

## Changes

**Unified registry deployment** — removes the microk8s-specific `microk8s enable registry` path. Both MicroK8s and canonical k8s now use the same approach:
1. `kubectl wait --for=condition=Ready node --all`
2. `kubectl apply -f src/opcli/data/registry.yaml`
3. `kubectl rollout status deployment/registry -n container-registry`

**`src/opcli/data/registry.yaml`** — new file (from `canonical/spring-petclinic`), deploying `registry:2.8.3` on NodePort 32000 in namespace `container-registry`. No more embedded string or temp files.

**Fix `_provider_enabled` default** (#60) — changed `entry.get("enable", False)` → `entry.get("enable", True)`. A provider listed under `providers:` in `concierge.yaml` is now treated as enabled by default, matching concierge's own semantics. Explicit `enable: false` still opts it out.