### PR TITLE
fix(artifacts): prefix output.file paths with ./ to disambiguate local paths

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -126,10 +126,15 @@ def _pick_new_output(
 
 
 def _relative_to_root(path_str: str, root: Path) -> str:
-    """Return *path_str* as a relative path from *root*."""
+    """Return *path_str* as a ``./``-prefixed relative path from *root*.
+
+    The ``./`` prefix makes the path unambiguously local (required by Juju
+    when distinguishing a local charm/rock from a CharmHub reference).
+    """
     resolved = Path(path_str).resolve()
     try:
-        return str(resolved.relative_to(root.resolve()))
+        rel = str(resolved.relative_to(root.resolve()))
+        return f"./{rel}"
     except ValueError as exc:
         msg = f"Built artifact {resolved} is outside repository root {root}"
         raise OpcliError(msg) from exc

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -84,8 +84,8 @@ class TestArtifactsBuild:
         assert len(gen.charms) == 1
         assert gen.charms[0].name == "mycharm"
         assert gen.charms[0].output.file is not None
+        assert gen.charms[0].output.file.startswith("./")
         assert gen.charms[0].output.file.endswith(".charm")
-        assert not Path(gen.charms[0].output.file).is_absolute()
 
     def test_build_single_rock(self, tmp_path: Path) -> None:
         _write(
@@ -106,7 +106,7 @@ class TestArtifactsBuild:
         gen = load_artifacts_generated(result)
         assert len(gen.rocks) == 1
         assert gen.rocks[0].output.file is not None
-        assert not Path(gen.rocks[0].output.file).is_absolute()
+        assert gen.rocks[0].output.file.startswith("./")
 
     def test_build_single_snap(self, tmp_path: Path) -> None:
         _write(
@@ -217,8 +217,8 @@ class TestArtifactsBuild:
         assert res.type == "oci-image"
         assert res.rock == "myrock"
         assert res.file is not None
+        assert res.file.startswith("./")
         assert "myrock_1.0_amd64.rock" in res.file
-        assert not Path(res.file).is_absolute()
 
     def test_resource_unresolved_when_rock_not_built(self, tmp_path: Path) -> None:
         """Resource referencing a rock not in artifacts.yaml has unresolved output."""


### PR DESCRIPTION
Fixes #67

## Problem

`opcli artifacts build` wrote paths like `charms/foo/foo_amd64.charm` into `artifacts-generated.yaml`. When `opcli pytest args` emitted `--charm-file=charms/foo/foo_amd64.charm`, Juju rejected it:

```
ERROR The charm or bundle "charms/foo/foo_amd64.charm" is ambiguous.
To deploy a local charm or bundle, run `juju deploy ./charms/foo/...`
```

## Fix

Normalize paths at **write time** in `_relative_to_root()` — the single function in `artifacts.py` that converts all built artifact paths before writing to `artifacts-generated.yaml`. Prepend `./` so paths are unambiguously local.

This covers all artifact types: charms, rocks, snaps, and OCI-image resource `file` references propagated from rocks.

Every downstream consumer benefits automatically:
- `pytest_args.py` — `--charm-file` and `--{resource}` flags
- `provision load` — skopeo calls (accepts `./`-prefixed paths)

## Note

Users with existing `artifacts-generated.yaml` files must rerun `opcli artifacts build` to get the corrected paths.