### PR TITLE
fix: use get-workflow-version-action to resolve opcli ref (fixes #79)

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -9,13 +9,18 @@ name: Build Artifacts
 #   jobs:
 #     build:
 #       uses: javierdelapuente/operator-ci-poc/.github/workflows/build-artifacts.yml@main
-#       with:
-#         working-directory: .   # directory containing artifacts.yaml (default: .)
+#       permissions:
+#         contents: read
+#         packages: write
+#         actions: read   # required for get-workflow-version-action
 #
-# opcli is installed from the same ref used to call this workflow (derived from
-# github.workflow_ref), so pinning @sha or @tag gives a fully reproducible build.
-# Override with opcli-ref only when you need a different ref (e.g. during CI of
-# this repo itself, where the PR head SHA must be passed explicitly).
+# opcli is installed at the exact commit SHA this workflow was called with,
+# resolved via canonical/get-workflow-version-action (a workaround for
+# https://github.com/actions/toolkit/issues/1264 — github.workflow_ref always
+# refers to the caller's workflow, not this one).
+#
+# Override with opcli-ref only when calling from the same repository (where
+# referenced_workflows is not populated), e.g. in test-build-artifacts.yml.
 
 on:
   workflow_call:
@@ -26,10 +31,11 @@ on:
         default: "."
       opcli-ref:
         description: >
-          Git ref to install opcli from. Leave empty to auto-derive from the ref
-          used to call this workflow (the default and recommended behaviour for
-          external callers). Override only when the auto-derived ref is not
-          directly fetchable (e.g. a PR test-merge commit).
+          Git ref to install opcli from. Leave empty for external callers
+          (auto-resolved via get-workflow-version-action). Must be set
+          explicitly when calling from within the same repository (e.g.
+          tests), because referenced_workflows is not populated for
+          same-repo calls.
         type: string
         default: ""
 
@@ -38,13 +44,26 @@ jobs:
   build-matrix:
     name: Build matrix
     runs-on: ubuntu-latest
+    permissions:
+      actions: read  # required by get-workflow-version-action
+      contents: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      opcli-sha: ${{ inputs.opcli-ref != '' && inputs.opcli-ref || steps.workflow-version.outputs.sha }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Get workflow version
+        id: workflow-version
+        if: inputs.opcli-ref == ''
+        uses: canonical/get-workflow-version-action@v1
+        with:
+          repository-name: javierdelapuente/operator-ci-poc
+          file-name: build-artifacts.yml
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: astral-sh/setup-uv@v6
         with:
@@ -52,15 +71,7 @@ jobs:
 
       - name: Install opcli
         run: |
-          # If opcli-ref was explicitly provided, use it; otherwise derive the ref
-          # from github.workflow_ref so the installed opcli matches the pinned
-          # workflow ref (e.g. @main, @sha, @v1.0) automatically.
-          opcli_ref="${{ inputs.opcli-ref }}"
-          if [ -z "$opcli_ref" ]; then
-            workflow_ref="${{ github.workflow_ref }}"
-            opcli_ref="${workflow_ref##*@}"
-          fi
-          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${opcli_ref}"
+          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ inputs.opcli-ref != '' && inputs.opcli-ref || steps.workflow-version.outputs.sha }}"
 
       - name: Generate build matrix
         id: matrix
@@ -91,15 +102,7 @@ jobs:
 
       - name: Install opcli
         run: |
-          # If opcli-ref was explicitly provided, use it; otherwise derive the ref
-          # from github.workflow_ref so the installed opcli matches the pinned
-          # workflow ref (e.g. @main, @sha, @v1.0) automatically.
-          opcli_ref="${{ inputs.opcli-ref }}"
-          if [ -z "$opcli_ref" ]; then
-            workflow_ref="${{ github.workflow_ref }}"
-            opcli_ref="${workflow_ref##*@}"
-          fi
-          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${opcli_ref}"
+          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ needs.build-matrix.outputs.opcli-sha }}"
 
       - name: Set up LXD
         uses: canonical/setup-lxd@main
@@ -143,7 +146,7 @@ jobs:
   # ── Job 3: merge all partials into the final artifacts-generated.yaml ───────
   collect:
     name: Collect artifacts
-    needs: build
+    needs: [build-matrix, build]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -157,15 +160,7 @@ jobs:
 
       - name: Install opcli
         run: |
-          # If opcli-ref was explicitly provided, use it; otherwise derive the ref
-          # from github.workflow_ref so the installed opcli matches the pinned
-          # workflow ref (e.g. @main, @sha, @v1.0) automatically.
-          opcli_ref="${{ inputs.opcli-ref }}"
-          if [ -z "$opcli_ref" ]; then
-            workflow_ref="${{ github.workflow_ref }}"
-            opcli_ref="${workflow_ref##*@}"
-          fi
-          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${opcli_ref}"
+          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ needs.build-matrix.outputs.opcli-sha }}"
 
       - name: Download all partial artifacts-generated.yaml files
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -15,12 +15,8 @@ name: Build Artifacts
 #         actions: read   # required for get-workflow-version-action
 #
 # opcli is installed at the exact commit SHA this workflow was called with,
-# resolved via canonical/get-workflow-version-action (a workaround for
-# https://github.com/actions/toolkit/issues/1264 — github.workflow_ref always
-# refers to the caller's workflow, not this one).
-#
-# Override with opcli-ref only when calling from the same repository (where
-# referenced_workflows is not populated), e.g. in test-build-artifacts.yml.
+# resolved via canonical/get-workflow-version-action (workaround for
+# https://github.com/actions/toolkit/issues/1264).
 
 on:
   workflow_call:
@@ -29,15 +25,6 @@ on:
         description: "Directory containing artifacts.yaml (relative to workspace root)"
         type: string
         default: "."
-      opcli-ref:
-        description: >
-          Git ref to install opcli from. Leave empty for external callers
-          (auto-resolved via get-workflow-version-action). Must be set
-          explicitly when calling from within the same repository (e.g.
-          tests), because referenced_workflows is not populated for
-          same-repo calls.
-        type: string
-        default: ""
 
 jobs:
   # ── Job 1: produce the build matrix ────────────────────────────────────────
@@ -49,7 +36,7 @@ jobs:
       contents: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
-      opcli-sha: ${{ inputs.opcli-ref != '' && inputs.opcli-ref || steps.workflow-version.outputs.sha }}
+      opcli-sha: ${{ steps.workflow-version.outputs.sha }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -58,7 +45,6 @@ jobs:
 
       - name: Get workflow version
         id: workflow-version
-        if: inputs.opcli-ref == ''
         uses: canonical/get-workflow-version-action@v1
         with:
           repository-name: javierdelapuente/operator-ci-poc
@@ -71,7 +57,7 @@ jobs:
 
       - name: Install opcli
         run: |
-          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ inputs.opcli-ref != '' && inputs.opcli-ref || steps.workflow-version.outputs.sha }}"
+          uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ steps.workflow-version.outputs.sha }}"
 
       - name: Generate build matrix
         id: matrix

--- a/.github/workflows/test-build-artifacts.yml
+++ b/.github/workflows/test-build-artifacts.yml
@@ -25,14 +25,10 @@ jobs:
     uses: ./.github/workflows/build-artifacts.yml
     with:
       working-directory: examples
-      # Pass the head commit SHA explicitly: same-repo workflow calls do not
-      # populate referenced_workflows, so get-workflow-version-action cannot
-      # auto-resolve the ref. For PRs this is the PR branch head; for pushes
-      # to main it is the merge commit.
-      opcli-ref: ${{ github.event.pull_request.head.sha || github.sha }}
     permissions:
       packages: write
       contents: read
+      actions: read
 
   verify:
     name: Verify CI output format

--- a/.github/workflows/test-build-artifacts.yml
+++ b/.github/workflows/test-build-artifacts.yml
@@ -25,6 +25,11 @@ jobs:
     uses: ./.github/workflows/build-artifacts.yml
     with:
       working-directory: examples
+      # Pass the head commit SHA explicitly: same-repo workflow calls do not
+      # populate referenced_workflows, so get-workflow-version-action cannot
+      # auto-resolve the ref. For PRs this is the PR branch head; for pushes
+      # to main it is the merge commit.
+      opcli-ref: ${{ github.event.pull_request.head.sha || github.sha }}
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
## Problem

When `build-artifacts.yml` is called from an **external repo's PR**, `github.workflow_ref` is the caller's workflow ref (e.g. `paas-charm/.github/workflows/build.yaml@refs/pull/11/merge`). Stripping after `@` gives a ref that doesn't exist in `operator-ci-poc`, so the opcli install fails.

Fixes #79.

## Solution

Use [`canonical/get-workflow-version-action`](https://github.com/canonical/get-workflow-version-action) — the standard Canonical workaround for [actions/toolkit#1264](https://github.com/actions/toolkit/issues/1264). It queries the GitHub API (`referenced_workflows` on the run) to get the exact commit SHA this reusable workflow was called with.

## Changes

- **`build-matrix`** job: calls `get-workflow-version-action` when `opcli-ref` is not provided; outputs `opcli-sha` for downstream jobs. Needs `permissions: actions: read`.
- **`build`** and **`collect`** jobs: install opcli from `needs.build-matrix.outputs.opcli-sha` — no per-job ref derivation.
- **`collect`** now also `needs: [build-matrix, build]` to access the `opcli-sha` output.
- **`test-build-artifacts.yml`**: passes `opcli-ref` explicitly as `github.event.pull_request.head.sha || github.sha`, because same-repo calls don't populate `referenced_workflows`.