### PR TITLE
refactor: align local and CI prepare scripts to use uv

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -274,31 +274,7 @@ fi
 
 _LOCAL_PREPARE = """\
 loginctl enable-linger ubuntu
-sudo snap install concierge --classic
-sudo snap install astral-uv --classic
-sudo apt-get update --quiet
-sudo apt-get install -y pipx golang-go --quiet
-sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
-    pipx install \
-    "git+https://github.com/javierdelapuente/operator-ci-poc@${OPCLI_GIT_REF}" \
-    --quiet
-go install github.com/canonical/spread/cmd/spread@latest
-sudo ln -sf ~/go/bin/spread /usr/local/bin/spread
-runuser -l ubuntu -c "uv tool install tox --with tox-uv"
-if [ -f "$CONCIERGE" ]; then
-  concierge prepare -c "$CONCIERGE"
-  runuser -l ubuntu -c \
-    "cd \\"${SPREAD_PATH}\\" && opcli provision registry -c \\"$CONCIERGE\\""
-fi
-if [ -f artifacts-generated.yaml ] && \
-    curl -sf --max-time 5 http://localhost:32000/v2/ > /dev/null 2>&1; then
-  opcli provision load
-fi
-chown -R ubuntu:ubuntu "${SPREAD_PATH}"
-"""
-
-_CI_PREPARE = """\
-loginctl enable-linger ubuntu
+sudo snap install astral-uv --classic || true
 export UV_TOOL_BIN_DIR=/usr/local/bin
 if grep -q 'name = "opcli"' "${SPREAD_PATH}/pyproject.toml" 2>/dev/null; then
   uv tool install "${SPREAD_PATH}" --quiet
@@ -307,9 +283,44 @@ else
       "git+https://github.com/javierdelapuente/operator-ci-poc@${OPCLI_GIT_REF:-main}" \
       --quiet
 fi
+if ! command -v spread >/dev/null 2>&1; then
+  sudo snap install go --classic
+  go install github.com/canonical/spread/cmd/spread@latest
+  sudo ln -sf ~/go/bin/spread /usr/local/bin/spread
+fi
 runuser -l ubuntu -c "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox --with tox-uv --quiet"
 if [ -f "$CONCIERGE" ]; then
-  snap install concierge --classic
+  sudo snap install concierge --classic || true
+  concierge prepare -c "$CONCIERGE"
+  runuser -l ubuntu -c \
+    "cd \\"${SPREAD_PATH}\\" && opcli provision registry -c \\"$CONCIERGE\\""
+fi
+if [ -f "${SPREAD_PATH}/artifacts-generated.yaml" ] && \
+    curl -sf --max-time 5 http://localhost:32000/v2/ > /dev/null 2>&1; then
+  opcli provision load
+fi
+chown -R ubuntu:ubuntu "${SPREAD_PATH}"
+"""
+
+_CI_PREPARE = """\
+loginctl enable-linger ubuntu
+snap install astral-uv --classic || true
+export UV_TOOL_BIN_DIR=/usr/local/bin
+if grep -q 'name = "opcli"' "${SPREAD_PATH}/pyproject.toml" 2>/dev/null; then
+  uv tool install "${SPREAD_PATH}" --quiet
+else
+  uv tool install \
+      "git+https://github.com/javierdelapuente/operator-ci-poc@${OPCLI_GIT_REF:-main}" \
+      --quiet
+fi
+if ! command -v spread >/dev/null 2>&1; then
+  snap install go --classic
+  go install github.com/canonical/spread/cmd/spread@latest
+  ln -sf ~/go/bin/spread /usr/local/bin/spread
+fi
+runuser -l ubuntu -c "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox --with tox-uv --quiet"
+if [ -f "$CONCIERGE" ]; then
+  snap install concierge --classic || true
   concierge prepare -c "$CONCIERGE"
 fi
 if [ -n "${GITHUB_RUN_ID:-}" ]; then
@@ -356,13 +367,18 @@ echo "root:${SPREAD_PASSWORD}" | sudo chpasswd
 ADDRESS localhost
 """
 
-# Tutorial backend: install pip then opcli from the GitHub repo main branch so
-# that ``opcli tutorial expand`` is available inside the VM.
+# Tutorial backend: install uv then opcli so that ``opcli tutorial expand``
+# is available inside the VM.
 _TUTORIAL_LOCAL_PREPARE = """\
-sudo apt-get update --quiet
-sudo apt-get install -y pipx --quiet
-sudo PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
-    pipx install git+https://github.com/javierdelapuente/operator-ci-poc@main --quiet
+sudo snap install astral-uv --classic || true
+export UV_TOOL_BIN_DIR=/usr/local/bin
+if grep -q 'name = "opcli"' "${SPREAD_PATH}/pyproject.toml" 2>/dev/null; then
+  uv tool install "${SPREAD_PATH}" --quiet
+else
+  uv tool install \
+      "git+https://github.com/javierdelapuente/operator-ci-poc@${OPCLI_GIT_REF:-main}" \
+      --quiet
+fi
 """
 
 

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -288,7 +288,7 @@ if ! command -v spread >/dev/null 2>&1; then
   go install github.com/canonical/spread/cmd/spread@latest
   sudo ln -sf ~/go/bin/spread /usr/local/bin/spread
 fi
-runuser -l ubuntu -c "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox --with tox-uv --quiet"
+runuser -l ubuntu -c "uv tool install tox --with tox-uv --quiet"
 if [ -f "$CONCIERGE" ]; then
   sudo snap install concierge --classic || true
   concierge prepare -c "$CONCIERGE"
@@ -318,7 +318,7 @@ if ! command -v spread >/dev/null 2>&1; then
   go install github.com/canonical/spread/cmd/spread@latest
   ln -sf ~/go/bin/spread /usr/local/bin/spread
 fi
-runuser -l ubuntu -c "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox --with tox-uv --quiet"
+runuser -l ubuntu -c "uv tool install tox --with tox-uv --quiet"
 if [ -f "$CONCIERGE" ]; then
   snap install concierge --classic || true
   concierge prepare -c "$CONCIERGE"

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -288,7 +288,7 @@ if ! command -v spread >/dev/null 2>&1; then
   go install github.com/canonical/spread/cmd/spread@latest
   sudo ln -sf ~/go/bin/spread /usr/local/bin/spread
 fi
-runuser -l ubuntu -c "uv tool install tox --with tox-uv --quiet"
+runuser -l ubuntu -c "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox --with tox-uv --quiet"
 if [ -f "$CONCIERGE" ]; then
   sudo snap install concierge --classic || true
   concierge prepare -c "$CONCIERGE"
@@ -318,7 +318,7 @@ if ! command -v spread >/dev/null 2>&1; then
   go install github.com/canonical/spread/cmd/spread@latest
   ln -sf ~/go/bin/spread /usr/local/bin/spread
 fi
-runuser -l ubuntu -c "uv tool install tox --with tox-uv --quiet"
+runuser -l ubuntu -c "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox --with tox-uv --quiet"
 if [ -f "$CONCIERGE" ]; then
   snap install concierge --classic || true
   concierge prepare -c "$CONCIERGE"

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -217,8 +217,7 @@ class TestSpreadExpand:
         # tox is installed for the ubuntu user via runuser with explicit bin dir
         assert "runuser" in ci["prepare"]
         assert "runuser -l ubuntu" in ci["prepare"]
-        assert "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox" not in ci["prepare"]
-        assert "uv tool install tox" in ci["prepare"]
+        assert "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox" in ci["prepare"]
         assert "loginctl enable-linger ubuntu" in ci["prepare"]
         assert "UV_TOOL_BIN_DIR=/usr/local/bin" in ci["prepare"]
         # CI prepare waits for and downloads build artifacts via gh CLI

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -175,6 +175,17 @@ class TestSpreadExpand:
         assert "opcli provision registry" in prepare
         assert '[ -f "$CONCIERGE" ]' in prepare
         assert "opcli provision load" in prepare
+        # Local uses uv (not pipx) with dev-mode detection, same as CI
+        assert "pipx" not in prepare
+        assert "uv tool install" in prepare
+        assert "UV_TOOL_BIN_DIR=/usr/local/bin" in prepare
+        assert "pyproject.toml" in prepare
+        assert "SPREAD_PATH" in prepare
+        # spread installed if not already present
+        assert "command -v spread" in prepare
+        assert "loginctl enable-linger ubuntu" in prepare
+        # artifacts-generated check uses SPREAD_PATH
+        assert "${SPREAD_PATH}/artifacts-generated.yaml" in prepare
 
         # Systems should have username: ubuntu injected
         systems = local["systems"]
@@ -227,6 +238,10 @@ class TestSpreadExpand:
         assert "SUDO_USER" not in ci_env
         assert "useradd" in ci["allocate"]
         assert "pipx install" not in ci["prepare"]
+        # uv installed in CI prepare (idempotent: already on runner but re-ensures)
+        assert "astral-uv" in ci["prepare"]
+        # spread installed if not already present
+        assert "command -v spread" in ci["prepare"]
         assert "discard" not in ci
         # CI injects username: root per-system for SSH access
         systems = ci["systems"]
@@ -353,7 +368,7 @@ suites:
         prepare = parsed["backends"]["local"]["prepare"]
 
         assert '[ -f "$CONCIERGE" ]' in prepare
-        assert "[ -f artifacts-generated.yaml ]" in prepare
+        assert '[ -f "${SPREAD_PATH}/artifacts-generated.yaml" ]' in prepare
 
     def test_ci_prepare_conditional(self, tmp_path: Path) -> None:
         """CI prepare gates concierge on file existence."""
@@ -814,8 +829,11 @@ suites:
         assert backend["type"] == "adhoc"
         assert "lxc launch --vm" in backend["allocate"]
         assert "lxc delete" in backend["discard"]
-        assert "pipx install" in backend["prepare"]
-        assert "astral.sh" not in backend["prepare"]
+        # Tutorial uses uv (not pipx) with dev-mode detection
+        assert "pipx install" not in backend["prepare"]
+        assert "uv tool install" in backend["prepare"]
+        assert "UV_TOOL_BIN_DIR=/usr/local/bin" in backend["prepare"]
+        assert "pyproject.toml" in backend["prepare"]
         assert "operator-ci-poc" in backend["prepare"]
         # No concierge/provision in tutorial prepare
         assert "concierge" not in backend["prepare"]

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -217,7 +217,8 @@ class TestSpreadExpand:
         # tox is installed for the ubuntu user via runuser with explicit bin dir
         assert "runuser" in ci["prepare"]
         assert "runuser -l ubuntu" in ci["prepare"]
-        assert "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox" in ci["prepare"]
+        assert "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox" not in ci["prepare"]
+        assert "uv tool install tox" in ci["prepare"]
         assert "loginctl enable-linger ubuntu" in ci["prepare"]
         assert "UV_TOOL_BIN_DIR=/usr/local/bin" in ci["prepare"]
         # CI prepare waits for and downloads build artifacts via gh CLI


### PR DESCRIPTION
Both `_LOCAL_PREPARE` and `_CI_PREPARE` now share the same structure and toolchain.

## Changes

**Before:**
- Local used `apt-get` + `pipx` + `golang-go` apt package to install opcli and spread
- Local always installed concierge at the top (even without a concierge file)
- No dev-mode detection in local (always installed from git)
- `artifacts-generated.yaml` check was a bare filename (not `${SPREAD_PATH}`-relative)
- Tutorial used `pipx` with hardcoded `@main` ref

**After (both scripts):**
- `snap install astral-uv --classic || true` — uv installed idempotently
- `export UV_TOOL_BIN_DIR=/usr/local/bin` — opcli and tox land on PATH
- Dev-mode detection: if `pyproject.toml` in `${SPREAD_PATH}` is opcli, install from local path
- `command -v spread || install` — spread installed only if not already present
- Concierge snap install moved inside the `if [ -f "$CONCIERGE" ]` guard
- `${SPREAD_PATH}/artifacts-generated.yaml` for robust path check
- Tutorial (`_TUTORIAL_LOCAL_PREPARE`) migrated to same uv pattern with dev-mode detection