### PR TITLE
feat: multi-base charm output in artifacts-generated.yaml

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import glob as globmod
 import logging
 import os
+import re
 from pathlib import Path
 
 from opcli.core.discovery import discover_artifacts
@@ -28,6 +29,8 @@ from opcli.models.artifacts import (
 from opcli.models.artifacts_generated import (
     ArtifactOutput,
     ArtifactsGenerated,
+    CharmArtifactOutput,
+    CharmFile,
     GeneratedCharm,
     GeneratedResource,
     GeneratedRock,
@@ -142,6 +145,54 @@ def _relative_to_root(path_str: str, root: Path) -> str:
         raise OpcliError(msg) from exc
 
 
+# Pattern: {name}_{distro}-{version}-{arch}.charm
+# e.g. aproxy_ubuntu-22.04-amd64.charm → distro=ubuntu, version=22.04
+_CHARM_FILENAME_RE = re.compile(
+    r"^.+_(?P<distro>[a-z]+)-(?P<version>\d+\.\d+)-[^.]+\.charm$"
+)
+
+
+def _parse_base_from_charm_path(path: str) -> str | None:
+    """Return the base string (e.g. ``ubuntu@22.04``) parsed from a charm filename.
+
+    Returns ``None`` if the filename does not follow the expected
+    ``{name}_{distro}-{version}-{arch}.charm`` convention.
+    """
+    filename = Path(path).name
+    m = _CHARM_FILENAME_RE.match(filename)
+    if not m:
+        return None
+    return f"{m.group('distro')}@{m.group('version')}"
+
+
+def _pick_new_charm_outputs(
+    before: set[str], after: set[str], pack_dir: Path
+) -> list[str]:
+    """Return all charm files produced by pack, relative paths TBD by caller.
+
+    Extends :func:`_pick_new_output` logic for charms: when multiple bases are
+    declared, ``charmcraft pack`` produces one file per base in a single
+    invocation.  All of them are returned.
+
+    Cases:
+    1. New files appeared — return all new files (sorted for determinism).
+    2. No files at all — raise error.
+    3. No new files, some pre-existing — the build overwrote existing files
+       in place; return all of them (assumes pack-dir is dedicated to this
+       charm).
+    """
+    new_files = sorted(after - before)
+    if new_files:
+        return new_files
+
+    if not after:
+        msg = f"No *.charm found in {pack_dir} after pack"
+        raise OpcliError(msg)
+
+    # Overwrite-in-place: all pre-existing files were just rebuilt.
+    return sorted(after)
+
+
 def _resolve_pack_dir(yaml_path: Path, pack_dir_str: str | None, root: Path) -> Path:
     """Resolve the directory from which the pack command should run."""
     if pack_dir_str:
@@ -235,8 +286,14 @@ def _build_charm(
     before = _snapshot_outputs(pack_dir, "charm")
     run_command([*_PACK_COMMANDS["charm"]], cwd=str(pack_dir))
     after = _snapshot_outputs(pack_dir, "charm")
-    new_output = _pick_new_output(before, after, "charm", pack_dir)
-    output_file = _relative_to_root(new_output, root)
+    new_outputs = _pick_new_charm_outputs(before, after, pack_dir)
+    charm_files = [
+        CharmFile(
+            path=_relative_to_root(p, root),
+            base=_parse_base_from_charm_path(p),
+        )
+        for p in new_outputs
+    ]
 
     resources: dict[str, GeneratedResource] = {}
     for res_name, res_def in charm.resources.items():
@@ -256,7 +313,7 @@ def _build_charm(
     return GeneratedCharm(
         name=charm.name,
         **{"charmcraft-yaml": charm.charmcraft_yaml},
-        output=ArtifactOutput(file=output_file),
+        output=CharmArtifactOutput(files=charm_files),
         resources=resources if resources else None,
     )
 

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -170,26 +170,19 @@ def _pick_new_charm_outputs(
 ) -> list[str]:
     """Return all charm files produced by pack, relative paths TBD by caller.
 
-    Extends :func:`_pick_new_output` logic for charms: when multiple bases are
-    declared, ``charmcraft pack`` produces one file per base in a single
-    invocation.  All of them are returned.
+    ``charmcraft pack`` always rebuilds **all** declared bases in a single
+    invocation, so the complete set of output files is always ``after``.
+    The ``before`` snapshot is only used to detect the error case where the
+    pack produced nothing.
 
     Cases:
-    1. New files appeared — return all new files (sorted for determinism).
+    1. Files present after pack — return all of them (sorted for determinism).
     2. No files at all — raise error.
-    3. No new files, some pre-existing — the build overwrote existing files
-       in place; return all of them (assumes pack-dir is dedicated to this
-       charm).
     """
-    new_files = sorted(after - before)
-    if new_files:
-        return new_files
-
     if not after:
         msg = f"No *.charm found in {pack_dir} after pack"
         raise OpcliError(msg)
 
-    # Overwrite-in-place: all pre-existing files were just rebuilt.
     return sorted(after)
 
 

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -54,8 +54,9 @@ def assemble_pytest_args(
     args: list[str] = []
 
     for charm in generated.charms:
-        if charm.output.file:
-            args.append(f"--charm-file={charm.output.file}")
+        if charm.output.files:
+            for charm_file in charm.output.files:
+                args.append(f"--charm-file={charm_file.path}")
         elif charm.output.artifact:
             logger.warning(
                 "Skipping --charm-file for charm '%s': output is a CI artifact "

--- a/src/opcli/models/artifacts_generated.py
+++ b/src/opcli/models/artifacts_generated.py
@@ -8,6 +8,9 @@ Schema version: 1
 - Charm entries include a ``resources`` mapping with resolved output paths
   (file or image), making ``artifacts-generated.yaml`` self-contained for
   pytest flag assembly without needing to also read ``artifacts.yaml``.
+- Charm output uses ``files`` (a list of :class:`CharmFile` with path and
+  optional base annotation) rather than a single ``file``, because
+  ``charmcraft pack`` may produce one file per declared base.
 """
 
 from __future__ import annotations
@@ -31,6 +34,45 @@ class ArtifactOutput(BaseModel):
     def _at_least_one_output(self) -> ArtifactOutput:
         if not any([self.file, self.image, self.artifact]):
             msg = "ArtifactOutput must specify at least one of file, image, or artifact"
+            raise ValueError(msg)
+        if self.artifact and not self.run_id:
+            msg = "run-id is required when artifact is set"
+            raise ValueError(msg)
+        return self
+
+
+class CharmFile(BaseModel):
+    """A single charm file with its local path and optional base annotation.
+
+    The ``base`` field is parsed from the charmcraft output filename on a
+    best-effort basis (e.g. ``aproxy_ubuntu-22.04-amd64.charm`` →
+    ``ubuntu@22.04``).  It is ``None`` when the filename does not follow the
+    expected ``{name}_{distro}-{version}-{arch}.charm`` convention.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    base: str | None = None
+
+
+class CharmArtifactOutput(BaseModel):
+    """Output of a charm build — local files or a CI artifact reference.
+
+    Local builds populate ``files`` (one :class:`CharmFile` per built base).
+    CI builds populate ``artifact`` and ``run-id`` instead.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    files: list[CharmFile] = []
+    artifact: str | None = None
+    run_id: str | None = Field(default=None, alias="run-id")
+
+    @model_validator(mode="after")
+    def _at_least_one_output(self) -> CharmArtifactOutput:
+        if not self.files and not self.artifact:
+            msg = "CharmArtifactOutput must specify files or artifact"
             raise ValueError(msg)
         if self.artifact and not self.run_id:
             msg = "run-id is required when artifact is set"
@@ -71,7 +113,7 @@ class GeneratedCharm(BaseModel):
 
     name: str
     charmcraft_yaml: str = Field(alias="charmcraft-yaml")
-    output: ArtifactOutput
+    output: CharmArtifactOutput
     resources: dict[str, GeneratedResource] | None = None
 
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -83,9 +83,37 @@ class TestArtifactsBuild:
         gen = load_artifacts_generated(result)
         assert len(gen.charms) == 1
         assert gen.charms[0].name == "mycharm"
-        assert gen.charms[0].output.file is not None
-        assert gen.charms[0].output.file.startswith("./")
-        assert gen.charms[0].output.file.endswith(".charm")
+        assert len(gen.charms[0].output.files) == 1
+        assert gen.charms[0].output.files[0].path.startswith("./")
+        assert gen.charms[0].output.files[0].path.endswith(".charm")
+
+    def test_build_multi_base_charm(self, tmp_path: Path) -> None:
+        """Multi-base charm: all produced files appear in output.files."""
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n- name: aproxy\n  charmcraft-yaml: charmcraft.yaml\n",
+        )
+        _write(tmp_path / "charmcraft.yaml", "name: aproxy\n")
+        # Simulate charmcraft pack producing three .charm files (one per base)
+        _write(tmp_path / "aproxy_ubuntu-20.04-amd64.charm", "fake")
+        _write(tmp_path / "aproxy_ubuntu-22.04-amd64.charm", "fake")
+        _write(tmp_path / "aproxy_ubuntu-24.04-amd64.charm", "fake")
+
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path)
+
+        gen = load_artifacts_generated(result)
+        files = gen.charms[0].output.files
+        expected_count = 3
+        assert len(files) == expected_count
+        paths = {f.path for f in files}
+        assert "./aproxy_ubuntu-20.04-amd64.charm" in paths
+        assert "./aproxy_ubuntu-22.04-amd64.charm" in paths
+        assert "./aproxy_ubuntu-24.04-amd64.charm" in paths
+        bases = {f.base for f in files}
+        assert "ubuntu@20.04" in bases
+        assert "ubuntu@22.04" in bases
+        assert "ubuntu@24.04" in bases
 
     def test_build_single_rock(self, tmp_path: Path) -> None:
         _write(
@@ -452,12 +480,18 @@ class TestArtifactsBuild:
 
         mock_run.assert_not_called()
 
-    def test_pick_new_output_ambiguous_overwrite_raises(self, tmp_path: Path) -> None:
-        """Overwrite-in-place with multiple pre-existing files raises OpcliError."""
+    def test_pick_new_charm_output_overwrite_in_place_multi(
+        self, tmp_path: Path
+    ) -> None:
+        """Overwrite-in-place with multiple pre-existing charm files returns all.
+
+        This is the multi-base scenario: charmcraft pack rebuilds the same set of
+        files in-place (no new files appear). All pre-existing files are returned
+        since they were all just rebuilt.
+        """
         _write(tmp_path / "charmcraft.yaml", "name: mycharm\n")
-        # Pre-existing output files — build overwrites one but we can't tell which
-        _write(tmp_path / "mycharm_v1.charm", "old1")
-        _write(tmp_path / "mycharm_v2.charm", "old2")
+        _write(tmp_path / "mycharm_ubuntu-22.04-amd64.charm", "old1")
+        _write(tmp_path / "mycharm_ubuntu-24.04-amd64.charm", "old2")
 
         _write(
             tmp_path / "artifacts.yaml",
@@ -465,8 +499,13 @@ class TestArtifactsBuild:
             "  charmcraft-yaml: charmcraft.yaml\n",
         )
 
-        with (
-            patch("opcli.core.artifacts.run_command"),
-            pytest.raises(OpcliError, match="Cannot determine which"),
-        ):
-            artifacts_build(tmp_path)
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path)
+
+        gen = load_artifacts_generated(result)
+        files = gen.charms[0].output.files
+        expected_count = 2
+        assert len(files) == expected_count
+        paths = {f.path for f in files}
+        assert "./mycharm_ubuntu-22.04-amd64.charm" in paths
+        assert "./mycharm_ubuntu-24.04-amd64.charm" in paths

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -115,6 +115,34 @@ class TestArtifactsBuild:
         assert "ubuntu@22.04" in bases
         assert "ubuntu@24.04" in bases
 
+    def test_build_multi_base_charm_incremental(self, tmp_path: Path) -> None:
+        """Adding a new base: pre-existing files + new file all appear in output.
+
+        charmcraft pack always rebuilds all declared bases, so after adding a
+        base we must return all files in the output directory, not just new ones.
+        """
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n- name: aproxy\n  charmcraft-yaml: charmcraft.yaml\n",
+        )
+        _write(tmp_path / "charmcraft.yaml", "name: aproxy\n")
+        # Pre-existing file from a previous single-base build
+        _write(tmp_path / "aproxy_ubuntu-20.04-amd64.charm", "old")
+        # charmcraft pack rebuilds ubuntu-20.04 AND produces ubuntu-22.04
+        # (simulated: file already existed before, pack just overwrites)
+        _write(tmp_path / "aproxy_ubuntu-22.04-amd64.charm", "new")
+
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path)
+
+        gen = load_artifacts_generated(result)
+        files = gen.charms[0].output.files
+        expected_count = 2
+        assert len(files) == expected_count
+        paths = {f.path for f in files}
+        assert "./aproxy_ubuntu-20.04-amd64.charm" in paths
+        assert "./aproxy_ubuntu-22.04-amd64.charm" in paths
+
     def test_build_single_rock(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -14,6 +14,8 @@ from opcli.models.artifacts import (
 from opcli.models.artifacts_generated import (
     ArtifactOutput,
     ArtifactsGenerated,
+    CharmArtifactOutput,
+    CharmFile,
     GeneratedCharm,
     GeneratedRock,
     GeneratedSnap,
@@ -189,12 +191,14 @@ class TestArtifactsGenerated:
                 GeneratedCharm(
                     name="indico",
                     charmcraft_yaml="charmcraft.yaml",
-                    output=ArtifactOutput(file="./indico.charm"),
+                    output=CharmArtifactOutput(
+                        files=[CharmFile(path="./indico.charm", base="ubuntu@22.04")]
+                    ),
                 )
             ],
         )
         assert gen.rocks[0].output.file == "./indico.rock"
-        assert gen.charms[0].output.file == "./indico.charm"
+        assert gen.charms[0].output.files[0].path == "./indico.charm"
 
     def test_generated_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError, match="Extra inputs"):
@@ -211,3 +215,49 @@ class TestArtifactsGenerated:
             ],
         )
         assert gen.snaps[0].name == "mysnap"
+
+
+class TestCharmArtifactOutput:
+    """Validation tests for CharmArtifactOutput and CharmFile models."""
+
+    def test_local_single_base(self) -> None:
+        out = CharmArtifactOutput(
+            files=[
+                CharmFile(path="./aproxy_ubuntu-22.04-amd64.charm", base="ubuntu@22.04")
+            ]
+        )
+        assert len(out.files) == 1
+        assert out.files[0].base == "ubuntu@22.04"
+
+    def test_local_multi_base(self) -> None:
+        out = CharmArtifactOutput(
+            files=[
+                CharmFile(path="./a_ubuntu-20.04-amd64.charm", base="ubuntu@20.04"),
+                CharmFile(path="./a_ubuntu-22.04-amd64.charm", base="ubuntu@22.04"),
+            ]
+        )
+        expected_count = 2
+        assert len(out.files) == expected_count
+
+    def test_ci_artifact_output(self) -> None:
+        out = CharmArtifactOutput(artifact="charm-aproxy", run_id="999")
+        assert out.artifact == "charm-aproxy"
+        assert out.run_id == "999"
+        assert out.files == []
+
+    def test_ci_artifact_yaml_alias(self) -> None:
+        out = CharmArtifactOutput.model_validate({"artifact": "charm-x", "run-id": "1"})
+        assert out.run_id == "1"
+
+    def test_empty_output_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="files or artifact"):
+            CharmArtifactOutput()
+
+    def test_artifact_without_run_id_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="run-id"):
+            CharmArtifactOutput(artifact="charm-x")
+
+    def test_base_none_allowed(self) -> None:
+        """Base can be None when filename does not follow convention."""
+        out = CharmArtifactOutput(files=[CharmFile(path="./mycharm.charm")])
+        assert out.files[0].base is None

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -33,7 +33,9 @@ charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
   output:
-    file: ./mycharm.charm
+    files:
+    - path: ./mycharm_ubuntu-22.04-amd64.charm
+      base: ubuntu@22.04
 """
 
 _GENERATED_WITH_ROCKS_AND_RESOURCES = """\
@@ -47,7 +49,9 @@ charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
   output:
-    file: ./mycharm.charm
+    files:
+    - path: ./mycharm_ubuntu-22.04-amd64.charm
+      base: ubuntu@22.04
   resources:
     myrock-image:
       type: oci-image

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -33,7 +33,9 @@ charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
   output:
-    file: ./mycharm.charm
+    files:
+    - path: ./mycharm_ubuntu-22.04-amd64.charm
+      base: ubuntu@22.04
   resources:
     myrock-image:
       type: oci-image
@@ -67,7 +69,9 @@ charms:
 - name: simple
   charmcraft-yaml: charmcraft.yaml
   output:
-    file: ./simple.charm
+    files:
+    - path: ./simple_ubuntu-22.04-amd64.charm
+      base: ubuntu@22.04
 """
 
 
@@ -82,7 +86,7 @@ class TestAssemblePytestArgs:
         _write(
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: c\n  source: .\n"
-            "  output:\n    file: ./c.charm\n",
+            "  output:\n    files:\n    - path: ./c.charm\n      base: ubuntu@22.04\n",
         )
         with pytest.raises(Exception, match=_V1_ERROR_MATCH):
             assemble_pytest_args(tmp_path)
@@ -92,7 +96,7 @@ class TestAssemblePytestArgs:
 
         args = assemble_pytest_args(tmp_path)
 
-        assert "--charm-file=./mycharm.charm" in args
+        assert "--charm-file=./mycharm_ubuntu-22.04-amd64.charm" in args
         assert "--myrock-image=./rock_dir/myrock.rock" in args
 
     def test_ci_scenario_only_generated_file(self, tmp_path: Path) -> None:
@@ -126,7 +130,28 @@ class TestAssemblePytestArgs:
 
         args = assemble_pytest_args(tmp_path)
 
-        assert args == ["--charm-file=./simple.charm"]
+        assert args == ["--charm-file=./simple_ubuntu-22.04-amd64.charm"]
+
+    def test_multi_base_charm_emits_multiple_charm_file_flags(
+        self, tmp_path: Path
+    ) -> None:
+        """Multi-base charm produces one --charm-file per output file."""
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            "version: 1\ncharms:\n- name: aproxy\n"
+            "  charmcraft-yaml: charmcraft.yaml\n"
+            "  output:\n    files:\n"
+            "    - path: ./aproxy_ubuntu-20.04-amd64.charm\n      base: ubuntu@20.04\n"
+            "    - path: ./aproxy_ubuntu-22.04-amd64.charm\n      base: ubuntu@22.04\n"
+            "    - path: ./aproxy_ubuntu-24.04-amd64.charm\n      base: ubuntu@24.04\n",
+        )
+
+        args = assemble_pytest_args(tmp_path)
+
+        assert "--charm-file=./aproxy_ubuntu-20.04-amd64.charm" in args
+        assert "--charm-file=./aproxy_ubuntu-22.04-amd64.charm" in args
+        assert "--charm-file=./aproxy_ubuntu-24.04-amd64.charm" in args
+        assert args.count("--charm-file=./aproxy_ubuntu-22.04-amd64.charm") == 1
 
     def test_empty_generated(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
@@ -139,13 +164,14 @@ class TestAssemblePytestArgs:
         _write(
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    file: ./c.charm\n"
+            "  output:\n    files:\n    - path: ./c_ubuntu-22.04-amd64.charm\n"
+            "      base: ubuntu@22.04\n"
             "  resources:\n    img:\n      type: oci-image\n      rock: myrock\n",
         )
 
         args = assemble_pytest_args(tmp_path)
 
-        assert args == ["--charm-file=./c.charm"]
+        assert args == ["--charm-file=./c_ubuntu-22.04-amd64.charm"]
         assert not any(a.startswith("--img=") for a in args)
 
     def test_image_takes_priority_over_file_when_both_set(self, tmp_path: Path) -> None:
@@ -153,7 +179,8 @@ class TestAssemblePytestArgs:
         _write(
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    file: ./c.charm\n"
+            "  output:\n    files:\n    - path: ./c_ubuntu-22.04-amd64.charm\n"
+            "      base: ubuntu@22.04\n"
             "  resources:\n    myrock-image:\n      type: oci-image\n"
             "      rock: myrock\n"
             "      file: ./rock_dir/myrock.rock\n"
@@ -184,7 +211,7 @@ class TestAssembleToxArgv:
 
         assert argv[:3] == ["tox", "-e", "integration"]
         assert "--" in argv
-        assert "--charm-file=./mycharm.charm" in argv
+        assert "--charm-file=./mycharm_ubuntu-22.04-amd64.charm" in argv
 
     def test_extra_args_only_include_separator(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts-generated.yaml", "version: 1\n")
@@ -209,7 +236,7 @@ class TestAssembleToxArgv:
 
         sep_idx = argv.index("--")
         tail = argv[sep_idx + 1 :]
-        assert "--charm-file=./mycharm.charm" in tail
+        assert "--charm-file=./mycharm_ubuntu-22.04-amd64.charm" in tail
         assert "-v" in tail
         assert "-k" in tail
         assert "test_charm" in tail


### PR DESCRIPTION
## Summary

charmcraft pack produces one .charm file per declared base when multiple platforms are configured (e.g. aproxy-operator with ubuntu@20.04/22.04/24.04).

## Changes

- **New models**: `CharmFile(path, base)` and `CharmArtifactOutput(files, artifact, run_id)` replace the old single `ArtifactOutput` on `GeneratedCharm.output`
- **Base parsing**: `_parse_base_from_charm_path()` extracts `ubuntu@22.04` from filenames like `aproxy_ubuntu-22.04-amd64.charm` (best-effort, returns `None` on unknown format)
- **Multi-file collection**: `_pick_new_charm_outputs()` returns all newly produced files, or all pre-existing files on overwrite-in-place (the second-build-same-bases case)
- **pytest args**: now iterates `charm.output.files` emitting one `--charm-file` flag per file
- CI artifact format (`artifact`/`run-id`) preserved in `CharmArtifactOutput`

## Schema example

```yaml
charms:
- name: aproxy
  charmcraft-yaml: charmcraft.yaml
  output:
    files:
    - path: ./aproxy_ubuntu-20.04-amd64.charm
      base: ubuntu@20.04
    - path: ./aproxy_ubuntu-22.04-amd64.charm
      base: ubuntu@22.04
    - path: ./aproxy_ubuntu-24.04-amd64.charm
      base: ubuntu@24.04
```

## Tests

227 tests passing. New tests: multi-base build, multi-base pytest args, CharmArtifactOutput model validation.