### PR TITLE
feat(artifacts): always set ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS for rockcraft pack

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -45,6 +45,8 @@ _PACK_COMMANDS: dict[str, list[str]] = {
     "snap": ["snapcraft", "pack"],
 }
 
+_ROCKCRAFT_ENV = {"ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS": "1"}
+
 _OUTPUT_GLOBS: dict[str, str] = {
     "charm": "*.charm",
     "rock": "*.rock",
@@ -201,7 +203,7 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
 
     symlink_path, symlink_created = _with_rock_symlink(yaml_path, pack_dir)
     try:
-        run_command([*_PACK_COMMANDS["rock"]], cwd=str(pack_dir))
+        run_command([*_PACK_COMMANDS["rock"]], cwd=str(pack_dir), env=_ROCKCRAFT_ENV)
     finally:
         if symlink_created and symlink_path and symlink_path.exists():
             symlink_path.unlink()

--- a/src/opcli/core/subprocess.py
+++ b/src/opcli/core/subprocess.py
@@ -11,6 +11,7 @@ failures can be reproduced manually by copy-pasting from the output.
 from __future__ import annotations
 
 import io
+import os
 import shlex
 import subprocess
 import sys
@@ -68,6 +69,7 @@ def run_command(  # noqa: PLR0913
     stream: bool = True,
     interactive: bool = False,
     stdin: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> SubprocessResult:
     """Execute *cmd* and return captured output.
 
@@ -89,6 +91,10 @@ def run_command(  # noqa: PLR0913
         stdin: Optional string to feed to the subprocess's standard input.
             Useful for commands that read from stdin (e.g. ``kubectl apply
             -f -``). Cannot be combined with *interactive*.
+        env: Optional extra environment variables to overlay on top of the
+            current process environment.  The subprocess inherits all of
+            ``os.environ``; any key in *env* overrides the corresponding
+            inherited value.
 
     Raises:
         SubprocessError: If the command fails and *check* is ``True``.
@@ -98,11 +104,16 @@ def run_command(  # noqa: PLR0913
     if interactive and stdin is not None:
         msg = "'interactive' and 'stdin' are mutually exclusive"
         raise ValueError(msg)
+    merged_env = {**os.environ, **env} if env else None
     if interactive:
-        return _run_interactive(cmd, cwd=cwd, check=check)
+        return _run_interactive(cmd, cwd=cwd, check=check, env=merged_env)
     if stream:
-        return _run_streaming(cmd, cwd=cwd, timeout=timeout, check=check, stdin=stdin)
-    return _run_captured(cmd, cwd=cwd, timeout=timeout, check=check, stdin=stdin)
+        return _run_streaming(
+            cmd, cwd=cwd, timeout=timeout, check=check, stdin=stdin, env=merged_env
+        )
+    return _run_captured(
+        cmd, cwd=cwd, timeout=timeout, check=check, stdin=stdin, env=merged_env
+    )
 
 
 def _log_command(cmd: list[str], cwd: str | None) -> None:
@@ -117,11 +128,12 @@ def _run_interactive(
     *,
     cwd: str | None = None,
     check: bool = True,
+    env: dict[str, str] | None = None,
 ) -> SubprocessResult:
     """Run *cmd* with inherited stdin/stdout/stderr for full TTY access."""
     _log_command(cmd, cwd)
     try:
-        proc = subprocess.run(cmd, cwd=cwd, check=False)
+        proc = subprocess.run(cmd, cwd=cwd, check=False, env=env)
     except OSError as exc:
         raise SubprocessError(
             cmd=cmd,
@@ -141,13 +153,14 @@ def _run_interactive(
     return result
 
 
-def _run_streaming(
+def _run_streaming(  # noqa: PLR0913
     cmd: list[str],
     *,
     cwd: str | None = None,
     timeout: int = _DEFAULT_TIMEOUT_SECONDS,
     check: bool = True,
     stdin: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> SubprocessResult:
     """Run *cmd* with real-time output to the terminal."""
     _log_command(cmd, cwd)
@@ -159,6 +172,7 @@ def _run_streaming(
             stdin=subprocess.PIPE if stdin is not None else None,
             text=True,
             cwd=cwd,
+            env=env,
         )
     except OSError as exc:
         raise SubprocessError(
@@ -234,13 +248,14 @@ def _run_streaming(
     return result
 
 
-def _run_captured(
+def _run_captured(  # noqa: PLR0913
     cmd: list[str],
     *,
     cwd: str | None = None,
     timeout: int = _DEFAULT_TIMEOUT_SECONDS,
     check: bool = True,
     stdin: str | None = None,
+    env: dict[str, str] | None = None,
 ) -> SubprocessResult:
     """Run *cmd* with fully buffered output (no terminal echo)."""
     _log_command(cmd, cwd)
@@ -253,6 +268,7 @@ def _run_captured(
             timeout=timeout,
             check=False,
             input=stdin,
+            env=env,
         )
     except subprocess.TimeoutExpired as exc:
         partial_err = exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -108,6 +108,27 @@ class TestArtifactsBuild:
         assert gen.rocks[0].output.file is not None
         assert gen.rocks[0].output.file.startswith("./")
 
+    def test_build_rock_sets_experimental_extensions_env(
+        self, tmp_path: Path
+    ) -> None:
+        """rockcraft pack must always pass ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS."""
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\nrocks:\n- name: myrock\n"
+            "  rockcraft-yaml: rock_dir/rockcraft.yaml\n",
+        )
+        rock_dir = tmp_path / "rock_dir"
+        rock_dir.mkdir()
+        _write(rock_dir / "rockcraft.yaml", "name: myrock\n")
+        _write(rock_dir / "myrock_1.0_amd64.rock", "fake rock")
+
+        with patch("opcli.core.artifacts.run_command") as mock_run:
+            artifacts_build(tmp_path)
+
+        env_kwarg = mock_run.call_args.kwargs.get("env")
+        assert env_kwarg is not None
+        assert env_kwarg.get("ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS") == "1"
+
     def test_build_single_snap(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -108,9 +108,7 @@ class TestArtifactsBuild:
         assert gen.rocks[0].output.file is not None
         assert gen.rocks[0].output.file.startswith("./")
 
-    def test_build_rock_sets_experimental_extensions_env(
-        self, tmp_path: Path
-    ) -> None:
+    def test_build_rock_sets_experimental_extensions_env(self, tmp_path: Path) -> None:
         """rockcraft pack must always pass ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS."""
         _write(
             tmp_path / "artifacts.yaml",

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -199,7 +199,7 @@ class TestSubprocessWrapper:
             assert result.stdout == ""
             assert result.stderr == ""
             mock_run.assert_called_once_with(
-                ["spread", "-shell"], cwd=None, check=False
+                ["spread", "-shell"], cwd=None, check=False, env=None
             )
 
     def test_interactive_failure_raises(self) -> None:

--- a/tests/unit/test_subprocess.py
+++ b/tests/unit/test_subprocess.py
@@ -54,6 +54,43 @@ class TestStdinStreaming:
             run_command(["false"], stream=True, stdin="some input")
 
 
+class TestEnvCaptured:
+    """env overlay in captured (non-streaming) mode."""
+
+    def test_extra_env_var_visible_to_process(self) -> None:
+        result = run_command(
+            ["sh", "-c", "echo $MY_TEST_VAR"],
+            stream=False,
+            env={"MY_TEST_VAR": "hello"},
+        )
+        assert result.stdout.strip() == "hello"
+
+    def test_env_none_inherits_parent_env(self) -> None:
+        """When env is None the subprocess still sees PATH (so sh works)."""
+        result = run_command(["sh", "-c", "echo ok"], stream=False, env=None)
+        assert "ok" in result.stdout
+
+    def test_env_overrides_existing_var(self) -> None:
+        result = run_command(
+            ["sh", "-c", "echo $HOME"],
+            stream=False,
+            env={"HOME": "/overridden"},
+        )
+        assert result.stdout.strip() == "/overridden"
+
+
+class TestEnvStreaming:
+    """env overlay in streaming (real-time) mode."""
+
+    def test_extra_env_var_visible_to_process(self) -> None:
+        result = run_command(
+            ["sh", "-c", "echo $MY_TEST_VAR"],
+            stream=True,
+            env={"MY_TEST_VAR": "streamed"},
+        )
+        assert result.stdout.strip() == "streamed"
+
+
 class TestInteractiveMutualExclusion:
     """interactive and stdin are mutually exclusive."""
 


### PR DESCRIPTION
Many rockcraft builds use experimental extensions (e.g. `django-framework`, `flask-framework`). Without `ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS=1`, rockcraft fails with a cryptic error. Setting it unconditionally is harmless when no experimental extensions are used.

## Changes

### `subprocess.py`
- Added `env: dict[str, str] | None = None` to `run_command`, `_run_streaming`, `_run_captured`, `_run_interactive`
- When provided, merged on top of `os.environ` so the subprocess still inherits the full parent environment

### `artifacts.py`
- Added `_ROCKCRAFT_ENV = {"ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS": "1"}` constant
- `_build_rock` passes `env=_ROCKCRAFT_ENV` to `run_command`

### Tests
- `test_subprocess.py`: new `TestEnvCaptured` and `TestEnvStreaming` classes verifying env overlay works in both modes
- `test_artifacts.py`: new test asserting the env kwarg is set correctly on the rockcraft call
- `test_scaffold.py`: updated interactive test to expect `env=None` in the `subprocess.run` call