### PR TITLE
fix: set UV_TOOL_BIN_DIR=/usr/local/bin in CI prepare

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -299,6 +299,7 @@ chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 """
 
 _CI_PREPARE = """\
+export UV_TOOL_BIN_DIR=/usr/local/bin
 if grep -q 'name = "opcli"' "${SPREAD_PATH}/pyproject.toml" 2>/dev/null; then
   uv tool install "${SPREAD_PATH}" --quiet
 else

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -197,6 +197,7 @@ class TestSpreadExpand:
         assert "SPREAD_PATH" in ci["prepare"]
         assert "chown" in ci["prepare"]
         assert "runuser" not in ci["prepare"]
+        assert "UV_TOOL_BIN_DIR=/usr/local/bin" in ci["prepare"]
         # CI backend overrides SUDO_USER so concierge targets the actual host user
         assert ci.get("environment", {}).get("SUDO_USER") == "$(HOST: id -un)"
         assert "pipx install" not in ci["prepare"]


### PR DESCRIPTION
## Problem

In CI, spread's EXECUTE script calls `opcli pytest expand` but `opcli` isn't found.

Root cause: `uv tool install` (running as root in `_CI_PREPARE`) installs wrappers to `/root/.local/bin`. Non-interactive SSH sessions used by spread's EXECUTE stage don't include `/root/.local/bin` in PATH.

## Fix

Set `UV_TOOL_BIN_DIR=/usr/local/bin` before all `uv tool install` calls in `_CI_PREPARE`. This installs the `opcli` and `tox` wrappers to `/usr/local/bin` which is always in PATH for all users and session types.