### PR TITLE
feat: CI artifact build workflow with matrix and collect commands

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Install opcli
         run: uv tool install ..
 
+      - name: Set up LXD
+        uses: canonical/setup-lxd@main
+
       - name: Install charmcraft
         if: matrix.type == 'charm'
         run: sudo snap install charmcraft --classic

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -10,10 +10,7 @@ name: Build Artifacts
 #     build:
 #       uses: javierdelapuente/operator-ci-poc/.github/workflows/build-artifacts.yml@main
 #       with:
-#         working-directory: .   # directory containing artifacts.yaml
-#
-# TODO: add workflow_call trigger with working-directory input when the
-# workflow is promoted from example to reusable.
+#         working-directory: .   # directory containing artifacts.yaml (default: .)
 
 on:
   push:
@@ -27,12 +24,12 @@ on:
       - "examples/**"
       - ".github/workflows/build-artifacts.yml"
   workflow_dispatch:
-
-defaults:
-  run:
-    # All run steps operate from the examples/ directory where artifacts.yaml
-    # lives.  actions/checkout is unaffected by working-directory.
-    working-directory: examples/
+  workflow_call:
+    inputs:
+      working-directory:
+        description: "Directory containing artifacts.yaml (relative to workspace root)"
+        type: string
+        default: "."
 
 jobs:
   # ── Job 1: produce the build matrix ────────────────────────────────────────
@@ -41,6 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+    defaults:
+      run:
+        # Non-workflow_call triggers use examples/ (self-test); callers pass their own.
+        working-directory: ${{ inputs.working-directory || 'examples' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -48,8 +49,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install opcli
+      - name: Install opcli (local source, self-test only)
+        if: github.repository == 'javierdelapuente/operator-ci-poc'
         run: uv tool install ..
+
+      - name: Install opcli
+        if: github.repository != 'javierdelapuente/operator-ci-poc'
+        run: uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git"
 
       - name: Generate build matrix
         id: matrix
@@ -65,6 +71,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory || 'examples' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -72,8 +81,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install opcli
+      - name: Install opcli (local source, self-test only)
+        if: github.repository == 'javierdelapuente/operator-ci-poc'
         run: uv tool install ..
+
+      - name: Install opcli
+        if: github.repository != 'javierdelapuente/operator-ci-poc'
+        run: uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git"
 
       - name: Set up LXD
         uses: canonical/setup-lxd@main
@@ -93,11 +107,18 @@ jobs:
       - name: Build ${{ matrix.type }} ${{ matrix.name }}
         run: opcli artifacts build --${{ matrix.type }} ${{ matrix.name }}
 
+      - name: Upload built ${{ matrix.type }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-${{ matrix.type }}-${{ matrix.name }}
+          path: ${{ inputs.working-directory || 'examples' }}/**/*.${{ matrix.type }}
+          if-no-files-found: error
+
       - name: Upload partial artifacts-generated.yaml
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-generated-${{ matrix.type }}-${{ matrix.name }}
-          path: examples/artifacts-generated.yaml
+          path: ${{ inputs.working-directory || 'examples' }}/artifacts-generated.yaml
           if-no-files-found: error
 
   # ── Job 3: merge all partials into the final artifacts-generated.yaml ───────
@@ -105,6 +126,9 @@ jobs:
     name: Collect artifacts
     needs: build
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory || 'examples' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -112,14 +136,19 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install opcli
+      - name: Install opcli (local source, self-test only)
+        if: github.repository == 'javierdelapuente/operator-ci-poc'
         run: uv tool install ..
+
+      - name: Install opcli
+        if: github.repository != 'javierdelapuente/operator-ci-poc'
+        run: uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git"
 
       - name: Download all partial artifacts-generated.yaml files
         uses: actions/download-artifact@v4
         with:
           pattern: artifacts-generated-*
-          path: examples/partial-artifacts/
+          path: ${{ inputs.working-directory || 'examples' }}/partial-artifacts/
 
       - name: Merge partials
         run: |
@@ -130,5 +159,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-generated
-          path: examples/artifacts-generated.yaml
+          path: ${{ inputs.working-directory || 'examples' }}/artifacts-generated.yaml
           if-no-files-found: error
+

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,131 @@
+name: Build Artifacts
+
+# Reusable workflow that builds all charms, rocks, and snaps declared in
+# artifacts.yaml and publishes a merged artifacts-generated.yaml as a
+# GitHub artifact.
+#
+# Call from your operator repository:
+#
+#   jobs:
+#     build:
+#       uses: javierdelapuente/operator-ci-poc/.github/workflows/build-artifacts.yml@main
+#       with:
+#         working-directory: .   # directory containing artifacts.yaml
+#
+# TODO: add workflow_call trigger with working-directory input when the
+# workflow is promoted from example to reusable.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - ".github/workflows/build-artifacts.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - ".github/workflows/build-artifacts.yml"
+  workflow_dispatch:
+
+defaults:
+  run:
+    # All run steps operate from the examples/ directory where artifacts.yaml
+    # lives.  actions/checkout is unaffected by working-directory.
+    working-directory: examples/
+
+jobs:
+  # ── Job 1: produce the build matrix ────────────────────────────────────────
+  build-matrix:
+    name: Build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install opcli
+        run: uv tool install ..
+
+      - name: Generate build matrix
+        id: matrix
+        run: |
+          matrix=$(opcli artifacts matrix)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  # ── Job 2: build each artifact in parallel ─────────────────────────────────
+  build:
+    name: "Build ${{ matrix.type }} ${{ matrix.name }}"
+    needs: build-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install opcli
+        run: uv tool install ..
+
+      - name: Install charmcraft
+        if: matrix.type == 'charm'
+        run: sudo snap install charmcraft --classic
+
+      - name: Install rockcraft
+        if: matrix.type == 'rock'
+        run: sudo snap install rockcraft --classic
+
+      - name: Install snapcraft
+        if: matrix.type == 'snap'
+        run: sudo snap install snapcraft --classic
+
+      - name: Build ${{ matrix.type }} ${{ matrix.name }}
+        run: opcli artifacts build --${{ matrix.type }} ${{ matrix.name }}
+
+      - name: Upload partial artifacts-generated.yaml
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-generated-${{ matrix.type }}-${{ matrix.name }}
+          path: examples/artifacts-generated.yaml
+          if-no-files-found: error
+
+  # ── Job 3: merge all partials into the final artifacts-generated.yaml ───────
+  collect:
+    name: Collect artifacts
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install opcli
+        run: uv tool install ..
+
+      - name: Download all partial artifacts-generated.yaml files
+        uses: actions/download-artifact@v4
+        with:
+          pattern: artifacts-generated-*
+          path: examples/partial-artifacts/
+
+      - name: Merge partials
+        run: |
+          opcli artifacts collect \
+            $(find ./partial-artifacts -name "artifacts-generated.yaml" | sort | tr '\n' ' ')
+
+      - name: Upload merged artifacts-generated.yaml
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-generated
+          path: examples/artifacts-generated.yaml
+          if-no-files-found: error

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -13,23 +13,16 @@ name: Build Artifacts
 #         working-directory: .   # directory containing artifacts.yaml (default: .)
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "examples/**"
-      - ".github/workflows/build-artifacts.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "examples/**"
-      - ".github/workflows/build-artifacts.yml"
-  workflow_dispatch:
   workflow_call:
     inputs:
       working-directory:
         description: "Directory containing artifacts.yaml (relative to workspace root)"
         type: string
         default: "."
+      opcli-ref:
+        description: "Git ref of javierdelapuente/operator-ci-poc to install opcli from"
+        type: string
+        default: "main"
 
 jobs:
   # ── Job 1: produce the build matrix ────────────────────────────────────────
@@ -40,8 +33,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
     defaults:
       run:
-        # Non-workflow_call triggers use examples/ (self-test); callers pass their own.
-        working-directory: ${{ inputs.working-directory || 'examples' }}
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4
 
@@ -49,13 +41,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install opcli (local source, self-test only)
-        if: github.repository == 'javierdelapuente/operator-ci-poc'
-        run: uv tool install ..
-
       - name: Install opcli
-        if: github.repository != 'javierdelapuente/operator-ci-poc'
-        run: uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git"
+        run: >
+          uv tool install
+          "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ inputs.opcli-ref }}"
 
       - name: Generate build matrix
         id: matrix
@@ -73,7 +62,7 @@ jobs:
       matrix: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
     defaults:
       run:
-        working-directory: ${{ inputs.working-directory || 'examples' }}
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4
 
@@ -81,13 +70,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install opcli (local source, self-test only)
-        if: github.repository == 'javierdelapuente/operator-ci-poc'
-        run: uv tool install ..
-
       - name: Install opcli
-        if: github.repository != 'javierdelapuente/operator-ci-poc'
-        run: uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git"
+        run: >
+          uv tool install
+          "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ inputs.opcli-ref }}"
 
       - name: Set up LXD
         uses: canonical/setup-lxd@main
@@ -111,14 +97,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: built-${{ matrix.type }}-${{ matrix.name }}
-          path: ${{ inputs.working-directory || 'examples' }}/**/*.${{ matrix.type }}
+          path: ${{ inputs.working-directory }}/**/*.${{ matrix.type }}
           if-no-files-found: error
 
       - name: Upload partial artifacts-generated.yaml
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-generated-${{ matrix.type }}-${{ matrix.name }}
-          path: ${{ inputs.working-directory || 'examples' }}/artifacts-generated.yaml
+          path: ${{ inputs.working-directory }}/artifacts-generated.yaml
           if-no-files-found: error
 
   # ── Job 3: merge all partials into the final artifacts-generated.yaml ───────
@@ -128,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ${{ inputs.working-directory || 'examples' }}
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4
 
@@ -136,19 +122,16 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install opcli (local source, self-test only)
-        if: github.repository == 'javierdelapuente/operator-ci-poc'
-        run: uv tool install ..
-
       - name: Install opcli
-        if: github.repository != 'javierdelapuente/operator-ci-poc'
-        run: uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git"
+        run: >
+          uv tool install
+          "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ inputs.opcli-ref }}"
 
       - name: Download all partial artifacts-generated.yaml files
         uses: actions/download-artifact@v4
         with:
           pattern: artifacts-generated-*
-          path: ${{ inputs.working-directory || 'examples' }}/partial-artifacts/
+          path: ${{ inputs.working-directory }}/partial-artifacts/
 
       - name: Merge partials
         run: |
@@ -159,6 +142,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-generated
-          path: ${{ inputs.working-directory || 'examples' }}/artifacts-generated.yaml
+          path: ${{ inputs.working-directory }}/artifacts-generated.yaml
           if-no-files-found: error
+
 

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -11,6 +11,11 @@ name: Build Artifacts
 #       uses: javierdelapuente/operator-ci-poc/.github/workflows/build-artifacts.yml@main
 #       with:
 #         working-directory: .   # directory containing artifacts.yaml (default: .)
+#
+# opcli is installed from the same ref used to call this workflow (derived from
+# github.workflow_ref), so pinning @sha or @tag gives a fully reproducible build.
+# Override with opcli-ref only when you need a different ref (e.g. during CI of
+# this repo itself, where the PR head SHA must be passed explicitly).
 
 on:
   workflow_call:
@@ -20,9 +25,13 @@ on:
         type: string
         default: "."
       opcli-ref:
-        description: "Git ref of javierdelapuente/operator-ci-poc to install opcli from"
+        description: >
+          Git ref to install opcli from. Leave empty to auto-derive from the ref
+          used to call this workflow (the default and recommended behaviour for
+          external callers). Override only when the auto-derived ref is not
+          directly fetchable (e.g. a PR test-merge commit).
         type: string
-        default: "main"
+        default: ""
 
 jobs:
   # ── Job 1: produce the build matrix ────────────────────────────────────────
@@ -42,9 +51,16 @@ jobs:
           python-version: "3.12"
 
       - name: Install opcli
-        run: >
-          uv tool install
-          "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ inputs.opcli-ref }}"
+        run: |
+          # If opcli-ref was explicitly provided, use it; otherwise derive the ref
+          # from github.workflow_ref so the installed opcli matches the pinned
+          # workflow ref (e.g. @main, @sha, @v1.0) automatically.
+          opcli_ref="${{ inputs.opcli-ref }}"
+          if [ -z "$opcli_ref" ]; then
+            workflow_ref="${{ github.workflow_ref }}"
+            opcli_ref="${workflow_ref##*@}"
+          fi
+          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${opcli_ref}"
 
       - name: Generate build matrix
         id: matrix
@@ -71,9 +87,16 @@ jobs:
           python-version: "3.12"
 
       - name: Install opcli
-        run: >
-          uv tool install
-          "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ inputs.opcli-ref }}"
+        run: |
+          # If opcli-ref was explicitly provided, use it; otherwise derive the ref
+          # from github.workflow_ref so the installed opcli matches the pinned
+          # workflow ref (e.g. @main, @sha, @v1.0) automatically.
+          opcli_ref="${{ inputs.opcli-ref }}"
+          if [ -z "$opcli_ref" ]; then
+            workflow_ref="${{ github.workflow_ref }}"
+            opcli_ref="${workflow_ref##*@}"
+          fi
+          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${opcli_ref}"
 
       - name: Set up LXD
         uses: canonical/setup-lxd@main
@@ -123,9 +146,16 @@ jobs:
           python-version: "3.12"
 
       - name: Install opcli
-        run: >
-          uv tool install
-          "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ inputs.opcli-ref }}"
+        run: |
+          # If opcli-ref was explicitly provided, use it; otherwise derive the ref
+          # from github.workflow_ref so the installed opcli matches the pinned
+          # workflow ref (e.g. @main, @sha, @v1.0) automatically.
+          opcli_ref="${{ inputs.opcli-ref }}"
+          if [ -z "$opcli_ref" ]; then
+            workflow_ref="${{ github.workflow_ref }}"
+            opcli_ref="${workflow_ref##*@}"
+          fi
+          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${opcli_ref}"
 
       - name: Download all partial artifacts-generated.yaml files
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-build-artifacts.yml
+++ b/.github/workflows/test-build-artifacts.yml
@@ -1,0 +1,28 @@
+name: Test Build Artifacts
+
+# Tests the build-artifacts reusable workflow using the examples/ directory
+# as a real operator repository fixture.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - "src/**"
+      - ".github/workflows/build-artifacts.yml"
+      - ".github/workflows/test-build-artifacts.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "examples/**"
+      - "src/**"
+      - ".github/workflows/build-artifacts.yml"
+      - ".github/workflows/test-build-artifacts.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-artifacts.yml
+    with:
+      working-directory: examples
+      opcli-ref: ${{ github.sha }}

--- a/.github/workflows/test-build-artifacts.yml
+++ b/.github/workflows/test-build-artifacts.yml
@@ -25,6 +25,3 @@ jobs:
     uses: ./.github/workflows/build-artifacts.yml
     with:
       working-directory: examples
-      # github.sha on pull_request is the test-merge commit (not in git history).
-      # Use the actual PR head SHA, falling back to github.sha for push/dispatch.
-      opcli-ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/test-build-artifacts.yml
+++ b/.github/workflows/test-build-artifacts.yml
@@ -25,4 +25,6 @@ jobs:
     uses: ./.github/workflows/build-artifacts.yml
     with:
       working-directory: examples
-      opcli-ref: ${{ github.sha }}
+      # github.sha on pull_request is the test-merge commit (not in git history).
+      # Use the actual PR head SHA, falling back to github.sha for push/dispatch.
+      opcli-ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/examples/artifacts.yaml
+++ b/examples/artifacts.yaml
@@ -1,0 +1,13 @@
+version: 1
+rocks:
+  - name: k8s-rock
+    rockcraft-yaml: k8s-rock/rockcraft.yaml
+charms:
+  - name: machine-charm
+    charmcraft-yaml: machine-charm/charmcraft.yaml
+  - name: k8s-charm
+    charmcraft-yaml: k8s-charm/charmcraft.yaml
+    resources:
+      k8s-rock-image:
+        type: oci-image
+        rock: k8s-rock

--- a/examples/k8s-charm/charmcraft.yaml
+++ b/examples/k8s-charm/charmcraft.yaml
@@ -5,10 +5,10 @@ description: |
   Minimal k8s charm with a rock image resource, used to validate the
   opcli CI build workflow. Not intended for real deployment.
 
+base: ubuntu@24.04
+
 platforms:
-  ubuntu@24.04:
-    build-on: [amd64]
-    build-for: [amd64]
+  amd64:
 
 resources:
   k8s-rock-image:

--- a/examples/k8s-charm/charmcraft.yaml
+++ b/examples/k8s-charm/charmcraft.yaml
@@ -5,13 +5,8 @@ description: |
   Minimal k8s charm with a rock image resource, used to validate the
   opcli CI build workflow. Not intended for real deployment.
 
-bases:
-  - build-on:
-      - name: ubuntu
-        channel: "24.04"
-    run-on:
-      - name: ubuntu
-        channel: "24.04"
+platforms:
+  ubuntu@24.04:
 
 resources:
   k8s-rock-image:

--- a/examples/k8s-charm/charmcraft.yaml
+++ b/examples/k8s-charm/charmcraft.yaml
@@ -7,6 +7,8 @@ description: |
 
 platforms:
   ubuntu@24.04:
+    build-on: [amd64]
+    build-for: [amd64]
 
 resources:
   k8s-rock-image:

--- a/examples/k8s-charm/charmcraft.yaml
+++ b/examples/k8s-charm/charmcraft.yaml
@@ -1,0 +1,24 @@
+name: k8s-charm
+type: charm
+summary: Trivial k8s charm for opcli CI workflow testing.
+description: |
+  Minimal k8s charm with a rock image resource, used to validate the
+  opcli CI build workflow. Not intended for real deployment.
+
+bases:
+  - build-on:
+      - name: ubuntu
+        channel: "24.04"
+    run-on:
+      - name: ubuntu
+        channel: "24.04"
+
+resources:
+  k8s-rock-image:
+    type: oci-image
+    description: The rock image for the k8s charm.
+
+parts:
+  charm:
+    plugin: charm
+    source: .

--- a/examples/k8s-rock/rockcraft.yaml
+++ b/examples/k8s-rock/rockcraft.yaml
@@ -1,0 +1,17 @@
+name: k8s-rock
+version: "1.0"
+summary: Trivial rock for opcli CI workflow testing.
+description: |
+  Minimal rock used to validate the opcli CI build workflow.
+  Not intended for real deployment.
+
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+license: Apache-2.0
+
+platforms:
+  amd64:
+
+parts:
+  empty:
+    plugin: nil

--- a/examples/machine-charm/charmcraft.yaml
+++ b/examples/machine-charm/charmcraft.yaml
@@ -1,0 +1,19 @@
+name: machine-charm
+type: charm
+summary: Trivial machine charm for opcli CI workflow testing.
+description: |
+  Minimal machine charm used to validate the opcli CI build workflow.
+  Not intended for real deployment.
+
+bases:
+  - build-on:
+      - name: ubuntu
+        channel: "24.04"
+    run-on:
+      - name: ubuntu
+        channel: "24.04"
+
+parts:
+  charm:
+    plugin: charm
+    source: .

--- a/examples/machine-charm/charmcraft.yaml
+++ b/examples/machine-charm/charmcraft.yaml
@@ -7,6 +7,8 @@ description: |
 
 platforms:
   ubuntu@24.04:
+    build-on: [amd64]
+    build-for: [amd64]
 
 parts:
   charm:

--- a/examples/machine-charm/charmcraft.yaml
+++ b/examples/machine-charm/charmcraft.yaml
@@ -5,13 +5,8 @@ description: |
   Minimal machine charm used to validate the opcli CI build workflow.
   Not intended for real deployment.
 
-bases:
-  - build-on:
-      - name: ubuntu
-        channel: "24.04"
-    run-on:
-      - name: ubuntu
-        channel: "24.04"
+platforms:
+  ubuntu@24.04:
 
 parts:
   charm:

--- a/examples/machine-charm/charmcraft.yaml
+++ b/examples/machine-charm/charmcraft.yaml
@@ -5,10 +5,10 @@ description: |
   Minimal machine charm used to validate the opcli CI build workflow.
   Not intended for real deployment.
 
+base: ubuntu@24.04
+
 platforms:
-  ubuntu@24.04:
-    build-on: [amd64]
-    build-for: [amd64]
+  amd64:
 
 parts:
   charm:

--- a/src/opcli/commands/artifacts.py
+++ b/src/opcli/commands/artifacts.py
@@ -1,10 +1,17 @@
 """CLI commands for artifact discovery and building."""
 
+import json
 from pathlib import Path
+from typing import Annotated
 
 import typer
 
-from opcli.core.artifacts import artifacts_build, artifacts_init
+from opcli.core.artifacts import (
+    artifacts_build,
+    artifacts_collect,
+    artifacts_init,
+    artifacts_matrix,
+)
 
 app = typer.Typer(
     help="Discover and build charms, rocks, and snaps.",
@@ -44,4 +51,32 @@ def build(
         rock_names=rock or None,
         snap_names=snap or None,
     )
+    typer.echo(f"Wrote {path}")
+
+
+@app.command()
+def matrix() -> None:
+    """Print the GitHub Actions build matrix as JSON.
+
+    Reads artifacts.yaml and outputs a JSON object with an ``include`` key
+    suitable for use as a GitHub Actions ``strategy.matrix`` value.
+    """
+    result = artifacts_matrix(Path.cwd())
+    typer.echo(json.dumps(result))
+
+
+@app.command()
+def collect(
+    partials: Annotated[
+        list[Path],
+        typer.Argument(help="Partial artifacts-generated.yaml files to merge."),
+    ],
+) -> None:
+    """Merge partial artifacts-generated.yaml files into one.
+
+    Downloads from each parallel CI build job produce a partial
+    artifacts-generated.yaml.  This command merges them and re-fills charm
+    resource references from the merged rock outputs.
+    """
+    path = artifacts_collect(Path.cwd(), partials)
     typer.echo(f"Wrote {path}")

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -19,6 +19,7 @@ from opcli.core.subprocess import run_command
 from opcli.core.yaml_io import (
     dump_artifacts_generated,
     dump_artifacts_plan,
+    load_artifacts_generated,
     load_artifacts_plan,
 )
 from opcli.models.artifacts import (
@@ -376,6 +377,135 @@ def artifacts_build(
     dest = root / _ARTIFACTS_GENERATED_YAML
     dump_artifacts_generated(generated, dest)
     logger.info("Wrote %s", dest)
+    return dest
+
+
+def artifacts_matrix(root: Path) -> dict[str, list[dict[str, str]]]:
+    """Read ``artifacts.yaml`` and return a GitHub Actions matrix dict.
+
+    The returned dict has a single key ``"include"`` whose value is a list of
+    entries — one per artifact — each with ``"name"`` and ``"type"`` keys.
+    Rocks come first, then charms, then snaps.
+
+    The result is JSON-serialisable and suitable for use as a GitHub Actions
+    ``strategy.matrix`` value via ``$GITHUB_OUTPUT``.
+
+    Raises:
+        ConfigurationError: If ``artifacts.yaml`` does not exist.
+    """
+    plan_path = root / _ARTIFACTS_YAML
+    if not plan_path.exists():
+        msg = f"{_ARTIFACTS_YAML} not found. Run 'opcli artifacts init' first."
+        raise ConfigurationError(msg)
+
+    plan = load_artifacts_plan(plan_path)
+    include: list[dict[str, str]] = []
+    for rock in plan.rocks:
+        include.append({"name": rock.name, "type": "rock"})
+    for charm in plan.charms:
+        include.append({"name": charm.name, "type": "charm"})
+    for snap in plan.snaps:
+        include.append({"name": snap.name, "type": "snap"})
+
+    return {"include": include}
+
+
+def artifacts_collect(root: Path, partial_paths: list[Path]) -> Path:
+    """Merge partial ``artifacts-generated.yaml`` files into one.
+
+    In CI, each matrix build job produces a partial file containing only the
+    artifact it built.  This function merges all partials into a single
+    ``artifacts-generated.yaml`` and re-fills charm resource ``file``/``image``
+    references from the merged rock outputs (rocks and charms build in parallel
+    so charm partials have ``null`` resource refs at build time).
+
+    Args:
+        root: Repository root; the merged file is written here.
+        partial_paths: Paths to the partial ``artifacts-generated.yaml`` files.
+
+    Returns:
+        The path to the written merged file.
+
+    Raises:
+        ConfigurationError: If *partial_paths* is empty or a path does not exist.
+    """
+    if not partial_paths:
+        msg = "No partial artifacts-generated.yaml files provided to collect."
+        raise ConfigurationError(msg)
+
+    for p in partial_paths:
+        if not p.exists():
+            msg = f"Partial artifacts-generated.yaml not found: {p}"
+            raise ConfigurationError(msg)
+
+    all_rocks: list[GeneratedRock] = []
+    all_charms: list[GeneratedCharm] = []
+    all_snaps: list[GeneratedSnap] = []
+
+    for p in partial_paths:
+        partial = load_artifacts_generated(p)
+        all_rocks.extend(partial.rocks)
+        all_charms.extend(partial.charms)
+        all_snaps.extend(partial.snaps)
+
+    # Reject duplicate artifact names — each name must appear in exactly one partial.
+    for kind, names in (
+        ("rock", [r.name for r in all_rocks]),
+        ("charm", [c.name for c in all_charms]),
+        ("snap", [s.name for s in all_snaps]),
+    ):
+        dupes = {n for n in names if names.count(n) > 1}
+        if dupes:
+            msg = (
+                f"Duplicate {kind} name(s) across collected partials: "
+                f"{', '.join(sorted(dupes))}. Each artifact must appear in "
+                "exactly one partial file."
+            )
+            raise ConfigurationError(msg)
+
+    # Re-fill charm resource refs from the merged rock outputs.
+    rocks_by_name: dict[str, GeneratedRock] = {r.name: r for r in all_rocks}
+    filled_charms: list[GeneratedCharm] = []
+    for charm in all_charms:
+        if not charm.resources:
+            filled_charms.append(charm)
+            continue
+        filled: dict[str, GeneratedResource] = {}
+        for res_name, res in charm.resources.items():
+            if res.rock and res.rock in rocks_by_name:
+                rock_out = rocks_by_name[res.rock].output
+                filled[res_name] = GeneratedResource(
+                    type=res.type,
+                    rock=res.rock,
+                    file=rock_out.file,
+                    image=rock_out.image,
+                )
+            elif res.rock and res.rock not in rocks_by_name:
+                msg = (
+                    f"Charm '{charm.name}' resource '{res_name}' references rock "
+                    f"'{res.rock}' which was not found in the collected partials. "
+                    f"Ensure the rock build job partial is included."
+                )
+                raise ConfigurationError(msg)
+            else:
+                filled[res_name] = res
+        filled_charms.append(
+            GeneratedCharm(
+                name=charm.name,
+                **{"charmcraft-yaml": charm.charmcraft_yaml},
+                output=charm.output,
+                resources=filled,
+            )
+        )
+
+    generated = ArtifactsGenerated(
+        rocks=all_rocks,
+        charms=filled_charms,
+        snaps=all_snaps,
+    )
+    dest = root / _ARTIFACTS_GENERATED_YAML
+    dump_artifacts_generated(generated, dest)
+    logger.info("Wrote merged %s", dest)
     return dest
 
 

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -359,6 +359,17 @@ def artifacts_build(
         raise ConfigurationError(msg)
 
     plan = load_artifacts_plan(plan_path)
+
+    # If any type filter is provided, unspecified types default to empty so
+    # that `--charm foo` builds only the charm, not all rocks/snaps too.
+    any_filter = (
+        charm_names is not None or rock_names is not None or snap_names is not None
+    )
+    if any_filter:
+        rock_names = rock_names if rock_names is not None else []
+        charm_names = charm_names if charm_names is not None else []
+        snap_names = snap_names if snap_names is not None else []
+
     rocks_to_build = _filter_by_name(plan.rocks, rock_names, "rock")
     charms_to_build = _filter_by_name(plan.charms, charm_names, "charm")
     snaps_to_build = _filter_by_name(plan.snaps, snap_names, "snap")
@@ -514,8 +525,11 @@ def _filter_by_name[T: (RockArtifact, CharmArtifact, SnapArtifact)](
     names: list[str] | None,
     kind: str,
 ) -> list[T]:
-    """Return items filtered by *names*, or all if *names* is None/empty."""
-    if not names:
+    """Return items filtered by *names*, or all if *names* is None.
+
+    ``None`` means "no filter — build all".  An empty list means "build none".
+    """
+    if names is None:
         return items
     name_set = set(names)
     available = {item.name for item in items}

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -226,6 +226,26 @@ class TestArtifactsBuild:
         assert len(gen.charms) == 1
         assert gen.charms[0].name == "charm-a"
 
+    def test_charm_filter_does_not_build_rocks(self, tmp_path: Path) -> None:
+        """--charm only must not build rocks (each matrix job builds one artifact)."""
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
+            "charms:\n- name: mycharm\n  charmcraft-yaml: charm_dir/charmcraft.yaml\n",
+        )
+        (tmp_path / "charm_dir").mkdir()
+        _write(tmp_path / "charm_dir" / "charmcraft.yaml", "name: mycharm\n")
+        _write(tmp_path / "charm_dir" / "mycharm.charm", "fake")
+
+        with patch("opcli.core.artifacts.run_command") as mock_run:
+            artifacts_build(tmp_path, charm_names=["mycharm"])
+
+        # Only charmcraft should have been called — rockcraft must not be invoked.
+        for call in mock_run.call_args_list:
+            cmd = call[0][0]
+            assert "rockcraft" not in cmd[0], f"rockcraft unexpectedly invoked: {cmd}"
+
     def test_unknown_charm_name_raises(self, tmp_path: Path) -> None:
         _write(
             tmp_path / "artifacts.yaml",

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1,14 +1,20 @@
-"""Tests for ``opcli artifacts init`` and ``opcli artifacts build``."""
+"""Tests for ``opcli artifacts init``, ``build``, ``matrix``, and ``collect``."""
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from opcli.core.artifacts import artifacts_build, artifacts_init
+from opcli.core.artifacts import (
+    artifacts_build,
+    artifacts_collect,
+    artifacts_init,
+    artifacts_matrix,
+)
 from opcli.core.exceptions import ConfigurationError, OpcliError
 from opcli.core.yaml_io import load_artifacts_generated, load_artifacts_plan
 
@@ -537,3 +543,206 @@ class TestArtifactsBuild:
         paths = {f.path for f in files}
         assert "./mycharm_ubuntu-22.04-amd64.charm" in paths
         assert "./mycharm_ubuntu-24.04-amd64.charm" in paths
+
+
+class TestArtifactsMatrix:
+    """Tests for artifacts_matrix()."""
+
+    def test_returns_include_list_for_all_types(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
+            "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
+            "snaps:\n- name: my-snap\n  snapcraft-yaml: snap/snapcraft.yaml\n",
+        )
+
+        result = artifacts_matrix(tmp_path)
+
+        assert result == {
+            "include": [
+                {"name": "my-rock", "type": "rock"},
+                {"name": "my-charm", "type": "charm"},
+                {"name": "my-snap", "type": "snap"},
+            ]
+        }
+
+    def test_only_charms_no_rocks_no_snaps(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n",
+        )
+
+        result = artifacts_matrix(tmp_path)
+
+        assert result == {"include": [{"name": "my-charm", "type": "charm"}]}
+
+    def test_empty_artifacts_yaml_returns_empty_include(self, tmp_path: Path) -> None:
+        _write(tmp_path / "artifacts.yaml", "version: 1\n")
+
+        result = artifacts_matrix(tmp_path)
+
+        assert result == {"include": []}
+
+    def test_missing_artifacts_yaml_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match=r"artifacts\.yaml"):
+            artifacts_matrix(tmp_path)
+
+    def test_result_is_json_serializable(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
+            "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n",
+        )
+
+        result = artifacts_matrix(tmp_path)
+
+        serialized = json.dumps(result)
+        assert json.loads(serialized) == result
+
+
+class TestArtifactsCollect:
+    """Tests for artifacts_collect()."""
+
+    def _partial(
+        self,
+        tmp_path: Path,
+        name: str,
+        content: str,
+    ) -> Path:
+        p = tmp_path / name / "artifacts-generated.yaml"
+        _write(p, content)
+        return p
+
+    def test_merges_rock_and_charm_partials(self, tmp_path: Path) -> None:
+        rock_partial = self._partial(
+            tmp_path,
+            "rock-job",
+            "version: 1\n"
+            "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
+            "  output:\n    file: ./my-rock_1.0_amd64.rock\n",
+        )
+        charm_partial = self._partial(
+            tmp_path,
+            "charm-job",
+            "version: 1\n"
+            "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
+            "  output:\n    files:\n"
+            "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
+            "      base: ubuntu@24.04\n",
+        )
+
+        dest = tmp_path / "artifacts-generated.yaml"
+        artifacts_collect(tmp_path, [rock_partial, charm_partial])
+
+        gen = load_artifacts_generated(dest)
+        assert len(gen.rocks) == 1
+        assert len(gen.charms) == 1
+        assert gen.rocks[0].name == "my-rock"
+        assert gen.charms[0].name == "my-charm"
+
+    def test_fills_charm_resource_from_merged_rock(self, tmp_path: Path) -> None:
+        """Rock built in parallel job — resource ref must be filled during collect."""
+        rock_partial = self._partial(
+            tmp_path,
+            "rock-job",
+            "version: 1\n"
+            "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
+            "  output:\n    file: ./my-rock_1.0_amd64.rock\n",
+        )
+        charm_partial = self._partial(
+            tmp_path,
+            "charm-job",
+            "version: 1\n"
+            "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
+            "  output:\n    files:\n"
+            "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
+            "      base: ubuntu@24.04\n"
+            "  resources:\n"
+            "    my-rock-image:\n"
+            "      type: oci-image\n"
+            "      rock: my-rock\n"
+            "      file: null\n"
+            "      image: null\n",
+        )
+
+        artifacts_collect(tmp_path, [rock_partial, charm_partial])
+
+        gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        resource = gen.charms[0].resources["my-rock-image"]  # type: ignore[index]
+        assert resource.file == "./my-rock_1.0_amd64.rock"
+
+    def test_merges_multiple_rocks(self, tmp_path: Path) -> None:
+        rock1 = self._partial(
+            tmp_path,
+            "rock1-job",
+            "version: 1\n"
+            "rocks:\n- name: rock-a\n  rockcraft-yaml: rock-a/rockcraft.yaml\n"
+            "  output:\n    file: ./rock-a_1.0_amd64.rock\n",
+        )
+        rock2 = self._partial(
+            tmp_path,
+            "rock2-job",
+            "version: 1\n"
+            "rocks:\n- name: rock-b\n  rockcraft-yaml: rock-b/rockcraft.yaml\n"
+            "  output:\n    file: ./rock-b_1.0_amd64.rock\n",
+        )
+
+        artifacts_collect(tmp_path, [rock1, rock2])
+
+        gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        expected_count = 2
+        assert len(gen.rocks) == expected_count
+        names = {r.name for r in gen.rocks}
+        assert names == {"rock-a", "rock-b"}
+
+    def test_no_partials_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="partial"):
+            artifacts_collect(tmp_path, [])
+
+    def test_missing_partial_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ConfigurationError, match="not found"):
+            artifacts_collect(tmp_path, [tmp_path / "nonexistent.yaml"])
+
+    def test_missing_rock_partial_raises(self, tmp_path: Path) -> None:
+        """Charm references a rock that has no corresponding partial — must fail."""
+        charm_partial = self._partial(
+            tmp_path,
+            "charm-job",
+            "version: 1\n"
+            "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
+            "  output:\n    files:\n"
+            "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
+            "      base: ubuntu@24.04\n"
+            "  resources:\n"
+            "    missing-rock-image:\n"
+            "      type: oci-image\n"
+            "      rock: missing-rock\n"
+            "      file: null\n"
+            "      image: null\n",
+        )
+
+        with pytest.raises(ConfigurationError, match="missing-rock"):
+            artifacts_collect(tmp_path, [charm_partial])
+
+    def test_duplicate_rock_names_across_partials_raises(self, tmp_path: Path) -> None:
+        """Two partials with the same rock name must be rejected."""
+        rock1 = self._partial(
+            tmp_path,
+            "rock-job-1",
+            "version: 1\n"
+            "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
+            "  output:\n    file: ./my-rock_1.0_amd64.rock\n",
+        )
+        rock2 = self._partial(
+            tmp_path,
+            "rock-job-2",
+            "version: 1\n"
+            "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
+            "  output:\n    file: ./my-rock_2.0_amd64.rock\n",
+        )
+
+        with pytest.raises(ConfigurationError, match="my-rock"):
+            artifacts_collect(tmp_path, [rock1, rock2])


### PR DESCRIPTION
## Summary

Adds parallel CI artifact building:

### Sample operators (`examples/`)
- Trivial machine charm, k8s charm, and rock used as real test fixtures
- `examples/artifacts.yaml` declares all three with the rock→resource link

### `opcli artifacts matrix`
Reads `artifacts.yaml`, prints JSON build matrix to stdout:
```json
{"include": [{"name": "k8s-rock", "type": "rock"}, {"name": "machine-charm", "type": "charm"}, {"name": "k8s-charm", "type": "charm"}]}
```
Fails fast with `ConfigurationError` if `artifacts.yaml` is missing.

### `opcli artifacts collect`
Merges N partial `artifacts-generated.yaml` files (one per parallel build job) and re-fills charm resource `file`/`image` refs from the merged rock outputs.

### Bug fix: type filter isolation
`--charm foo` previously also built ALL rocks. Fixed so any type filter scopes unspecified types to empty — each matrix job builds exactly one artifact.

### `.github/workflows/build-artifacts.yml`
Three-job workflow with `working-directory: examples/`:
1. **build-matrix** — `opcli artifacts matrix` → `$GITHUB_OUTPUT`
2. **build (matrix)** — one job per artifact, uploads partial file; uses `canonical/setup-lxd` for LXD
3. **collect** — merges all partials, uploads final `artifacts-generated` artifact

## Tests
12 new unit tests covering both new commands (matrix and collect) including the filter isolation fix.