### PR TITLE
fix: remove redundant gh CLI check in CI prepare

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -327,10 +327,6 @@ if [ -f "$CONCIERGE" ]; then
   concierge prepare -c "$CONCIERGE"
 fi
 if [ -n "${GITHUB_RUN_ID:-}" ]; then
-  if ! command -v gh >/dev/null 2>&1; then
-    echo "Error: gh CLI is required for CI artifact download but was not found" >&2
-    exit 1
-  fi
   export GH_TOKEN="${GITHUB_TOKEN}"
   cd "${SPREAD_PATH}" && opcli artifacts fetch \
     --run-id "${GITHUB_RUN_ID}" \

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -229,7 +229,6 @@ class TestSpreadExpand:
         assert "GH_TOKEN" in ci["prepare"]
         assert "GITHUB_RUN_ID" in ci["prepare"]
         assert "opcli artifacts localize" not in ci["prepare"]  # fetch does it
-        assert "command -v gh" in ci["prepare"]
         assert "--wait" in ci["prepare"]
         # CI backend has GitHub Actions vars scoped to it for artifact download
         assert "environment" in ci


### PR DESCRIPTION
The explicit `command -v gh` check in `_CI_PREPARE` is redundant — `opcli artifacts fetch` already fails with a clear error if `gh` is not found. Removing the dead code.