### PR TITLE
fix(provision): pipe registry manifest via stdin to avoid snap path restrictions

### DIFF
--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -229,7 +229,7 @@ def provision_registry(
     run_command(
         [*kubectl, "wait", "--for=condition=Ready", "node", "--all", "--timeout=300s"]
     )
-    run_command([*kubectl, "apply", "-f", str(_REGISTRY_YAML)])
+    run_command([*kubectl, "apply", "-f", "-"], stdin=_REGISTRY_YAML.read_text())
     run_command(
         [
             *kubectl,

--- a/src/opcli/core/subprocess.py
+++ b/src/opcli/core/subprocess.py
@@ -189,6 +189,7 @@ def _run_streaming(
     # Write stdin in a dedicated thread so the main thread remains free to
     # enforce the timeout and reader threads can drain stdout/stderr
     # concurrently, preventing deadlocks.
+    in_thread: threading.Thread | None = None
     if stdin is not None and proc.stdin is not None:
         in_thread = threading.Thread(
             target=_write_stdin,
@@ -203,6 +204,8 @@ def _run_streaming(
         proc.kill()
         out_thread.join(timeout=2)
         err_thread.join(timeout=2)
+        if in_thread is not None:
+            in_thread.join(timeout=2)
         partial = "".join(stderr_lines)
         raise SubprocessError(
             cmd=cmd,
@@ -212,6 +215,8 @@ def _run_streaming(
 
     out_thread.join()
     err_thread.join()
+    if in_thread is not None:
+        in_thread.join()
 
     result = SubprocessResult(
         stdout="".join(stdout_lines),

--- a/src/opcli/core/subprocess.py
+++ b/src/opcli/core/subprocess.py
@@ -45,6 +45,20 @@ def _stream_pipe(
         dest.flush()
 
 
+def _write_stdin(pipe: io.TextIOWrapper, data: str) -> None:
+    """Write *data* to *pipe* and close it.
+
+    ``BrokenPipeError`` and ``ValueError`` are silently swallowed — they
+    mean the subprocess closed its stdin early, which is normal for commands
+    that consume all their input before exiting.
+    """
+    try:
+        pipe.write(data)
+        pipe.close()
+    except (BrokenPipeError, ValueError):
+        pass
+
+
 def run_command(  # noqa: PLR0913
     cmd: list[str],
     *,
@@ -53,6 +67,7 @@ def run_command(  # noqa: PLR0913
     check: bool = True,
     stream: bool = True,
     interactive: bool = False,
+    stdin: str | None = None,
 ) -> SubprocessResult:
     """Execute *cmd* and return captured output.
 
@@ -70,16 +85,24 @@ def run_command(  # noqa: PLR0913
         interactive: If ``True``, inherit the parent's stdin/stdout/stderr
             so the subprocess has full TTY access. Required for commands
             like ``spread -shell``. Output is not captured in this mode.
+            Cannot be combined with *stdin*.
+        stdin: Optional string to feed to the subprocess's standard input.
+            Useful for commands that read from stdin (e.g. ``kubectl apply
+            -f -``). Cannot be combined with *interactive*.
 
     Raises:
         SubprocessError: If the command fails and *check* is ``True``.
+        ValueError: If both *interactive* and *stdin* are provided.
 
     """
+    if interactive and stdin is not None:
+        msg = "'interactive' and 'stdin' are mutually exclusive"
+        raise ValueError(msg)
     if interactive:
         return _run_interactive(cmd, cwd=cwd, check=check)
     if stream:
-        return _run_streaming(cmd, cwd=cwd, timeout=timeout, check=check)
-    return _run_captured(cmd, cwd=cwd, timeout=timeout, check=check)
+        return _run_streaming(cmd, cwd=cwd, timeout=timeout, check=check, stdin=stdin)
+    return _run_captured(cmd, cwd=cwd, timeout=timeout, check=check, stdin=stdin)
 
 
 def _log_command(cmd: list[str], cwd: str | None) -> None:
@@ -124,6 +147,7 @@ def _run_streaming(
     cwd: str | None = None,
     timeout: int = _DEFAULT_TIMEOUT_SECONDS,
     check: bool = True,
+    stdin: str | None = None,
 ) -> SubprocessResult:
     """Run *cmd* with real-time output to the terminal."""
     _log_command(cmd, cwd)
@@ -132,6 +156,7 @@ def _run_streaming(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            stdin=subprocess.PIPE if stdin is not None else None,
             text=True,
             cwd=cwd,
         )
@@ -160,6 +185,17 @@ def _run_streaming(
     )
     out_thread.start()
     err_thread.start()
+
+    # Write stdin in a dedicated thread so the main thread remains free to
+    # enforce the timeout and reader threads can drain stdout/stderr
+    # concurrently, preventing deadlocks.
+    if stdin is not None and proc.stdin is not None:
+        in_thread = threading.Thread(
+            target=_write_stdin,
+            args=(proc.stdin, stdin),
+            daemon=True,
+        )
+        in_thread.start()
 
     try:
         proc.wait(timeout=timeout)
@@ -199,6 +235,7 @@ def _run_captured(
     cwd: str | None = None,
     timeout: int = _DEFAULT_TIMEOUT_SECONDS,
     check: bool = True,
+    stdin: str | None = None,
 ) -> SubprocessResult:
     """Run *cmd* with fully buffered output (no terminal echo)."""
     _log_command(cmd, cwd)
@@ -210,6 +247,7 @@ def _run_captured(
             cwd=cwd,
             timeout=timeout,
             check=False,
+            input=stdin,
         )
     except subprocess.TimeoutExpired as exc:
         partial_err = exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -311,12 +311,9 @@ class TestProvisionRegistry:
         # Three calls: microk8s kubectl wait + apply + rollout status
         assert mock_run.call_count == 3  # noqa: PLR2004
         assert mock_run.call_args_list[0][0][0][:3] == ["microk8s", "kubectl", "wait"]
-        assert mock_run.call_args_list[1][0][0][:4] == [
-            "microk8s",
-            "kubectl",
-            "apply",
-            "-f",
-        ]
+        apply_call = mock_run.call_args_list[1]
+        assert apply_call[0][0] == ["microk8s", "kubectl", "apply", "-f", "-"]
+        assert apply_call[1]["stdin"]  # manifest content passed via stdin
         assert mock_run.call_args_list[2][0][0][:3] == [
             "microk8s",
             "kubectl",
@@ -347,8 +344,9 @@ class TestProvisionRegistry:
         wait_cmd = mock_run.call_args_list[0][0][0]
         assert wait_cmd[:3] == ["k8s", "kubectl", "wait"]
         assert "--for=condition=Ready" in wait_cmd
-        apply_cmd = mock_run.call_args_list[1][0][0]
-        assert apply_cmd[:4] == ["k8s", "kubectl", "apply", "-f"]
+        apply_call = mock_run.call_args_list[1]
+        assert apply_call[0][0] == ["k8s", "kubectl", "apply", "-f", "-"]
+        assert apply_call[1]["stdin"]  # manifest content passed via stdin
         rollout_cmd = mock_run.call_args_list[2][0][0]
         assert rollout_cmd[:3] == ["k8s", "kubectl", "rollout"]
         assert "status" in rollout_cmd
@@ -374,13 +372,15 @@ class TestProvisionRegistry:
         mock_run.assert_called()
 
     def test_k8s_manifest_contains_registry_image(self, tmp_path: Path) -> None:
-        """Verify the registry.yaml file references registry:2 on NodePort 32000."""
+        """Verify the registry.yaml manifest references registry:2 on NodePort 32000."""
         _write(tmp_path / "concierge.yaml", _CONCIERGE_K8S)
-        applied_paths: list[str] = []
+        applied_stdin: list[str] = []
 
-        def capture_apply(cmd: list[str], **_kwargs: object) -> object:
+        def capture_apply(cmd: list[str], **kwargs: object) -> object:
             if "apply" in cmd:
-                applied_paths.append(cmd[cmd.index("-f") + 1])
+                stdin_content = kwargs.get("stdin")
+                if isinstance(stdin_content, str):
+                    applied_stdin.append(stdin_content)
             return None
 
         with (
@@ -389,8 +389,8 @@ class TestProvisionRegistry:
         ):
             provision_registry(tmp_path)
 
-        assert applied_paths, "apply was not called"
-        content = Path(applied_paths[0]).read_text()
+        assert applied_stdin, "apply was not called with stdin"
+        content = applied_stdin[0]
         assert "registry:2" in content
         assert "nodePort: 32000" in content
         assert "container-registry" in content

--- a/tests/unit/test_subprocess.py
+++ b/tests/unit/test_subprocess.py
@@ -1,0 +1,62 @@
+"""Tests for the central subprocess wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from opcli.core.exceptions import SubprocessError
+from opcli.core.subprocess import run_command
+
+
+class TestStdinCaptured:
+    """stdin forwarding in captured (non-streaming) mode."""
+
+    def test_stdin_piped_to_process(self) -> None:
+        result = run_command(
+            ["cat"],
+            stream=False,
+            stdin="hello from stdin\n",
+        )
+        assert result.stdout == "hello from stdin\n"
+        assert result.returncode == 0
+
+    def test_stdin_none_is_harmless(self) -> None:
+        result = run_command(["echo", "ok"], stream=False, stdin=None)
+        assert "ok" in result.stdout
+        assert result.returncode == 0
+
+
+class TestStdinStreaming:
+    """stdin forwarding in streaming (real-time) mode."""
+
+    def test_stdin_piped_to_process(self) -> None:
+        result = run_command(
+            ["cat"],
+            stream=True,
+            stdin="streamed input\n",
+        )
+        assert result.stdout == "streamed input\n"
+        assert result.returncode == 0
+
+    def test_stdin_none_is_harmless(self) -> None:
+        result = run_command(["echo", "ok"], stream=True, stdin=None)
+        assert "ok" in result.stdout
+        assert result.returncode == 0
+
+    def test_broken_pipe_does_not_raise_from_writer_thread(self) -> None:
+        """Commands that close stdin early must not crash the wrapper."""
+        # `true` exits immediately without reading stdin — triggers BrokenPipeError.
+        result = run_command(["true"], stream=True, stdin="ignored input")
+        assert result.returncode == 0
+
+    def test_failed_command_raises_subprocess_error(self) -> None:
+        with pytest.raises(SubprocessError):
+            run_command(["false"], stream=True, stdin="some input")
+
+
+class TestInteractiveMutualExclusion:
+    """interactive and stdin are mutually exclusive."""
+
+    def test_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            run_command(["echo", "hi"], interactive=True, stdin="hello")


### PR DESCRIPTION
Fixes #65

## Problem

MicroK8s strict snap confinement blocks file access to paths outside its snap directories (e.g. `/opt/pipx/venvs/opcli/...`). Calling `kubectl apply -f /path/to/registry.yaml` fails when opcli is installed via pipx.

## Solution

Pass the manifest content via stdin using `kubectl apply -f -`. This bypasses path restrictions entirely.

## Changes

### `subprocess.py`
- Added `stdin: str | None = None` parameter to `run_command`, `_run_streaming`, `_run_captured`
- In streaming mode: uses a dedicated **writer thread** so stdin writing never blocks the main thread or the timeout mechanism
- Writer thread catches `BrokenPipeError`/`ValueError` silently (subprocess closed stdin early = normal)
- `_run_captured`: passes `input=stdin` to `subprocess.run` (trivial)
- `interactive=True` + `stdin` raises `ValueError` (mutually exclusive)

### `provision.py`
- `run_command([*kubectl, "apply", "-f", "-"], stdin=_REGISTRY_YAML.read_text())`

### `tests/unit/test_subprocess.py` (new)
- Captured mode: stdin piped correctly
- Streaming mode: stdin piped correctly, broken pipe handled, failed command raises
- Interactive+stdin mutual exclusion

### `tests/unit/test_provision.py`
- Updated `test_microk8s_provider_applies_manifest` and `test_k8s_provider_applies_manifest_and_waits`: assert command ends in `"-"` and `stdin` kwarg is set
- Updated `test_k8s_manifest_contains_registry_image`: capture stdin content instead of reading from file path