### PR TITLE
fix: use rock name for OCI image flags, matching operator-workflows

### DIFF
--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -7,9 +7,9 @@ tox/pytest need to locate built charms and their OCI-image resources.
 charm entry, so this module no longer needs to read ``artifacts.yaml``.
 
 Convention (matching operator-workflows):
-    --charm-file=<path>          for each locally built charm
-    --<resource-name>=<path>     for each OCI-image resource with a local file
-    --<resource-name>=<image>    for each OCI-image resource with a registry image
+    --charm-file=<path>             for each locally built charm
+    --<rock-name>-image=<path>      for each OCI-image resource linked to a rock
+    --<resource-name>=<path>        for OCI-image resources not linked to a rock
 
 The ``KEY=VALUE`` form is required because some conftest.py files register
 ``--charm-file`` with ``nargs="+"``, which makes argparse greedy.  With the
@@ -68,7 +68,8 @@ def assemble_pytest_args(
         for res_name, res in (charm.resources or {}).items():
             value = res.image or res.file
             if value:
-                args.append(f"--{res_name}={value}")
+                arg_name = f"{res.rock}-image" if res.rock else res_name
+                args.append(f"--{arg_name}={value}")
 
     return args
 

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -192,6 +192,47 @@ class TestAssemblePytestArgs:
         assert "--myrock-image=localhost:32000/myrock:latest" in args
         assert not any("myrock.rock" in a for a in args)
 
+    def test_rock_name_used_for_flag_not_resource_name(self, tmp_path: Path) -> None:
+        """Flag uses rock name, not resource name — matches operator-workflows.
+
+        When the resource name (e.g. ``app-image``) differs from the rock name
+        (e.g. ``expressjs-app``), the generated flag must be
+        ``--expressjs-app-image=...``, not ``--app-image=...``.
+        """
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            "version: 1\ncharms:\n- name: expressjs-k8s\n"
+            "  charmcraft-yaml: charmcraft.yaml\n"
+            "  output:\n    files:\n"
+            "    - path: ./expressjs-k8s_ubuntu-22.04-amd64.charm\n"
+            "      base: ubuntu@22.04\n"
+            "  resources:\n    app-image:\n      type: oci-image\n"
+            "      rock: expressjs-app\n"
+            "      file: ./expressjs-app_1.0_amd64.rock\n",
+        )
+
+        args = assemble_pytest_args(tmp_path)
+
+        assert "--expressjs-app-image=./expressjs-app_1.0_amd64.rock" in args
+        assert not any(a.startswith("--app-image=") for a in args)
+
+    def test_resource_without_rock_uses_resource_name(self, tmp_path: Path) -> None:
+        """Resources not linked to a rock fall back to the resource name as flag."""
+        _write(
+            tmp_path / "artifacts-generated.yaml",
+            "version: 1\ncharms:\n- name: mycharm\n"
+            "  charmcraft-yaml: charmcraft.yaml\n"
+            "  output:\n    files:\n"
+            "    - path: ./mycharm_ubuntu-22.04-amd64.charm\n"
+            "      base: ubuntu@22.04\n"
+            "  resources:\n    standalone-image:\n      type: oci-image\n"
+            "      image: ghcr.io/canonical/standalone:latest\n",
+        )
+
+        args = assemble_pytest_args(tmp_path)
+
+        assert "--standalone-image=ghcr.io/canonical/standalone:latest" in args
+
 
 class TestAssembleToxArgv:
     """Tests for assemble_tox_argv()."""


### PR DESCRIPTION
Fixes #71

## Problem

`opcli pytest expand` was generating `--<resource-name>=...` (e.g. `--app-image=...`) but `operator-workflows` generates `--<rock-name>-image=...` (e.g. `--expressjs-app-image=...`).

In repos like `paas-charm` where multiple charms share the same resource name (`app-image`), this produced duplicate, ambiguous flags pointing to different images.

## Fix

One-line change in `core/pytest_args.py`:

```python
arg_name = f"{res.rock}-image" if res.rock else res_name
```

Resources not linked to a rock (no `rock:` field) fall back to the resource name unchanged.

## Tests

230 passing. New tests:
- `test_rock_name_used_for_flag_not_resource_name`: `rock: expressjs-app` + resource `app-image` → `--expressjs-app-image=...`
- `test_resource_without_rock_uses_resource_name`: standalone resource (no rock link) still uses resource name