### PR TITLE
fix: enable ubuntu linger before concierge to fix snap cgroup issue

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -151,6 +151,10 @@ jobs:
       - name: Localize artifacts
         run: opcli artifacts localize
 
+      # ── Make workspace readable by the ubuntu user spread runs tests as ───
+      - name: Make workspace world-readable
+        run: chmod -R o+rX $GITHUB_WORKSPACE
+
       # ── Run the spread task ───────────────────────────────────────────────
       - name: Run spread task
         env:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -151,10 +151,6 @@ jobs:
       - name: Localize artifacts
         run: opcli artifacts localize
 
-      # ── Make workspace readable by the ubuntu user spread runs tests as ───
-      - name: Make workspace world-readable
-        run: chmod -R o+rX $GITHUB_WORKSPACE
-
       # ── Run the spread task ───────────────────────────────────────────────
       - name: Run spread task
         env:

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -681,7 +681,8 @@ def artifacts_localize(root: Path) -> int:
                 matches[0],
             )
 
-        charm.output.files = [CharmFile(path="./" + str(Path(matches[0]).relative_to(root)))]
+        rel = "./" + str(Path(matches[0]).relative_to(root))
+        charm.output.files = [CharmFile(path=rel)]
         logger.info("Localised charm '%s' → %s", charm.name, matches[0])
         updated += 1
 

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -681,7 +681,7 @@ def artifacts_localize(root: Path) -> int:
                 matches[0],
             )
 
-        charm.output.files = [CharmFile(path=matches[0])]
+        charm.output.files = [CharmFile(path="./" + str(Path(matches[0]).relative_to(root)))]
         logger.info("Localised charm '%s' → %s", charm.name, matches[0])
         updated += 1
 

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -307,8 +307,9 @@ else
       "git+https://github.com/javierdelapuente/operator-ci-poc@${OPCLI_GIT_REF:-main}" \
       --quiet
 fi
-runuser -l ubuntu -c "uv tool install tox --with tox-uv --quiet"
+runuser -l ubuntu -c "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox --with tox-uv --quiet"
 if [ -f "$CONCIERGE" ]; then
+  loginctl enable-linger ubuntu
   snap install concierge --classic
   concierge prepare -c "$CONCIERGE"
 fi

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1007,7 +1007,10 @@ class TestArtifactsLocalize:
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
         assert gen.charms[0].output.files is not None
         assert len(gen.charms[0].output.files) == 1
-        assert gen.charms[0].output.files[0].path.endswith(".charm")
+        path = gen.charms[0].output.files[0].path
+        assert path.endswith(".charm")
+        assert path.startswith("./"), f"Expected relative path, got: {path}"
+        assert "/home/" not in path, f"Expected no absolute home path, got: {path}"
 
     def test_skips_charm_already_with_local_files(self, tmp_path: Path) -> None:
         """Does not overwrite charms that already have output.files."""

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -196,9 +196,11 @@ class TestSpreadExpand:
         assert "opcli" in ci["prepare"]
         assert "SPREAD_PATH" in ci["prepare"]
         assert "chown" in ci["prepare"]
-        # tox is installed for the ubuntu user via runuser
+        # tox is installed for the ubuntu user via runuser with explicit bin dir
         assert "runuser" in ci["prepare"]
         assert "runuser -l ubuntu" in ci["prepare"]
+        assert "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox" in ci["prepare"]
+        assert "loginctl enable-linger ubuntu" in ci["prepare"]
         assert "UV_TOOL_BIN_DIR=/usr/local/bin" in ci["prepare"]
         # CI backend does NOT override SUDO_USER; ubuntu is created in allocate
         assert "environment" not in ci


### PR DESCRIPTION
## Problem

When concierge (snap) runs as root via SSH and internally calls `sudo -u ubuntu juju`, juju's snap-confine fails:

```
snap.concierge.concierge-UUID.scope is not a snap cgroup for tag snap.juju.juju
```

This causes concierge to fail bootstrapping the Juju controller.

## Root Cause

Snap-confine needs ubuntu's systemd user manager to be running so it can create `snap.juju.juju-*.scope` under ubuntu's user slice. Without linger, ubuntu has no active user session and snap-confine can't place the juju invocation in the correct cgroup.

## Fix

Add `loginctl enable-linger ubuntu` in `_CI_PREPARE` before installing/running concierge. This starts ubuntu's systemd user manager, enabling snap-confine to properly scope the juju snap invocation.