### PR TITLE
feat: run test provisioning in parallel with artifact build

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -141,4 +141,8 @@ jobs:
       - name: Run spread task
         env:
           CI: "true"
-        run: opcli spread run -- ${{ matrix.selector }}
+          # GITHUB_TOKEN must be explicit — it is not auto-exported by Actions.
+          # Spread captures it via $(HOST: echo "${GITHUB_TOKEN:-}") and the
+          # _CI_PREPARE script uses it to authenticate `gh run download`.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: opcli spread run -- -vv ${{ matrix.selector }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,9 +40,9 @@ jobs:
       actions: read
 
   # ── Job 2: generate the spread test matrix ──────────────────────────────────
+  # Runs in parallel with the build job — only needs spread.yaml from the repo.
   test-plan:
     name: Generate test matrix
-    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,9 +82,12 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   # ── Job 3: run each spread task ─────────────────────────────────────────────
+  # Starts as soon as test-plan finishes — does NOT wait for the build job.
+  # Provisioning runs in parallel with the build.  The spread _CI_PREPARE script
+  # waits for and downloads the build artifacts before executing tests.
   test:
     name: "${{ matrix.name }}"
-    needs: [build, test-plan]
+    needs: [test-plan]
     runs-on: ${{ fromJSON(matrix.runs-on) }}
     permissions:
       contents: read
@@ -133,25 +136,8 @@ jobs:
           go install github.com/canonical/spread/cmd/spread@latest
           sudo ln -sf ~/go/bin/spread /usr/local/bin/spread
 
-      # ── Download build artifacts ──────────────────────────────────────────
-      - name: Download artifacts-generated.yaml
-        uses: actions/download-artifact@v4
-        with:
-          name: artifacts-generated
-          path: ${{ inputs.working-directory }}/
-
-      - name: Download built charm files
-        uses: actions/download-artifact@v4
-        with:
-          pattern: built-charm-*
-          merge-multiple: true
-          path: ${{ inputs.working-directory }}/
-
-      # ── Localize charm artifact refs to downloaded files ──────────────────
-      - name: Localize artifacts
-        run: opcli artifacts localize
-
       # ── Run the spread task ───────────────────────────────────────────────
+      # Artifact download happens inside spread _CI_PREPARE (after provisioning).
       - name: Run spread task
         env:
           CI: "true"

--- a/examples/spread.yaml
+++ b/examples/spread.yaml
@@ -11,9 +11,6 @@ environment:
   LANGUAGE: en
   CONCIERGE: '$(HOST: echo "${CONCIERGE:-concierge.yaml}")'
   OPCLI_GIT_REF: '$(HOST: echo "${OPCLI_GIT_REF:-main}")'
-  GITHUB_TOKEN: '$(HOST: echo "${GITHUB_TOKEN:-}")'
-  GITHUB_RUN_ID: '$(HOST: echo "${GITHUB_RUN_ID:-}")'
-  GITHUB_REPOSITORY: '$(HOST: echo "${GITHUB_REPOSITORY:-}")'
 exclude:
 - .git
 - .tox

--- a/examples/spread.yaml
+++ b/examples/spread.yaml
@@ -11,6 +11,9 @@ environment:
   LANGUAGE: en
   CONCIERGE: '$(HOST: echo "${CONCIERGE:-concierge.yaml}")'
   OPCLI_GIT_REF: '$(HOST: echo "${OPCLI_GIT_REF:-main}")'
+  GITHUB_TOKEN: '$(HOST: echo "${GITHUB_TOKEN:-}")'
+  GITHUB_RUN_ID: '$(HOST: echo "${GITHUB_RUN_ID:-}")'
+  GITHUB_REPOSITORY: '$(HOST: echo "${GITHUB_REPOSITORY:-}")'
 exclude:
 - .git
 - .tox

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -646,7 +646,8 @@ def artifacts_localize(root: Path) -> int:
     Returns the number of charms that were localised.
 
     Raises:
-        ConfigurationError: If ``artifacts-generated.yaml`` is not found.
+        ConfigurationError: If ``artifacts-generated.yaml`` is not found or
+            if a charm with a CI artifact reference has no matching file.
     """
     gen_path = root / _ARTIFACTS_GENERATED_YAML
     if not gen_path.exists():
@@ -656,6 +657,7 @@ def artifacts_localize(root: Path) -> int:
     generated = load_artifacts_generated(gen_path)
 
     updated = 0
+    missing: list[str] = []
     for charm in generated.charms:
         if charm.output.files:
             continue  # Already has local files — nothing to do.
@@ -667,7 +669,8 @@ def artifacts_localize(root: Path) -> int:
         pattern = str(root / "**" / f"{charm.name}_*.charm")
         matches = sorted(globmod.glob(pattern, recursive=True))
         if not matches:
-            logger.warning(
+            missing.append(charm.name)
+            logger.error(
                 "No .charm file found for charm '%s' (pattern: %s).",
                 charm.name,
                 pattern,
@@ -685,6 +688,13 @@ def artifacts_localize(root: Path) -> int:
         charm.output.files = [CharmFile(path=rel)]
         logger.info("Localised charm '%s' → %s", charm.name, matches[0])
         updated += 1
+
+    if missing:
+        msg = (
+            f"Could not find downloaded charm files for: {', '.join(missing)}. "
+            "Ensure charm artifacts were downloaded before running localize."
+        )
+        raise ConfigurationError(msg)
 
     if updated:
         dump_artifacts_generated(generated, gen_path)

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -90,6 +90,11 @@ def _generate_spread_yaml(
         # Defaults to "main"; override on the host with OPCLI_GIT_REF=<branch>
         # before running spread to install opcli from a specific branch.
         "OPCLI_GIT_REF": '$(HOST: echo "${OPCLI_GIT_REF:-main}")',
+        # GitHub Actions vars forwarded so _CI_PREPARE can download artifacts.
+        # Empty locally — the download block checks GITHUB_RUN_ID before acting.
+        "GITHUB_TOKEN": '$(HOST: echo "${GITHUB_TOKEN:-}")',
+        "GITHUB_RUN_ID": '$(HOST: echo "${GITHUB_RUN_ID:-}")',
+        "GITHUB_REPOSITORY": '$(HOST: echo "${GITHUB_REPOSITORY:-}")',
     }
 
     # Suite environment: MODULE variants + TOX_ENV (scoped to this suite)
@@ -312,6 +317,33 @@ if [ -f "$CONCIERGE" ]; then
   loginctl enable-linger ubuntu
   snap install concierge --classic
   concierge prepare -c "$CONCIERGE"
+fi
+if [ -n "${GITHUB_RUN_ID:-}" ]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh CLI is required for CI artifact download but was not found" >&2
+    exit 1
+  fi
+  export GH_TOKEN="${GITHUB_TOKEN}"
+  echo "Waiting for artifacts-generated artifact (run ${GITHUB_RUN_ID})..."
+  _MAX_WAIT=60
+  _n=0
+  until gh run download "${GITHUB_RUN_ID}" \
+      --repo "${GITHUB_REPOSITORY}" \
+      --name artifacts-generated \
+      --dir "${SPREAD_PATH}" 2>/dev/null; do
+    _n=$((_n + 1))
+    if [ "$_n" -ge "$_MAX_WAIT" ]; then
+      echo "Timed out waiting for artifacts-generated after $((_n * 30))s" >&2
+      exit 1
+    fi
+    echo "  ...attempt ${_n}/${_MAX_WAIT}, retrying in 30s"
+    sleep 30
+  done
+  gh run download "${GITHUB_RUN_ID}" \
+      --repo "${GITHUB_REPOSITORY}" \
+      --pattern "built-charm-*" \
+      --dir "${SPREAD_PATH}" || true
+  cd "${SPREAD_PATH}" && opcli artifacts localize
 fi
 chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 """

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -90,11 +90,6 @@ def _generate_spread_yaml(
         # Defaults to "main"; override on the host with OPCLI_GIT_REF=<branch>
         # before running spread to install opcli from a specific branch.
         "OPCLI_GIT_REF": '$(HOST: echo "${OPCLI_GIT_REF:-main}")',
-        # GitHub Actions vars forwarded so _CI_PREPARE can download artifacts.
-        # Empty locally — the download block checks GITHUB_RUN_ID before acting.
-        "GITHUB_TOKEN": '$(HOST: echo "${GITHUB_TOKEN:-}")',
-        "GITHUB_RUN_ID": '$(HOST: echo "${GITHUB_RUN_ID:-}")',
-        "GITHUB_REPOSITORY": '$(HOST: echo "${GITHUB_REPOSITORY:-}")',
     }
 
     # Suite environment: MODULE variants + TOX_ENV (scoped to this suite)
@@ -535,6 +530,14 @@ def _build_concrete_backend(
         backend_def["allocate"] = _CI_ALLOCATE
         if ci_prepare:
             backend_def["prepare"] = ci_prepare
+        # GitHub Actions vars are only needed for the CI backend so that
+        # _CI_PREPARE can authenticate and download build artifacts via gh.
+        # Scoping them here keeps the root spread.yaml clean for local runs.
+        backend_def["environment"] = {
+            "GITHUB_TOKEN": '$(HOST: echo "${GITHUB_TOKEN:-}")',
+            "GITHUB_RUN_ID": '$(HOST: echo "${GITHUB_RUN_ID:-}")',
+            "GITHUB_REPOSITORY": '$(HOST: echo "${GITHUB_REPOSITORY:-}")',
+        }
         if isinstance(systems, list):
             backend_def["systems"] = _transform_systems(
                 systems, strip_keys=_CI_STRIP_KEYS, inject_username="root"

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 from pathlib import Path
 from typing import ClassVar
@@ -1032,18 +1031,13 @@ class TestArtifactsLocalize:
 
         assert count == 0
 
-    def test_warns_when_no_charm_file_found(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Logs a warning when no .charm file matches the charm name."""
+    def test_raises_when_no_charm_file_found(self, tmp_path: Path) -> None:
+        """Raises ConfigurationError when a CI-ref charm has no matching .charm file."""
 
         _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
 
-        with caplog.at_level(logging.WARNING):
-            count = artifacts_localize(tmp_path)
-
-        assert count == 0
-        assert any("No .charm file found" in r.message for r in caplog.records)
+        with pytest.raises(ConfigurationError, match="my-charm"):
+            artifacts_localize(tmp_path)
 
     def test_missing_generated_yaml_raises(self, tmp_path: Path) -> None:
         """Raises ConfigurationError when artifacts-generated.yaml is missing."""
@@ -1079,6 +1073,5 @@ class TestArtifactsLocalize:
         # Only the longer-prefix file exists — pattern must NOT match it
         (tmp_path / "my-charm-k8s_ubuntu-24.04-amd64.charm").write_bytes(b"")
 
-        count = artifacts_localize(tmp_path)
-
-        assert count == 0
+        with pytest.raises(ConfigurationError, match="my-charm"):
+            artifacts_localize(tmp_path)

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -90,6 +90,10 @@ class TestSpreadInit:
         assert env["LANG"] == "C.UTF-8"
         assert env["LANGUAGE"] == "en"
         assert "CONCIERGE" in env
+        # GitHub Actions vars forwarded for CI artifact download
+        assert "GITHUB_TOKEN" in env
+        assert "GITHUB_RUN_ID" in env
+        assert "GITHUB_REPOSITORY" in env
         # MODULE variants belong in the suite, not the root environment
         assert not any(k.startswith("MODULE") for k in env)
         assert "TOX_ENV" not in env
@@ -202,6 +206,14 @@ class TestSpreadExpand:
         assert "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox" in ci["prepare"]
         assert "loginctl enable-linger ubuntu" in ci["prepare"]
         assert "UV_TOOL_BIN_DIR=/usr/local/bin" in ci["prepare"]
+        # CI prepare waits for and downloads build artifacts via gh CLI
+        assert "gh run download" in ci["prepare"]
+        assert "artifacts-generated" in ci["prepare"]
+        assert "built-charm-*" in ci["prepare"]
+        assert "GH_TOKEN" in ci["prepare"]
+        assert "GITHUB_RUN_ID" in ci["prepare"]
+        assert "opcli artifacts localize" in ci["prepare"]
+        assert "command -v gh" in ci["prepare"]
         # CI backend does NOT override SUDO_USER; ubuntu is created in allocate
         assert "environment" not in ci
         assert "useradd" in ci["allocate"]

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -90,10 +90,10 @@ class TestSpreadInit:
         assert env["LANG"] == "C.UTF-8"
         assert env["LANGUAGE"] == "en"
         assert "CONCIERGE" in env
-        # GitHub Actions vars forwarded for CI artifact download
-        assert "GITHUB_TOKEN" in env
-        assert "GITHUB_RUN_ID" in env
-        assert "GITHUB_REPOSITORY" in env
+        # GitHub Actions vars belong only in the expanded CI backend, not root
+        assert "GITHUB_TOKEN" not in env
+        assert "GITHUB_RUN_ID" not in env
+        assert "GITHUB_REPOSITORY" not in env
         # MODULE variants belong in the suite, not the root environment
         assert not any(k.startswith("MODULE") for k in env)
         assert "TOX_ENV" not in env
@@ -214,8 +214,14 @@ class TestSpreadExpand:
         assert "GITHUB_RUN_ID" in ci["prepare"]
         assert "opcli artifacts localize" in ci["prepare"]
         assert "command -v gh" in ci["prepare"]
+        # CI backend has GitHub Actions vars scoped to it for artifact download
+        assert "environment" in ci
+        ci_env = ci["environment"]
+        assert "GITHUB_TOKEN" in ci_env
+        assert "GITHUB_RUN_ID" in ci_env
+        assert "GITHUB_REPOSITORY" in ci_env
         # CI backend does NOT override SUDO_USER; ubuntu is created in allocate
-        assert "environment" not in ci
+        assert "SUDO_USER" not in ci_env
         assert "useradd" in ci["allocate"]
         assert "pipx install" not in ci["prepare"]
         assert "discard" not in ci


### PR DESCRIPTION
Implements the spec's intended parallel execution model.

## What changes

**Before:** sequential — `build → test-plan → test` (total = build_time + provision_time + test_time)

**After:** parallel — `build ∥ (test-plan → provision → wait → test)` (total ≈ max(build_time, provision_time) + test_time)

### Workflow (`integration-test.yml`)
- `test-plan` drops `needs: build` — only reads `spread.yaml` from the repo (no artifacts needed)
- `test` drops `needs: build`, keeps `needs: [test-plan]` — provisioning starts while build runs
- Removed artifact download steps (now handled inside spread prepare)

### Spread `_CI_PREPARE` (`core/spread.py`)
After concierge provisioning (the slow part that runs in parallel with build):
1. Checks `gh` CLI is installed (fails with clear error if not)
2. Waits up to 30 min for `artifacts-generated` artifact via retry loop
3. Downloads `built-charm-*` artifacts
4. Runs `opcli artifacts localize`

### GitHub token forwarding
`GITHUB_TOKEN`, `GITHUB_RUN_ID`, `GITHUB_REPOSITORY` added to the generated `spread.yaml` environment via `$(HOST: echo "${VAR:-}")`. Empty locally (gated on `GITHUB_RUN_ID` before use).

### `artifacts_localize` (`core/artifacts.py`)
Upgraded from warning to `ConfigurationError` when a CI-ref charm has no matching `.charm` file — fail fast instead of letting the missing file cause an opaque pytest error.