### PR TITLE
feat: add opcli artifacts fetch command

### DIFF
--- a/src/opcli/commands/artifacts.py
+++ b/src/opcli/commands/artifacts.py
@@ -9,6 +9,7 @@ import typer
 from opcli.core.artifacts import (
     artifacts_build,
     artifacts_collect,
+    artifacts_fetch,
     artifacts_init,
     artifacts_localize,
     artifacts_matrix,
@@ -81,6 +82,33 @@ def collect(
     """
     path = artifacts_collect(Path.cwd(), partials)
     typer.echo(f"Wrote {path}")
+
+
+@app.command()
+def fetch(
+    *,
+    run_id: Annotated[
+        str,
+        typer.Option("--run-id", help="GitHub Actions workflow run ID."),
+    ],
+    repo: Annotated[
+        str | None,
+        typer.Option(
+            "--repo",
+            help="GitHub repository in 'owner/name' format. "
+            "Defaults to the current git remote.",
+        ),
+    ] = None,
+) -> None:
+    """Download artifacts from a CI run and prepare for local testing.
+
+    Downloads artifacts-generated.yaml, then downloads all charm/snap artifact
+    archives. Rock artifacts are GHCR images and require no download.
+    Finally rewrites artifacts-generated.yaml with local file paths so that
+    ``opcli pytest run`` and ``opcli spread run`` work without a local build.
+    """
+    path = artifacts_fetch(Path.cwd(), run_id=run_id, repo=repo)
+    typer.echo(f"Fetched artifacts and updated {path}")
 
 
 @app.command()

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -724,7 +724,7 @@ def artifacts_localize(root: Path) -> int:
 # artifacts fetch
 # ---------------------------------------------------------------------------
 
-_GITHUB_URL_RE = re.compile(r"github\.com[:/](.+?)(?:\.git)?$")
+_GITHUB_URL_RE = re.compile(r"github\.com[:/](.+?)(?:\.git)?/?$")
 
 
 def _infer_repo_from_git(root: Path) -> str:
@@ -810,16 +810,16 @@ def artifacts_fetch(root: Path, run_id: str, repo: str | None = None) -> Path:
 
     generated = load_artifacts_generated(gen_path)
 
-    # Download each charm / snap artifact archive
-    artifact_names: list[str] = []
+    # Download each charm / snap artifact archive (deduplicated)
+    seen_artifacts: set[str] = set()
     for charm in generated.charms:
         if charm.output.artifact:
-            artifact_names.append(charm.output.artifact)
+            seen_artifacts.add(charm.output.artifact)
     for snap in generated.snaps:
         if snap.output.artifact:
-            artifact_names.append(snap.output.artifact)
+            seen_artifacts.add(snap.output.artifact)
 
-    for name in artifact_names:
+    for name in sorted(seen_artifacts):
         run_command(
             [
                 "gh",

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -634,21 +634,43 @@ def _filter_by_name[T: (RockArtifact, CharmArtifact, SnapArtifact)](
     return [item for item in items if item.name in name_set]
 
 
+def _find_local_file(root: Path, name: str, extension: str) -> str | None:
+    """Find a single ``name_*.{extension}`` file under *root*.
+
+    Returns the relative path (``./...``) on success, or ``None`` if no file
+    is found (caller should report the error).  Logs a warning when multiple
+    matches exist and picks the first.
+    """
+    pattern = str(root / "**" / f"{name}_*.{extension}")
+    matches = sorted(globmod.glob(pattern, recursive=True))
+    if not matches:
+        return None
+    if len(matches) > 1:
+        logger.warning(
+            "Multiple .%s files found for '%s'; using %s.",
+            extension,
+            name,
+            matches[0],
+        )
+    return "./" + str(Path(matches[0]).relative_to(root))
+
+
 def artifacts_localize(root: Path) -> int:
-    """Update ``artifacts-generated.yaml`` with local charm file paths.
+    """Update ``artifacts-generated.yaml`` with local artifact file paths.
 
-    In CI, charm outputs are recorded as ``artifact + run-id`` references.
-    Before running integration tests, the workflow downloads the charm
-    artifacts to the working directory.  This command scans the project tree
-    for ``.charm`` files and rewrites ``artifacts-generated.yaml`` so that
-    each charm with only a CI artifact reference gets an ``output.files``
-    entry pointing to the discovered local file.
+    In CI, charm and snap outputs are recorded as ``artifact + run-id``
+    references.  Before running integration tests, the workflow downloads
+    the artifacts to the working directory.  This command scans the project
+    tree for ``.charm`` / ``.snap`` files and rewrites
+    ``artifacts-generated.yaml`` so that each artifact with only a CI
+    artifact reference gets an ``output.file(s)`` entry pointing to the
+    discovered local file.
 
-    Returns the number of charms that were localised.
+    Returns the total number of artifacts that were localised.
 
     Raises:
         ConfigurationError: If ``artifacts-generated.yaml`` is not found or
-            if a charm with a CI artifact reference has no matching file.
+            if any artifact with a CI reference has no matching local file.
     """
     gen_path = root / _ARTIFACTS_GENERATED_YAML
     if not gen_path.exists():
@@ -659,47 +681,41 @@ def artifacts_localize(root: Path) -> int:
 
     updated = 0
     missing: list[str] = []
+
     for charm in generated.charms:
-        if charm.output.files:
-            continue  # Already has local files — nothing to do.
-        if not charm.output.artifact:
-            continue  # No CI ref either — skip.
-
-        # Search for .charm files whose name starts with the charm name followed
-        # by an underscore, to avoid prefix collisions (e.g., "foo" vs "foo-k8s").
-        pattern = str(root / "**" / f"{charm.name}_*.charm")
-        matches = sorted(globmod.glob(pattern, recursive=True))
-        if not matches:
-            missing.append(charm.name)
-            logger.error(
-                "No .charm file found for charm '%s' (pattern: %s).",
-                charm.name,
-                pattern,
-            )
+        if charm.output.files or not charm.output.artifact:
             continue
-
-        if len(matches) > 1:
-            logger.warning(
-                "Multiple .charm files found for charm '%s'; using %s.",
-                charm.name,
-                matches[0],
-            )
-
-        rel = "./" + str(Path(matches[0]).relative_to(root))
+        rel = _find_local_file(root, charm.name, "charm")
+        if rel is None:
+            missing.append(charm.name)
+            logger.error("No .charm file found for charm '%s'.", charm.name)
+            continue
         charm.output.files = [CharmFile(path=rel)]
-        logger.info("Localised charm '%s' → %s", charm.name, matches[0])
+        logger.info("Localised charm '%s' → %s", charm.name, rel)
+        updated += 1
+
+    for snap in generated.snaps:
+        if snap.output.file or not snap.output.artifact:
+            continue
+        rel = _find_local_file(root, snap.name, "snap")
+        if rel is None:
+            missing.append(snap.name)
+            logger.error("No .snap file found for snap '%s'.", snap.name)
+            continue
+        snap.output.file = rel
+        logger.info("Localised snap '%s' → %s", snap.name, rel)
         updated += 1
 
     if missing:
         msg = (
-            f"Could not find downloaded charm files for: {', '.join(missing)}. "
-            "Ensure charm artifacts were downloaded before running localize."
+            f"Could not find downloaded artifact files for: {', '.join(missing)}. "
+            "Ensure artifacts were downloaded before running localize."
         )
         raise ConfigurationError(msg)
 
     if updated:
         dump_artifacts_generated(generated, gen_path)
-        logger.info("Updated %s with %d localised charm(s).", gen_path, updated)
+        logger.info("Updated %s with %d localised artifact(s).", gen_path, updated)
 
     return updated
 

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -1,8 +1,9 @@
-"""Core logic for ``opcli artifacts init`` and ``opcli artifacts build``.
+"""Core logic for ``opcli artifacts`` commands.
 
 ``init`` discovers artifacts and writes ``artifacts.yaml``.
 ``build`` reads the plan, invokes pack tools, and writes
 ``artifacts-generated.yaml``.
+``fetch`` downloads a completed CI run's artifacts so tests can run locally.
 """
 
 from __future__ import annotations
@@ -701,3 +702,125 @@ def artifacts_localize(root: Path) -> int:
         logger.info("Updated %s with %d localised charm(s).", gen_path, updated)
 
     return updated
+
+
+# ---------------------------------------------------------------------------
+# artifacts fetch
+# ---------------------------------------------------------------------------
+
+_GITHUB_URL_RE = re.compile(r"github\.com[:/](.+?)(?:\.git)?$")
+
+
+def _infer_repo_from_git(root: Path) -> str:
+    """Return ``owner/repo`` inferred from the git remote of *root*.
+
+    Raises:
+        ConfigurationError: If the git remote URL cannot be parsed.
+    """
+    try:
+        result = run_command(["git", "remote", "get-url", "origin"], cwd=str(root))
+    except Exception as exc:
+        msg = (
+            "Could not read git remote 'origin'. Use --repo to specify the repository."
+        )
+        raise ConfigurationError(msg) from exc
+
+    url = result.stdout.strip()
+    m = _GITHUB_URL_RE.search(url)
+    if not m:
+        msg = (
+            f"Could not parse a GitHub 'owner/repo' from remote URL {url!r}. "
+            "Use --repo to specify the repository."
+        )
+        raise ConfigurationError(msg)
+    return m.group(1)
+
+
+def artifacts_fetch(root: Path, run_id: str, repo: str | None = None) -> Path:
+    """Download a CI run's artifacts and prepare for local testing.
+
+    Steps:
+    1. Infer ``owner/repo`` from the local git remote if *repo* is not given.
+    2. Download ``artifacts-generated.yaml`` from the named GitHub Actions artifact.
+    3. For every charm/snap that carries a CI artifact reference, download the
+       corresponding artifact archive.
+    4. Call :func:`artifacts_localize` to rewrite ``artifacts-generated.yaml``
+       with the local ``.charm`` / ``.snap`` file paths.
+
+    Rock artifacts are OCI images on GHCR and need no download — their
+    ``output.image`` reference is already usable locally.
+
+    Args:
+        root: Working directory; all artifacts are downloaded here.
+        run_id: GitHub Actions workflow run ID.
+        repo: GitHub repository in ``owner/name`` format.  Inferred from the
+            local git remote when ``None``.
+
+    Returns:
+        Path to the updated ``artifacts-generated.yaml``.
+
+    Raises:
+        ConfigurationError: If the repo cannot be inferred or the yaml is missing
+            after download.
+        SubprocessError: If ``gh run download`` fails.
+    """
+    if repo is None:
+        repo = _infer_repo_from_git(root)
+
+    # Download the merged artifacts-generated.yaml
+    run_command(
+        [
+            "gh",
+            "run",
+            "download",
+            run_id,
+            "--repo",
+            repo,
+            "--name",
+            "artifacts-generated",
+            "--dir",
+            str(root),
+        ],
+        cwd=str(root),
+    )
+
+    gen_path = root / _ARTIFACTS_GENERATED_YAML
+    if not gen_path.exists():
+        msg = (
+            f"{_ARTIFACTS_GENERATED_YAML} not found after download. "
+            "Ensure the CI run completed its build phase."
+        )
+        raise ConfigurationError(msg)
+
+    generated = load_artifacts_generated(gen_path)
+
+    # Download each charm / snap artifact archive
+    artifact_names: list[str] = []
+    for charm in generated.charms:
+        if charm.output.artifact:
+            artifact_names.append(charm.output.artifact)
+    for snap in generated.snaps:
+        if snap.output.artifact:
+            artifact_names.append(snap.output.artifact)
+
+    for name in artifact_names:
+        run_command(
+            [
+                "gh",
+                "run",
+                "download",
+                run_id,
+                "--repo",
+                repo,
+                "--name",
+                name,
+                "--dir",
+                str(root),
+            ],
+            cwd=str(root),
+        )
+        logger.info("Downloaded artifact '%s'.", name)
+
+    # Rewrite artifact refs to local file paths
+    artifacts_localize(root)
+    return gen_path

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1215,6 +1215,25 @@ class TestArtifactsFetch:
         with patch("opcli.core.artifacts.run_command", side_effect=results):
             artifacts_fetch(tmp_path, run_id="99887766")
 
+    def test_infers_repo_strips_trailing_slash(self, tmp_path: Path) -> None:
+        """Strips trailing slash from git remote URLs like https://github.com/o/r/."""
+        _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
+        self._make_charm_files(tmp_path)
+        self._make_snap_files(tmp_path)
+
+        trailing_slash = SubprocessResult(
+            stdout="https://github.com/owner/my-repo/\n", stderr="", returncode=0
+        )
+        gh = self._GH_RESULT
+        results = [trailing_slash, gh, gh, gh, gh]
+        with patch("opcli.core.artifacts.run_command", side_effect=results) as mock_run:
+            artifacts_fetch(tmp_path, run_id="99887766")
+
+        for c in mock_run.call_args_list[1:]:
+            repo_val = c.args[0][c.args[0].index("--repo") + 1]
+            assert not repo_val.endswith("/"), f"repo has trailing slash: {repo_val!r}"
+            assert repo_val == "owner/my-repo"
+
     def test_raises_when_git_remote_not_github(self, tmp_path: Path) -> None:
         """Raises ConfigurationError when remote is not a GitHub URL."""
         non_github = SubprocessResult(

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1,4 +1,4 @@
-"""Tests for ``opcli artifacts init``, ``build``, ``matrix``, and ``collect``."""
+"""Tests for opcli artifacts commands: init, build, matrix, collect, fetch."""
 
 from __future__ import annotations
 
@@ -6,18 +6,20 @@ import json
 import os
 from pathlib import Path
 from typing import ClassVar
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
 from opcli.core.artifacts import (
     artifacts_build,
     artifacts_collect,
+    artifacts_fetch,
     artifacts_init,
     artifacts_localize,
     artifacts_matrix,
 )
 from opcli.core.exceptions import ConfigurationError, OpcliError
+from opcli.core.subprocess import SubprocessResult
 from opcli.core.yaml_io import load_artifacts_generated, load_artifacts_plan
 
 
@@ -244,8 +246,8 @@ class TestArtifactsBuild:
             artifacts_build(tmp_path, charm_names=["mycharm"])
 
         # Only charmcraft should have been called — rockcraft must not be invoked.
-        for call in mock_run.call_args_list:
-            cmd = call[0][0]
+        for c in mock_run.call_args_list:
+            cmd = c[0][0]
             assert "rockcraft" not in cmd[0], f"rockcraft unexpectedly invoked: {cmd}"
 
     def test_unknown_charm_name_raises(self, tmp_path: Path) -> None:
@@ -1075,3 +1077,140 @@ class TestArtifactsLocalize:
 
         with pytest.raises(ConfigurationError, match="my-charm"):
             artifacts_localize(tmp_path)
+
+
+class TestArtifactsFetch:
+    """Tests for artifacts_fetch()."""
+
+    _GENERATED_CI = (
+        "version: 1\n"
+        "rocks:\n"
+        "- name: my-rock\n"
+        "  rockcraft-yaml: rock/rockcraft.yaml\n"
+        "  output:\n"
+        "    image: ghcr.io/owner/repo/my-rock:abc1234\n"
+        "charms:\n"
+        "- name: my-charm\n"
+        "  charmcraft-yaml: charmcraft.yaml\n"
+        "  output:\n"
+        "    artifact: built-charm-my-charm\n"
+        "    run-id: '99887766'\n"
+        "- name: other-charm\n"
+        "  charmcraft-yaml: other/charmcraft.yaml\n"
+        "  output:\n"
+        "    artifact: built-charm-other-charm\n"
+        "    run-id: '99887766'\n"
+    )
+
+    _GH_RESULT = SubprocessResult(stdout="", stderr="", returncode=0)
+    _GIT_RESULT = SubprocessResult(
+        stdout="https://github.com/owner/my-repo.git\n",
+        stderr="",
+        returncode=0,
+    )
+
+    def _make_charm_files(self, tmp_path: Path) -> None:
+        """Create dummy .charm files so localize succeeds."""
+        d1 = tmp_path / "built-charm-my-charm"
+        d1.mkdir()
+        (d1 / "my-charm_ubuntu-24.04-amd64.charm").write_bytes(b"")
+        d2 = tmp_path / "built-charm-other-charm"
+        d2.mkdir()
+        (d2 / "other-charm_ubuntu-24.04-amd64.charm").write_bytes(b"")
+
+    def test_downloads_generated_and_charm_artifacts(self, tmp_path: Path) -> None:
+        """Downloads artifacts-generated + each charm artifact, then localises."""
+        _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
+        self._make_charm_files(tmp_path)
+
+        patch_target = "opcli.core.artifacts.run_command"
+        with patch(patch_target, return_value=self._GH_RESULT) as mock_run:
+            result = artifacts_fetch(tmp_path, run_id="99887766", repo="owner/my-repo")
+
+        assert result == tmp_path / "artifacts-generated.yaml"
+        calls = mock_run.call_args_list
+        # First call: download artifacts-generated
+        assert calls[0] == call(
+            [
+                "gh",
+                "run",
+                "download",
+                "99887766",
+                "--repo",
+                "owner/my-repo",
+                "--name",
+                "artifacts-generated",
+                "--dir",
+                str(tmp_path),
+            ],
+            cwd=str(tmp_path),
+        )
+        # Subsequent calls: one per charm artifact
+        artifact_names = {c.args[0][7] for c in calls[1:]}
+        assert artifact_names == {"built-charm-my-charm", "built-charm-other-charm"}
+
+    def test_skips_rocks_no_download(self, tmp_path: Path) -> None:
+        """Rock OCI images are not downloaded — only the initial yaml + charms."""
+        _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
+        self._make_charm_files(tmp_path)
+
+        _EXPECTED_CALLS = 3  # 1 artifacts-generated + 2 charm artifacts
+        patch_target = "opcli.core.artifacts.run_command"
+        with patch(patch_target, return_value=self._GH_RESULT) as mock_run:
+            artifacts_fetch(tmp_path, run_id="99887766", repo="owner/my-repo")
+
+        assert mock_run.call_count == _EXPECTED_CALLS
+
+    def test_infers_repo_from_git_remote(self, tmp_path: Path) -> None:
+        """Infers owner/repo from git remote when --repo is not given."""
+        _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
+        self._make_charm_files(tmp_path)
+
+        results = [self._GIT_RESULT, self._GH_RESULT, self._GH_RESULT, self._GH_RESULT]
+        patch_target = "opcli.core.artifacts.run_command"
+        with patch(patch_target, side_effect=results) as mock_run:
+            artifacts_fetch(tmp_path, run_id="99887766")
+
+        # First call is git remote get-url
+        git_call = mock_run.call_args_list[0]
+        assert git_call.args[0] == ["git", "remote", "get-url", "origin"]
+        # Subsequent gh calls use the inferred repo
+        for c in mock_run.call_args_list[1:]:
+            assert "--repo" in c.args[0]
+            assert "owner/my-repo" in c.args[0]
+
+    def test_infers_repo_from_ssh_remote(self, tmp_path: Path) -> None:
+        """Parses SSH-format git remote URLs (git@github.com:owner/repo.git)."""
+        _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
+        self._make_charm_files(tmp_path)
+
+        ssh_result = SubprocessResult(
+            stdout="git@github.com:owner/my-repo.git\n", stderr="", returncode=0
+        )
+        results = [ssh_result, self._GH_RESULT, self._GH_RESULT, self._GH_RESULT]
+        with patch("opcli.core.artifacts.run_command", side_effect=results):
+            artifacts_fetch(tmp_path, run_id="99887766")
+
+    def test_raises_when_git_remote_not_github(self, tmp_path: Path) -> None:
+        """Raises ConfigurationError when remote is not a GitHub URL."""
+        non_github = SubprocessResult(
+            stdout="https://gitlab.com/owner/repo.git\n", stderr="", returncode=0
+        )
+        with (
+            patch("opcli.core.artifacts.run_command", return_value=non_github),
+            pytest.raises(ConfigurationError, match="--repo"),
+        ):
+            artifacts_fetch(tmp_path, run_id="99887766")
+
+    def test_localises_after_download(self, tmp_path: Path) -> None:
+        """artifacts-generated.yaml is updated with local file paths after fetch."""
+        _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
+        self._make_charm_files(tmp_path)
+
+        with patch("opcli.core.artifacts.run_command", return_value=self._GH_RESULT):
+            artifacts_fetch(tmp_path, run_id="99887766", repo="owner/my-repo")
+
+        gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        for charm in gen.charms:
+            assert charm.output.files, f"Charm '{charm.name}' was not localised"
+            assert charm.output.files[0].path.endswith(".charm")

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1100,6 +1100,12 @@ class TestArtifactsFetch:
         "  output:\n"
         "    artifact: built-charm-other-charm\n"
         "    run-id: '99887766'\n"
+        "snaps:\n"
+        "- name: my-snap\n"
+        "  snapcraft-yaml: snap/snapcraft.yaml\n"
+        "  output:\n"
+        "    artifact: built-snap-my-snap\n"
+        "    run-id: '99887766'\n"
     )
 
     _GH_RESULT = SubprocessResult(stdout="", stderr="", returncode=0)
@@ -1118,10 +1124,17 @@ class TestArtifactsFetch:
         d2.mkdir()
         (d2 / "other-charm_ubuntu-24.04-amd64.charm").write_bytes(b"")
 
+    def _make_snap_files(self, tmp_path: Path) -> None:
+        """Create dummy .snap file so localize succeeds for snaps."""
+        d = tmp_path / "built-snap-my-snap"
+        d.mkdir(exist_ok=True)
+        (d / "my-snap_amd64.snap").write_bytes(b"")
+
     def test_downloads_generated_and_charm_artifacts(self, tmp_path: Path) -> None:
-        """Downloads artifacts-generated + each charm artifact, then localises."""
+        """Downloads artifacts-generated + each charm/snap artifact, then localises."""
         _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
         self._make_charm_files(tmp_path)
+        self._make_snap_files(tmp_path)
 
         patch_target = "opcli.core.artifacts.run_command"
         with patch(patch_target, return_value=self._GH_RESULT) as mock_run:
@@ -1145,16 +1158,22 @@ class TestArtifactsFetch:
             ],
             cwd=str(tmp_path),
         )
-        # Subsequent calls: one per charm artifact
+        # Subsequent calls: one per charm/snap artifact (rocks are skipped)
         artifact_names = {c.args[0][7] for c in calls[1:]}
-        assert artifact_names == {"built-charm-my-charm", "built-charm-other-charm"}
+        assert artifact_names == {
+            "built-charm-my-charm",
+            "built-charm-other-charm",
+            "built-snap-my-snap",
+        }
 
     def test_skips_rocks_no_download(self, tmp_path: Path) -> None:
-        """Rock OCI images are not downloaded — only the initial yaml + charms."""
+        """Rock OCI images are not downloaded — only the initial yaml + charms/snaps."""
         _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
         self._make_charm_files(tmp_path)
+        self._make_snap_files(tmp_path)
 
-        _EXPECTED_CALLS = 3  # 1 artifacts-generated + 2 charm artifacts
+        # 1 artifacts-generated + 2 charms + 1 snap = 4; no rock download
+        _EXPECTED_CALLS = 4
         patch_target = "opcli.core.artifacts.run_command"
         with patch(patch_target, return_value=self._GH_RESULT) as mock_run:
             artifacts_fetch(tmp_path, run_id="99887766", repo="owner/my-repo")
@@ -1165,8 +1184,11 @@ class TestArtifactsFetch:
         """Infers owner/repo from git remote when --repo is not given."""
         _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
         self._make_charm_files(tmp_path)
+        self._make_snap_files(tmp_path)
 
-        results = [self._GIT_RESULT, self._GH_RESULT, self._GH_RESULT, self._GH_RESULT]
+        # git + artifacts-generated + 2 charms + 1 snap = 5 calls
+        gh = self._GH_RESULT
+        results = [self._GIT_RESULT, gh, gh, gh, gh]
         patch_target = "opcli.core.artifacts.run_command"
         with patch(patch_target, side_effect=results) as mock_run:
             artifacts_fetch(tmp_path, run_id="99887766")
@@ -1183,11 +1205,13 @@ class TestArtifactsFetch:
         """Parses SSH-format git remote URLs (git@github.com:owner/repo.git)."""
         _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
         self._make_charm_files(tmp_path)
+        self._make_snap_files(tmp_path)
 
         ssh_result = SubprocessResult(
             stdout="git@github.com:owner/my-repo.git\n", stderr="", returncode=0
         )
-        results = [ssh_result, self._GH_RESULT, self._GH_RESULT, self._GH_RESULT]
+        gh = self._GH_RESULT
+        results = [ssh_result, gh, gh, gh, gh]
         with patch("opcli.core.artifacts.run_command", side_effect=results):
             artifacts_fetch(tmp_path, run_id="99887766")
 
@@ -1206,6 +1230,7 @@ class TestArtifactsFetch:
         """artifacts-generated.yaml is updated with local file paths after fetch."""
         _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
         self._make_charm_files(tmp_path)
+        self._make_snap_files(tmp_path)
 
         with patch("opcli.core.artifacts.run_command", return_value=self._GH_RESULT):
             artifacts_fetch(tmp_path, run_id="99887766", repo="owner/my-repo")
@@ -1214,3 +1239,6 @@ class TestArtifactsFetch:
         for charm in gen.charms:
             assert charm.output.files, f"Charm '{charm.name}' was not localised"
             assert charm.output.files[0].path.endswith(".charm")
+        for snap in gen.snaps:
+            assert snap.output.file, f"Snap '{snap.name}' was not localised"
+            assert snap.output.file.endswith(".snap")


### PR DESCRIPTION
Downloads `artifacts-generated.yaml` and built artifacts (charms/snaps) from a GitHub Actions run ID. Useful for running integration tests locally using CI-built artifacts without rebuilding them.

## What it does

- `opcli artifacts fetch --run-id <ID>` downloads the `artifacts-generated.yaml` from CI
- Downloads each charm/snap artifact directory via `gh run download`
- Rocks are skipped — GHCR image refs work directly without downloading
- Calls `artifacts_localize` afterwards to rewrite paths for local use
- Infers `owner/repo` from git remote when `--repo` is not provided (supports HTTPS and SSH remote formats)
- Works both locally and in CI

## Tests

6 new unit tests covering all key behaviours.