### PR TITLE
feat: CI-format output in artifacts build (GHCR images + artifact refs)

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -73,6 +73,9 @@ jobs:
     name: "Build ${{ matrix.type }} ${{ matrix.name }}"
     needs: build-matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
@@ -113,10 +116,17 @@ jobs:
         if: matrix.type == 'snap'
         run: sudo snap install snapcraft --classic
 
+      - name: Login to GHCR
+        if: matrix.type == 'rock'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            skopeo login ghcr.io --username "${{ github.actor }}" --password-stdin
+
       - name: Build ${{ matrix.type }} ${{ matrix.name }}
         run: opcli artifacts build --${{ matrix.type }} ${{ matrix.name }}
 
       - name: Upload built ${{ matrix.type }}
+        if: matrix.type != 'rock'
         uses: actions/upload-artifact@v4
         with:
           name: built-${{ matrix.type }}-${{ matrix.name }}

--- a/.github/workflows/test-build-artifacts.yml
+++ b/.github/workflows/test-build-artifacts.yml
@@ -25,3 +25,95 @@ jobs:
     uses: ./.github/workflows/build-artifacts.yml
     with:
       working-directory: examples
+    permissions:
+      packages: write
+      contents: read
+
+  verify:
+    name: Verify CI output format
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts-generated.yaml
+        uses: actions/download-artifact@v4
+        with:
+          name: artifacts-generated
+          path: output/
+
+      - name: Assert CI-format refs in artifacts-generated.yaml
+        run: |
+          python3 - <<'EOF'
+          import sys
+          import yaml
+
+          with open("output/artifacts-generated.yaml") as f:
+              gen = yaml.safe_load(f)
+
+          errors = []
+
+          # Rocks must have output.image (GHCR ref), not output.file
+          for rock in gen.get("rocks", []):
+              output = rock.get("output", {})
+              image = output.get("image")
+              file_ = output.get("file")
+              if not image:
+                  errors.append(
+                      f"Rock '{rock['name']}': expected output.image, got {output}"
+                  )
+              elif not image.startswith("ghcr.io/"):
+                  errors.append(
+                      f"Rock '{rock['name']}': image must start with ghcr.io/, got {image!r}"
+                  )
+              if file_:
+                  errors.append(
+                      f"Rock '{rock['name']}': output.file must not be set in CI, got {file_!r}"
+                  )
+
+          # Charms must have output.artifact + output.run-id, no files
+          for charm in gen.get("charms", []):
+              output = charm.get("output", {})
+              artifact = output.get("artifact")
+              run_id = output.get("run-id")
+              files = output.get("files", [])
+              if not artifact:
+                  errors.append(
+                      f"Charm '{charm['name']}': expected output.artifact, got {output}"
+                  )
+              if not run_id:
+                  errors.append(
+                      f"Charm '{charm['name']}': expected output.run-id, got {output}"
+                  )
+              if files:
+                  errors.append(
+                      f"Charm '{charm['name']}': output.files must not be set in CI, got {files!r}"
+                  )
+              # OCI resources must carry the rock's GHCR image ref
+              for res_name, res in (charm.get("resources") or {}).items():
+                  res_image = res.get("image")
+                  if not res_image:
+                      errors.append(
+                          f"Charm '{charm['name']}' resource '{res_name}': "
+                          f"expected image, got {res!r}"
+                      )
+                  elif not res_image.startswith("ghcr.io/"):
+                      errors.append(
+                          f"Charm '{charm['name']}' resource '{res_name}': "
+                          f"image must start with ghcr.io/, got {res_image!r}"
+                      )
+
+          if errors:
+              print("ASSERTION FAILURES:")
+              for e in errors:
+                  print(f"  - {e}")
+              sys.exit(1)
+
+          rocks = gen.get("rocks", [])
+          charms = gen.get("charms", [])
+          print("All CI-format assertions passed!")
+          print(f"  rocks  : {[r['name'] for r in rocks]}")
+          print(f"  charms : {[c['name'] for c in charms]}")
+          for rock in rocks:
+              print(f"    {rock['name']}.image = {rock['output']['image']}")
+          for charm in charms:
+              print(f"    {charm['name']}.artifact = {charm['output']['artifact']}")
+          EOF

--- a/.github/workflows/test-build-artifacts.yml
+++ b/.github/workflows/test-build-artifacts.yml
@@ -87,18 +87,19 @@ jobs:
                   errors.append(
                       f"Charm '{charm['name']}': output.files must not be set in CI, got {files!r}"
                   )
-              # OCI resources must carry the rock's GHCR image ref
+              # OCI resources: only rock link expected, no image field
               for res_name, res in (charm.get("resources") or {}).items():
+                  rock_link = res.get("rock")
                   res_image = res.get("image")
-                  if not res_image:
+                  if not rock_link:
                       errors.append(
                           f"Charm '{charm['name']}' resource '{res_name}': "
-                          f"expected image, got {res!r}"
+                          f"expected rock: reference, got {res!r}"
                       )
-                  elif not res_image.startswith("ghcr.io/"):
+                  if res_image:
                       errors.append(
                           f"Charm '{charm['name']}' resource '{res_name}': "
-                          f"image must start with ghcr.io/, got {res_image!r}"
+                          f"image must not be duplicated on resource (use rocks[].output.image)"
                       )
 
           if errors:

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -385,7 +385,6 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
 def _build_charm(
     charm: CharmArtifact,
     root: Path,
-    all_rocks: dict[str, GeneratedRock],
 ) -> GeneratedCharm:
     yaml_path = (root / charm.charmcraft_yaml).resolve()
     if not yaml_path.is_file():
@@ -410,17 +409,9 @@ def _build_charm(
 
     resources: dict[str, GeneratedResource] = {}
     for res_name, res_def in charm.resources.items():
-        file_val: str | None = None
-        image_val: str | None = None
-        if res_def.rock and res_def.rock in all_rocks:
-            rock_out = all_rocks[res_def.rock].output
-            file_val = rock_out.file
-            image_val = rock_out.image
         resources[res_name] = GeneratedResource(
             type=res_def.type,
             rock=res_def.rock,
-            file=file_val,
-            image=image_val,
         )
 
     return GeneratedCharm(
@@ -494,8 +485,7 @@ def artifacts_build(
     snaps_to_build = _filter_by_name(plan.snaps, snap_names, "snap")
 
     gen_rocks = [_build_rock(r, root) for r in rocks_to_build]
-    all_rocks = {r.name: r for r in gen_rocks}
-    gen_charms = [_build_charm(c, root, all_rocks) for c in charms_to_build]
+    gen_charms = [_build_charm(c, root) for c in charms_to_build]
     gen_snaps = [_build_snap(s, root) for s in snaps_to_build]
 
     # In GitHub Actions, rewrite outputs to CI-format references.
@@ -600,44 +590,21 @@ def artifacts_collect(root: Path, partial_paths: list[Path]) -> Path:
             )
             raise ConfigurationError(msg)
 
-    # Re-fill charm resource refs from the merged rock outputs.
+    # Validate that every rock referenced by a charm resource is present.
     rocks_by_name: dict[str, GeneratedRock] = {r.name: r for r in all_rocks}
-    filled_charms: list[GeneratedCharm] = []
     for charm in all_charms:
-        if not charm.resources:
-            filled_charms.append(charm)
-            continue
-        filled: dict[str, GeneratedResource] = {}
-        for res_name, res in charm.resources.items():
-            if res.rock and res.rock in rocks_by_name:
-                rock_out = rocks_by_name[res.rock].output
-                filled[res_name] = GeneratedResource(
-                    type=res.type,
-                    rock=res.rock,
-                    file=rock_out.file,
-                    image=rock_out.image,
-                )
-            elif res.rock and res.rock not in rocks_by_name:
+        for res_name, res in (charm.resources or {}).items():
+            if res.rock and res.rock not in rocks_by_name:
                 msg = (
                     f"Charm '{charm.name}' resource '{res_name}' references rock "
                     f"'{res.rock}' which was not found in the collected partials. "
                     f"Ensure the rock build job partial is included."
                 )
                 raise ConfigurationError(msg)
-            else:
-                filled[res_name] = res
-        filled_charms.append(
-            GeneratedCharm(
-                name=charm.name,
-                **{"charmcraft-yaml": charm.charmcraft_yaml},
-                output=charm.output,
-                resources=filled,
-            )
-        )
 
     generated = ArtifactsGenerated(
         rocks=all_rocks,
-        charms=filled_charms,
+        charms=all_charms,
         snaps=all_snaps,
     )
     dest = root / _ARTIFACTS_GENERATED_YAML

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -95,7 +95,7 @@ def _get_ci_context() -> _CIContext | None:
             ("GITHUB_REPOSITORY", repository),
             ("GITHUB_SHA", sha),
         ]
-        if not val
+        if not val.strip()
     ]
     if missing:
         msg = (
@@ -105,6 +105,9 @@ def _get_ci_context() -> _CIContext | None:
         raise ConfigurationError(msg)
 
     repo = repository.split("/", 1)[-1]
+    if not repo.strip():
+        msg = "GITHUB_REPOSITORY must be in 'owner/repo' format, got: {repository!r}"
+        raise ConfigurationError(msg)
     return _CIContext(run_id=run_id, owner=owner, repo=repo, sha=sha[:7])
 
 

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -11,6 +11,7 @@ import glob as globmod
 import logging
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 from opcli.core.discovery import discover_artifacts
@@ -56,6 +57,121 @@ _OUTPUT_GLOBS: dict[str, str] = {
     "rock": "*.rock",
     "snap": "*.snap",
 }
+
+
+@dataclass
+class _CIContext:
+    """GitHub Actions environment variables needed to produce CI-format outputs."""
+
+    run_id: str
+    owner: str  # lowercased GITHUB_REPOSITORY_OWNER
+    repo: str  # repository name only (not org/repo)
+    sha: str  # GITHUB_SHA[:7]
+
+
+def _get_ci_context() -> _CIContext | None:
+    """Return GitHub Actions context if running inside GitHub Actions, else ``None``.
+
+    Reads ``GITHUB_ACTIONS``, ``GITHUB_RUN_ID``, ``GITHUB_REPOSITORY_OWNER``,
+    ``GITHUB_REPOSITORY``, and ``GITHUB_SHA`` from the environment.
+
+    Raises:
+        ConfigurationError: If ``GITHUB_ACTIONS=true`` but required variables
+            are missing or empty.
+    """
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return None
+
+    run_id = os.environ.get("GITHUB_RUN_ID", "")
+    owner = os.environ.get("GITHUB_REPOSITORY_OWNER", "").lower()
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    sha = os.environ.get("GITHUB_SHA", "")
+
+    missing = [
+        name
+        for name, val in [
+            ("GITHUB_RUN_ID", run_id),
+            ("GITHUB_REPOSITORY_OWNER", owner),
+            ("GITHUB_REPOSITORY", repository),
+            ("GITHUB_SHA", sha),
+        ]
+        if not val
+    ]
+    if missing:
+        msg = (
+            f"GITHUB_ACTIONS=true but required variables are missing: "
+            f"{', '.join(missing)}"
+        )
+        raise ConfigurationError(msg)
+
+    repo = repository.split("/", 1)[-1]
+    return _CIContext(run_id=run_id, owner=owner, repo=repo, sha=sha[:7])
+
+
+def _push_rock_to_ghcr(
+    rock: GeneratedRock, ci: _CIContext, root: Path
+) -> GeneratedRock:
+    """Push a locally-built rock to GHCR and return an updated ``GeneratedRock``.
+
+    The rock ``.rock`` file is pushed to
+    ``ghcr.io/<owner>/<repo>/<name>:<sha7>`` using ``skopeo copy``.
+    The returned object has ``output.image`` set and no ``output.file``.
+
+    Raises:
+        OpcliError: If the rock file does not exist.
+        SubprocessError: If the skopeo push fails.
+    """
+    if not rock.output.file:
+        msg = f"Rock '{rock.name}' has no local file to push to GHCR."
+        raise OpcliError(msg)
+
+    rock_path = Path(rock.output.file)
+    if not rock_path.is_absolute():
+        rock_path = (root / rock_path).resolve()
+    if not rock_path.exists():
+        msg = f"Rock file not found: {rock_path}"
+        raise OpcliError(msg)
+
+    image_ref = f"ghcr.io/{ci.owner}/{ci.repo}/{rock.name}:{ci.sha}"
+    run_command(
+        [
+            "skopeo",
+            "--insecure-policy",
+            "copy",
+            f"oci-archive:{rock_path}",
+            f"docker://{image_ref}",
+        ],
+        cwd=str(root),
+    )
+    logger.info("Pushed rock '%s' to %s", rock.name, image_ref)
+    return GeneratedRock(
+        name=rock.name,
+        **{"rockcraft-yaml": rock.rockcraft_yaml},
+        output=ArtifactOutput(image=image_ref),
+    )
+
+
+def _to_ci_charm(charm: GeneratedCharm, ci: _CIContext) -> GeneratedCharm:
+    """Return a copy of *charm* with CI artifact-reference output."""
+    return GeneratedCharm(
+        name=charm.name,
+        **{"charmcraft-yaml": charm.charmcraft_yaml},
+        output=CharmArtifactOutput.model_validate(
+            {"artifact": f"built-charm-{charm.name}", "run-id": ci.run_id}
+        ),
+        resources=charm.resources,
+    )
+
+
+def _to_ci_snap(snap: GeneratedSnap, ci: _CIContext) -> GeneratedSnap:
+    """Return a copy of *snap* with CI artifact-reference output."""
+    return GeneratedSnap(
+        name=snap.name,
+        **{"snapcraft-yaml": snap.snapcraft_yaml},
+        output=ArtifactOutput.model_validate(
+            {"artifact": f"built-snap-{snap.name}", "run-id": ci.run_id}
+        ),
+    )
 
 
 def artifacts_init(root: Path, *, force: bool = False) -> Path:
@@ -378,6 +494,13 @@ def artifacts_build(
     all_rocks = {r.name: r for r in gen_rocks}
     gen_charms = [_build_charm(c, root, all_rocks) for c in charms_to_build]
     gen_snaps = [_build_snap(s, root) for s in snaps_to_build]
+
+    # In GitHub Actions, rewrite outputs to CI-format references.
+    ci = _get_ci_context()
+    if ci is not None:
+        gen_rocks = [_push_rock_to_ghcr(r, ci, root) for r in gen_rocks]
+        gen_charms = [_to_ci_charm(c, ci) for c in gen_charms]
+        gen_snaps = [_to_ci_snap(s, ci) for s in gen_snaps]
 
     generated = ArtifactsGenerated(
         rocks=gen_rocks,

--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -120,10 +120,6 @@ def provision_load(
         )
 
         rock.output.image = image_ref
-        for charm in generated.charms:
-            for res in (charm.resources or {}).values():
-                if res.rock == rock.name:
-                    res.image = image_ref
 
         pushed.append(image_ref)
         logger.info("Pushed %s", image_ref)

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -77,11 +77,8 @@ def assemble_pytest_args(
                 charm.output.artifact,
             )
 
-        # Only emit flags for resources not backed by a rock; rock-backed
-        # resources are already covered by the rock iteration above.
-        # Also skip any standalone resource whose flag name would duplicate a
-        # rock flag (e.g., a resource named "myrock-image" when "myrock" is in
-        # the rocks list).
+        # Resources backed by a rock are already covered by the rock
+        # iteration above. Resources without a rock link have no output info.
         for res_name, res in (charm.resources or {}).items():
             if res.rock:
                 continue
@@ -94,9 +91,6 @@ def assemble_pytest_args(
                     res_name,
                 )
                 continue
-            value = res.image or res.file
-            if value:
-                args.append(f"--{res_name}={value}")
 
     return args
 

--- a/src/opcli/models/artifacts_generated.py
+++ b/src/opcli/models/artifacts_generated.py
@@ -81,19 +81,16 @@ class CharmArtifactOutput(BaseModel):
 
 
 class GeneratedResource(BaseModel):
-    """A charm resource with its resolved output path or image reference.
+    """A charm OCI-image resource with a reference to its backing rock.
 
-    The ``file`` and ``image`` fields mirror the linked rock's ``output.file``
-    and ``output.image`` at build time.  Either may be ``None`` if the rock was
-    not built in the same ``opcli artifacts build`` invocation.
+    The actual image location is resolved by looking up the linked rock in
+    ``ArtifactsGenerated.rocks`` — it is not duplicated here.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["oci-image"]
     rock: str | None = None
-    file: str | None = None
-    image: str | None = None
 
 
 class GeneratedRock(BaseModel):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,20 @@
+"""Unit test fixtures for opcli.
+
+Unit tests exercise local (non-CI) behaviour by default.  The autouse
+fixture below removes GITHUB_ACTIONS from the environment so that tests
+never accidentally trigger GitHub-Actions-specific code paths (e.g.
+pushing rocks to GHCR) when the test suite runs inside GitHub Actions.
+
+Tests that explicitly cover CI mode (e.g. TestArtifactsBuildCIMode) set
+GITHUB_ACTIONS=true themselves via ``patch.dict(os.environ, ...)``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_github_actions_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure GITHUB_ACTIONS is unset for every unit test."""
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -318,12 +318,9 @@ class TestArtifactsBuild:
         res = charm.resources["myrock-image"]
         assert res.type == "oci-image"
         assert res.rock == "myrock"
-        assert res.file is not None
-        assert res.file.startswith("./")
-        assert "myrock_1.0_amd64.rock" in res.file
 
-    def test_resource_unresolved_when_rock_not_built(self, tmp_path: Path) -> None:
-        """Resource referencing a rock not in artifacts.yaml has unresolved output."""
+    def test_resource_only_carries_rock_link(self, tmp_path: Path) -> None:
+        """Resource referencing a rock only stores type + rock; no file/image."""
         _write(
             tmp_path / "artifacts.yaml",
             "version: 1\n"
@@ -343,8 +340,8 @@ class TestArtifactsBuild:
         charm = gen.charms[0]
         assert charm.resources is not None
         res = charm.resources["myrock-image"]
-        assert res.file is None
-        assert res.image is None
+        assert res.type == "oci-image"
+        assert res.rock == "nonexistent-rock"
 
     def test_invalid_generated_fields_rejected(self, tmp_path: Path) -> None:
         _write(
@@ -665,7 +662,7 @@ class TestArtifactsCollect:
         assert gen.charms[0].name == "my-charm"
 
     def test_fills_charm_resource_from_merged_rock(self, tmp_path: Path) -> None:
-        """Rock built in parallel job — resource ref must be filled during collect."""
+        """Collect validates rock reference; image lives on rock, not resource."""
         rock_partial = self._partial(
             tmp_path,
             "rock-job",
@@ -684,16 +681,16 @@ class TestArtifactsCollect:
             "  resources:\n"
             "    my-rock-image:\n"
             "      type: oci-image\n"
-            "      rock: my-rock\n"
-            "      file: null\n"
-            "      image: null\n",
+            "      rock: my-rock\n",
         )
 
         artifacts_collect(tmp_path, [rock_partial, charm_partial])
 
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        # Image lives on the rock, not on the resource
+        assert gen.rocks[0].output.file == "./my-rock_1.0_amd64.rock"
         resource = gen.charms[0].resources["my-rock-image"]  # type: ignore[index]
-        assert resource.file == "./my-rock_1.0_amd64.rock"
+        assert resource.rock == "my-rock"
 
     def test_merges_multiple_rocks(self, tmp_path: Path) -> None:
         rock1 = self._partial(
@@ -740,9 +737,7 @@ class TestArtifactsCollect:
             "  resources:\n"
             "    missing-rock-image:\n"
             "      type: oci-image\n"
-            "      rock: missing-rock\n"
-            "      file: null\n"
-            "      image: null\n",
+            "      rock: missing-rock\n",
         )
 
         with pytest.raises(ConfigurationError, match="missing-rock"):
@@ -952,7 +947,7 @@ class TestArtifactsCollectCIMode:
     def test_collect_fills_charm_resource_image_from_ghcr_rock(
         self, tmp_path: Path
     ) -> None:
-        """Collect must propagate rock GHCR image ref to charm resource."""
+        """Collect merges partials; rock GHCR image lives on rock, not the resource."""
         rock_partial = self._partial(
             tmp_path,
             "rock-job",
@@ -969,9 +964,7 @@ class TestArtifactsCollectCIMode:
             "  resources:\n"
             "    my-rock-image:\n"
             "      type: oci-image\n"
-            "      rock: my-rock\n"
-            "      file: null\n"
-            "      image: null\n",
+            "      rock: my-rock\n",
         )
 
         artifacts_collect(tmp_path, [rock_partial, charm_partial])
@@ -979,8 +972,8 @@ class TestArtifactsCollectCIMode:
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
         assert gen.rocks[0].output.image == "ghcr.io/myorg/my-repo/my-rock:abc1234"
         resource = gen.charms[0].resources["my-rock-image"]  # type: ignore[index]
-        assert resource.image == "ghcr.io/myorg/my-repo/my-rock:abc1234"
-        assert resource.file is None
+        # Resource carries the rock reference; image resolved from rock.output.image
+        assert resource.rock == "my-rock"
         # Charm itself still has artifact ref
         assert gen.charms[0].output.artifact == "built-charm-my-charm"
         assert gen.charms[0].output.run_id == "9876543210"

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -766,3 +767,220 @@ class TestArtifactsCollect:
 
         with pytest.raises(ConfigurationError, match="my-rock"):
             artifacts_collect(tmp_path, [rock1, rock2])
+
+
+class TestArtifactsBuildCIMode:
+    """Tests for artifacts_build() GitHub Actions CI output format."""
+
+    _CI_ENV: ClassVar[dict[str, str]] = {
+        "GITHUB_ACTIONS": "true",
+        "GITHUB_RUN_ID": "9876543210",
+        "GITHUB_REPOSITORY_OWNER": "MyOrg",
+        "GITHUB_REPOSITORY": "MyOrg/my-repo",
+        "GITHUB_SHA": "abc1234def5678",
+    }
+
+    def test_rock_build_pushes_to_ghcr_and_writes_image_ref(
+        self, tmp_path: Path
+    ) -> None:
+        """In CI, rock output should be a GHCR image ref, not a local file."""
+        _write(tmp_path / "rockcraft.yaml", "name: my-rock\n")
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\nrocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n",
+        )
+        rock_file = tmp_path / "my-rock_1.0_amd64.rock"
+        rock_file.write_bytes(b"fake rock")
+
+        with (
+            patch("opcli.core.artifacts.run_command") as mock_run,
+            patch.dict(os.environ, self._CI_ENV, clear=False),
+        ):
+            mock_run.side_effect = lambda cmd, **_: rock_file.touch()
+            result = artifacts_build(tmp_path, rock_names=["my-rock"])
+
+        gen = load_artifacts_generated(result)
+        assert len(gen.rocks) == 1
+        rock_out = gen.rocks[0].output
+        assert rock_out.file is None
+        assert rock_out.image == "ghcr.io/myorg/my-repo/my-rock:abc1234"
+
+        # Verify skopeo was called to push to GHCR
+        skopeo_calls = [c for c in mock_run.call_args_list if "skopeo" in str(c)]
+        assert len(skopeo_calls) == 1
+        skopeo_args = skopeo_calls[0][0][0]
+        assert "skopeo" in skopeo_args
+        assert any("ghcr.io/myorg/my-repo/my-rock:abc1234" in a for a in skopeo_args)
+
+    def test_charm_build_writes_artifact_ref(self, tmp_path: Path) -> None:
+        """In CI, charm output should be a GitHub artifact reference."""
+        _write(tmp_path / "charmcraft.yaml", "name: my-charm\n")
+        _write(
+            tmp_path / "artifacts.yaml",
+            (
+                "version: 1\ncharms:\n- name: my-charm\n"
+                "  charmcraft-yaml: charmcraft.yaml\n"
+            ),
+        )
+        charm_file = tmp_path / "my-charm_ubuntu-24.04-amd64.charm"
+
+        with (
+            patch("opcli.core.artifacts.run_command") as mock_run,
+            patch.dict(os.environ, self._CI_ENV, clear=False),
+        ):
+            mock_run.side_effect = lambda cmd, **_: charm_file.touch()
+            result = artifacts_build(tmp_path, charm_names=["my-charm"])
+
+        gen = load_artifacts_generated(result)
+        assert len(gen.charms) == 1
+        charm_out = gen.charms[0].output
+        assert charm_out.files == []
+        assert charm_out.artifact == "built-charm-my-charm"
+        assert charm_out.run_id == "9876543210"
+
+    def test_snap_build_writes_artifact_ref(self, tmp_path: Path) -> None:
+        """In CI, snap output should be a GitHub artifact reference."""
+        _write(tmp_path / "snap" / "snapcraft.yaml", "name: my-snap\n")
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\nsnaps:\n- name: my-snap\n"
+            "  snapcraft-yaml: snap/snapcraft.yaml\n",
+        )
+        snap_file = tmp_path / "snap" / "my-snap_1.0_amd64.snap"
+
+        with (
+            patch("opcli.core.artifacts.run_command") as mock_run,
+            patch.dict(os.environ, self._CI_ENV, clear=False),
+        ):
+            mock_run.side_effect = lambda cmd, **_: snap_file.touch()
+            result = artifacts_build(tmp_path, snap_names=["my-snap"])
+
+        gen = load_artifacts_generated(result)
+        assert len(gen.snaps) == 1
+        snap_out = gen.snaps[0].output
+        assert snap_out.file is None
+        assert snap_out.artifact == "built-snap-my-snap"
+        assert snap_out.run_id == "9876543210"
+
+    def test_local_build_unchanged_when_no_github_actions(self, tmp_path: Path) -> None:
+        """Without GITHUB_ACTIONS=true, build produces local file refs."""
+        _write(tmp_path / "charmcraft.yaml", "name: my-charm\n")
+        _write(
+            tmp_path / "artifacts.yaml",
+            (
+                "version: 1\ncharms:\n- name: my-charm\n"
+                "  charmcraft-yaml: charmcraft.yaml\n"
+            ),
+        )
+        charm_file = tmp_path / "my-charm_ubuntu-24.04-amd64.charm"
+
+        with (
+            patch("opcli.core.artifacts.run_command") as mock_run,
+            patch.dict(os.environ, {"GITHUB_ACTIONS": ""}, clear=False),
+        ):
+            mock_run.side_effect = lambda cmd, **_: charm_file.touch()
+            result = artifacts_build(tmp_path, charm_names=["my-charm"])
+
+        gen = load_artifacts_generated(result)
+        charm_out = gen.charms[0].output
+        assert charm_out.artifact is None
+        assert len(charm_out.files) == 1
+        assert "my-charm_ubuntu-24.04-amd64.charm" in charm_out.files[0].path
+
+    def test_ci_missing_env_vars_raises(self, tmp_path: Path) -> None:
+        """GITHUB_ACTIONS=true with missing env vars raises ConfigurationError."""
+        _write(tmp_path / "charmcraft.yaml", "name: my-charm\n")
+        _write(
+            tmp_path / "artifacts.yaml",
+            (
+                "version: 1\ncharms:\n- name: my-charm\n"
+                "  charmcraft-yaml: charmcraft.yaml\n"
+            ),
+        )
+        charm_file = tmp_path / "my-charm_ubuntu-24.04-amd64.charm"
+
+        with (
+            patch("opcli.core.artifacts.run_command") as mock_run,
+            patch.dict(
+                os.environ,
+                {
+                    "GITHUB_ACTIONS": "true",
+                    "GITHUB_RUN_ID": "",
+                    "GITHUB_REPOSITORY_OWNER": "",
+                    "GITHUB_REPOSITORY": "",
+                    "GITHUB_SHA": "",
+                },
+                clear=False,
+            ),
+            pytest.raises(ConfigurationError, match="GITHUB_RUN_ID"),
+        ):
+            mock_run.side_effect = lambda cmd, **_: charm_file.touch()
+            artifacts_build(tmp_path, charm_names=["my-charm"])
+
+    def test_owner_is_lowercased(self, tmp_path: Path) -> None:
+        """GITHUB_REPOSITORY_OWNER is lowercased in the image ref."""
+        _write(tmp_path / "rockcraft.yaml", "name: my-rock\n")
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\nrocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n",
+        )
+        rock_file = tmp_path / "my-rock_1.0_amd64.rock"
+        rock_file.write_bytes(b"fake rock")
+
+        with (
+            patch("opcli.core.artifacts.run_command") as mock_run,
+            patch.dict(os.environ, self._CI_ENV, clear=False),
+        ):
+            mock_run.side_effect = lambda cmd, **_: rock_file.touch()
+            result = artifacts_build(tmp_path, rock_names=["my-rock"])
+
+        gen = load_artifacts_generated(result)
+        assert gen.rocks[0].output.image is not None
+        assert "MyOrg" not in gen.rocks[0].output.image
+        assert "myorg" in gen.rocks[0].output.image
+
+
+class TestArtifactsCollectCIMode:
+    """Tests for artifacts_collect() with CI-format (image/artifact) partials."""
+
+    def _partial(self, tmp_path: Path, name: str, content: str) -> Path:
+        p = tmp_path / name / "artifacts-generated.yaml"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+        return p
+
+    def test_collect_fills_charm_resource_image_from_ghcr_rock(
+        self, tmp_path: Path
+    ) -> None:
+        """Collect must propagate rock GHCR image ref to charm resource."""
+        rock_partial = self._partial(
+            tmp_path,
+            "rock-job",
+            "version: 1\n"
+            "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
+            "  output:\n    image: ghcr.io/myorg/my-repo/my-rock:abc1234\n",
+        )
+        charm_partial = self._partial(
+            tmp_path,
+            "charm-job",
+            "version: 1\n"
+            "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
+            "  output:\n    artifact: built-charm-my-charm\n    run-id: '9876543210'\n"
+            "  resources:\n"
+            "    my-rock-image:\n"
+            "      type: oci-image\n"
+            "      rock: my-rock\n"
+            "      file: null\n"
+            "      image: null\n",
+        )
+
+        artifacts_collect(tmp_path, [rock_partial, charm_partial])
+
+        gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        assert gen.rocks[0].output.image == "ghcr.io/myorg/my-repo/my-rock:abc1234"
+        resource = gen.charms[0].resources["my-rock-image"]  # type: ignore[index]
+        assert resource.image == "ghcr.io/myorg/my-repo/my-rock:abc1234"
+        assert resource.file is None
+        # Charm itself still has artifact ref
+        assert gen.charms[0].output.artifact == "built-charm-my-charm"
+        assert gen.charms[0].output.run_id == "9876543210"

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -45,6 +45,10 @@ rocks:
   rockcraft-yaml: rock_dir/rockcraft.yaml
   output:
     file: ./rock_dir/myrock.rock
+- name: otherrock
+  rockcraft-yaml: other_dir/rockcraft.yaml
+  output:
+    image: ghcr.io/canonical/otherrock:abc
 charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
@@ -56,11 +60,9 @@ charms:
     myrock-image:
       type: oci-image
       rock: myrock
-      file: ./rock_dir/myrock.rock
     other-res:
       type: oci-image
       rock: otherrock
-      image: ghcr.io/canonical/otherrock:abc
 """
 
 
@@ -175,7 +177,7 @@ class TestProvisionLoad:
         assert myrock.output.file == "./rock_dir/myrock.rock"
 
     def test_updates_charm_resources_for_pushed_rock(self, tmp_path: Path) -> None:
-        """Charm resources referencing a pushed rock get image ref set."""
+        """provision_load pushes rocks; charm resources reference via rock: field."""
         _write(
             tmp_path / "artifacts-generated.yaml",
             _GENERATED_WITH_ROCKS_AND_RESOURCES,
@@ -185,13 +187,14 @@ class TestProvisionLoad:
             provision_load(tmp_path)
 
         updated = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        # Rock output.image is updated after push
+        myrock = next(r for r in updated.rocks if r.name == "myrock")
+        assert myrock.output.image == "localhost:32000/myrock:latest"
+        # Charm resources still only carry the rock reference, not a duplicated image
         charm = updated.charms[0]
-        myrock_res = charm.resources["myrock-image"]  # type: ignore[index]
-        assert myrock_res.image == "localhost:32000/myrock:latest"
-        assert myrock_res.file == "./rock_dir/myrock.rock"
-        # Resource referencing a different rock is not touched
-        other_res = charm.resources["other-res"]  # type: ignore[index]
-        assert other_res.image == "ghcr.io/canonical/otherrock:abc"
+        assert charm.resources is not None
+        assert charm.resources["myrock-image"].rock == "myrock"
+        assert charm.resources["other-res"].rock == "otherrock"
 
     def test_idempotent_skips_already_loaded_rock(self, tmp_path: Path) -> None:
         """Rock with image already set to the target ref is skipped."""

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -40,7 +40,6 @@ charms:
     myrock-image:
       type: oci-image
       rock: myrock
-      file: ./rock_dir/myrock.rock
 """
 
 _GENERATED_CI = """\
@@ -60,7 +59,6 @@ charms:
     myrock-image:
       type: oci-image
       rock: myrock
-      image: ghcr.io/canonical/myrock:abc123
 """
 
 _GENERATED_NO_RESOURCES = """\
@@ -245,8 +243,8 @@ class TestAssemblePytestArgs:
         assert "--expressjs-app-image=./expressjs-app_1.0_amd64.rock" in args
         assert "--fastapi-app-image=./fastapi-app_1.0_amd64.rock" in args
 
-    def test_resource_without_rock_uses_resource_name(self, tmp_path: Path) -> None:
-        """Resources not linked to a rock fall back to the resource name as flag."""
+    def test_resource_without_rock_link_produces_no_flag(self, tmp_path: Path) -> None:
+        """Resources not linked to a rock (no rock: field) produce no image flag."""
         _write(
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: mycharm\n"
@@ -254,13 +252,13 @@ class TestAssemblePytestArgs:
             "  output:\n    files:\n"
             "    - path: ./mycharm_ubuntu-22.04-amd64.charm\n"
             "      base: ubuntu@22.04\n"
-            "  resources:\n    standalone-image:\n      type: oci-image\n"
-            "      image: ghcr.io/canonical/standalone:latest\n",
+            "  resources:\n    standalone-image:\n      type: oci-image\n",
         )
 
         args = assemble_pytest_args(tmp_path)
 
-        assert "--standalone-image=ghcr.io/canonical/standalone:latest" in args
+        # Only charm-file; no image flag for a resource with no rock backing
+        assert args == ["--charm-file=./mycharm_ubuntu-22.04-amd64.charm"]
 
 
 class TestAssembleToxArgv:


### PR DESCRIPTION
## Summary

When running inside GitHub Actions, `opcli artifacts build` now produces CI-format references instead of local file paths:

| Type | Local | CI |
|------|-------|----|
| Rock | `output.file: ./path/to.rock` | `output.image: ghcr.io/<owner>/<repo>/<name>:<sha7>` |
| Charm | `output.files: [{path: ./path/to.charm}]` | `output.artifact: built-charm-<name>` + `output.run-id: <run_id>` |
| Snap | `output.file: ./path/to.snap` | `output.artifact: built-snap-<name>` + `output.run-id: <run_id>` |

## Detection

Triggered by `GITHUB_ACTIONS=true` (not the generic `CI` var, to avoid breakage in non-GitHub CI). Reads `GITHUB_RUN_ID`, `GITHUB_REPOSITORY_OWNER`, `GITHUB_REPOSITORY`, `GITHUB_SHA` — fails fast with a clear error if any are missing.

## Rock push

Rocks are pushed to GHCR via `skopeo copy oci-archive:<path> docker://ghcr.io/<owner>/<repo>/<name>:<sha7>`. The workflow adds `skopeo login ghcr.io` (only for rock jobs) and `permissions: packages: write`.

## Collect

The existing `artifacts_collect` already propagates `rock.output.image` to charm resources — no changes needed there.

## Tests

7 new unit tests (`TestArtifactsBuildCIMode`, `TestArtifactsCollectCIMode`) covering all CI-mode paths. 251 tests total passing.