### PR TITLE
docs: sync spec and copilot instructions with current implementation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,19 +83,21 @@ Not all YAML files should be modeled the same way:
 
 ### `artifacts.yaml` schema
 
+Each artifact points to its craft YAML file rather than a source directory. An optional `pack-dir` sets the working directory for the build tool.
+
 ```yaml
 version: 1
 rocks:
   - name: indico
-    source: indico_rock
+    rockcraft-yaml: indico_rock/rockcraft.yaml
   - name: indico-nginx
-    source: nginx_rock
+    rockcraft-yaml: nginx_rock/rockcraft.yaml
 snaps:
   - name: my-snap
-    source: snap/
+    snapcraft-yaml: snap/snapcraft.yaml
 charms:
   - name: indico
-    source: .
+    charmcraft-yaml: charmcraft.yaml
     resources:
       indico-image:
         type: oci-image
@@ -109,26 +111,34 @@ All three artifact lists (`rocks`, `charms`, `snaps`) are optional and default t
 
 ### `artifacts-generated.yaml` schema
 
-The `output` field shape depends on execution context:
+Each entry carries the same craft YAML path as `artifacts.yaml`. Charm output uses a `files` list because `charmcraft pack` may produce one `.charm` file per declared base.
 
 **Local** (file paths):
 ```yaml
 version: 1
 rocks:
   - name: indico
-    source: indico_rock
+    rockcraft-yaml: indico_rock/rockcraft.yaml
     output:
       file: ./indico_rock/indico_1.0_amd64.rock
 snaps:
   - name: my-snap
-    source: snap/
+    snapcraft-yaml: snap/snapcraft.yaml
     output:
       file: ./snap/my-snap_1.0_amd64.snap
 charms:
   - name: indico
-    source: .
+    charmcraft-yaml: charmcraft.yaml
     output:
-      file: ./indico_ubuntu-22.04-amd64.charm
+      files:
+        - path: ./indico_ubuntu-22.04-amd64.charm
+          base: ubuntu@22.04
+        - path: ./indico_ubuntu-24.04-amd64.charm
+          base: ubuntu@24.04
+    resources:
+      indico-image:
+        type: oci-image
+        rock: indico
 ```
 
 **CI** (GitHub artifacts / GHCR images):
@@ -136,18 +146,22 @@ charms:
 version: 1
 rocks:
   - name: indico
-    source: indico_rock
+    rockcraft-yaml: indico_rock/rockcraft.yaml
     output:
       image: ghcr.io/canonical/indico:abc1234-22.04
 charms:
   - name: indico
-    source: .
+    charmcraft-yaml: charmcraft.yaml
     output:
       artifact: charm-indico
-      run-id: 1234567890
+      run-id: "1234567890"
+    resources:
+      indico-image:
+        type: oci-image
+        rock: indico
 ```
 
-**Modeling guidance:** The `output` section is a union — local builds produce `file`, CI rocks produce `image`, CI charms/snaps produce `artifact` + `run-id`. Model with optional fields (all `str | None`) rather than a complex tagged union.
+**Modeling guidance:** Rocks/snaps use `ArtifactOutput` (optional fields `file`, `image`, `artifact`+`run-id`). Charms use `CharmArtifactOutput` with a `files` list (each entry has `path` and optional `base`) for local builds, or `artifact`+`run-id` for CI.
 
 ### `spread.yaml`
 
@@ -224,21 +238,17 @@ tests/
 
 - Same expansion logic as `spread run`, but prints the fully expanded `spread.yaml` to stdout without running spread. Useful for debugging.
 
-### `opcli pytest run`
+### `opcli pytest expand`
 
-- Wraps `tox -e integration` (default tox environment; override with `-e <env>`).
-- Assembles pytest arguments from `artifacts-generated.yaml` (same as `opcli pytest args`) and passes them to tox.
-- Extra arguments after `--` are forwarded verbatim to pytest.
-  ```bash
-  opcli pytest run -- -k test_charm
-  ```
-
-### `opcli pytest args`
-
-- Reads `artifacts-generated.yaml` and prints the assembled tox/pytest flags to stdout without running anything.
+- Reads `artifacts-generated.yaml` and prints the full assembled tox command to stdout without running anything.
 - Flag assembly rules (matching current operator-workflows conventions):
   - For each charm: `--charm-file <path-or-artifact-ref>`
   - For each OCI resource: `--<resource-name> <image-ref-or-local-path>`
+- Extra arguments after `--` are forwarded into the printed command.
+  ```bash
+  opcli pytest expand -- -k test_charm
+  # prints: tox -e integration -- --charm-file ./indico.charm ... -k test_charm
+  ```
 
 ---
 

--- a/docs/ISD277-redesign.md
+++ b/docs/ISD277-redesign.md
@@ -109,7 +109,7 @@ opcli artifacts build
 opcli provision run
 # If spread.yaml or task.yaml was modified manually, that prepare section should be executed here.
 # Runs "tox -e integration -- --charm-file=... ..."
-opcli pytest run -- -k test_charm
+opcli pytest expand -- -k test_charm | bash
 ```
 
 ### **CI (GitHub)**
@@ -141,58 +141,82 @@ The following files serve as the interfaces for the different steps of the pipel
 
 ### **artifacts.yaml**
 
-```
+Each artifact points to its craft YAML file (`charmcraft-yaml`, `rockcraft-yaml`, or `snapcraft-yaml`) rather than a source directory. An optional `pack-dir` field sets the working directory for the build tool (useful when the craft YAML lives in a subdirectory but packing must run from the repo root).
+
+```yaml
 version: 1
 rocks:
-- name: indico
-  source: indico_rock
-- name: indico-nginx
-  source: nginx_rock
+  - name: indico
+    rockcraft-yaml: indico_rock/rockcraft.yaml
+  - name: indico-nginx
+    rockcraft-yaml: nginx_rock/rockcraft.yaml
 charms:
-- name: indico
-  source: .
-  resources:
-    indico-image:
-      type: oci-image
-      rock: indico
-    indico-nginx-image:
-      type: oci-image
-      rock: indico-nginx
+  - name: indico
+    charmcraft-yaml: charmcraft.yaml
+    resources:
+      indico-image:
+        type: oci-image
+        rock: indico
+      indico-nginx-image:
+        type: oci-image
+        rock: indico-nginx
+snaps:
+  - name: my-snap
+    snapcraft-yaml: snap/snapcraft.yaml
 ```
 
 ### **artifacts-generated.yaml**
 
-**Locally** — always local files:
+Extends the build plan with output paths. Each entry carries the same craft YAML path as `artifacts.yaml`. Charm output uses a `files` list because `charmcraft pack` may produce one `.charm` file per declared base; each entry records the file path and an inferred `base` annotation.
 
-```
+**Locally** — built files on disk:
+
+```yaml
 version: 1
 rocks:
   - name: indico
-    source: indico_rock
+    rockcraft-yaml: indico_rock/rockcraft.yaml
     output:
       file: ./indico_rock/indico_1.0_amd64.rock
 charms:
   - name: indico
-    source: .
+    charmcraft-yaml: charmcraft.yaml
     output:
-      file: ./indico_ubuntu-22.04-amd64.charm
+      files:
+        - path: ./indico_ubuntu-22.04-amd64.charm
+          base: ubuntu@22.04
+        - path: ./indico_ubuntu-24.04-amd64.charm
+          base: ubuntu@24.04
+    resources:
+      indico-image:
+        type: oci-image
+        rock: indico
+snaps:
+  - name: my-snap
+    snapcraft-yaml: snap/snapcraft.yaml
+    output:
+      file: ./snap/my-snap_1.0_amd64.snap
 ```
 
-**In CI** — artifacts in GitHub or OCI images pushed to GHCR:
+**In CI** — rocks are pushed to GHCR; charms/snaps reference the GitHub artifact archive:
 
-```
+```yaml
 version: 1
 rocks:
   - name: indico
-    source: indico_rock
+    rockcraft-yaml: indico_rock/rockcraft.yaml
     output:
       image: ghcr.io/canonical/indico:abc1234-22.04
 charms:
   - name: indico
-    source: .
+    charmcraft-yaml: charmcraft.yaml
     output:
       artifact: charm-indico
-      run-id: 1234567890
+      run-id: "1234567890"
+    resources:
+      indico-image:
+        type: oci-image
+        rock: indico
 ```
 
 ### **concierge.yaml**
@@ -282,7 +306,7 @@ environment:
   # MODULE variants could be there instead of spread.yaml
 
 execute: |
-    $( opcli pytest run -- -k $MODULE )
+    $( opcli pytest expand -- -k $MODULE )
 ```
 
 The  MODULE  environment variable is set by the spread variant (defined in  spread.yaml ). Each variant runs one test module.
@@ -297,30 +321,35 @@ The functionality for opcli is grouped into four command families:  artifacts , 
 
 | Command | Description | Extra options |
 | :---- | :---- | :---- |
-| opcli artifacts init | Discovers charms, rocks and snaps in the repository and generates artifacts.yaml |  |
-| opcli artifacts build | Builds all artifacts declared in artifacts.yaml and produces artifacts-generated.yaml If charms or rocks arg is used, only those artifacts will be built. |  —charm \<charm-name\>, charms to build. Can be used several times. —rock \<rock-name\>, rocks to build Can be used several times.  |
+| opcli artifacts init | Discovers charms, rocks and snaps in the repository and generates artifacts.yaml | --force: overwrite existing artifacts.yaml |
+| opcli artifacts build | Builds all artifacts declared in artifacts.yaml and produces artifacts-generated.yaml | --charm \<name\>: build only this charm (repeatable). --rock \<name\>: rocks to build (repeatable). --snap \<name\>: snaps to build (repeatable). |
+| opcli artifacts matrix | Prints the GitHub Actions build matrix as JSON, suitable for use as strategy.matrix in a workflow. | |
+| opcli artifacts collect \<partial…\> | Merges partial artifacts-generated.yaml files produced by parallel CI build jobs into a single file. | |
+| opcli artifacts fetch | Downloads artifacts-generated.yaml and all built charm/snap archives from a CI run, then rewrites paths to local files so that opcli pytest run and opcli spread run work without a local build. Rock artifacts are GHCR images and require no download. | --run-id \<id\>: GitHub Actions workflow run ID (required). --repo \<owner/name\>: GitHub repository (default: current git remote). --wait/--no-wait: retry until artifacts-generated appears, for use when the build job may still be running. |
+| opcli artifacts localize | Rewrites artifacts-generated.yaml to replace CI artifact references with local .charm file paths after the charm archives have been manually downloaded. (Prefer opcli artifacts fetch for the full workflow.) | |
 
 ### **opcli provision**
 
 | Command | Description | Extra options |
 | :---- | :---- | :---- |
-| opcli provision run | Runs concierge prepare to provision the test. |  |
-| opcli provision load | Loads the image artifacts into the local image registry. | \-r registry. Specify the image registry. Defaults to localhost:32000 |
+| opcli provision run | Runs concierge prepare to provision the test environment. |  |
+| opcli provision load | Loads OCI image artifacts (rocks) into a local image registry. | -r / --registry: target registry (default: localhost:32000) |
+| opcli provision registry | Deploys a local OCI registry at localhost:32000 for k8s/MicroK8s. Reads concierge.yaml to detect the active k8s provider. No-op if the registry is already running or no k8s provider is configured. | -c / --concierge: path to concierge.yaml (default: concierge.yaml) |
 
 ### **opcli spread**
 
 | Command | Description | Extra options |
 | :---- | :---- | :---- |
 | opcli spread init | Discovers integration tests and generates spread.yaml and tests/integration/run/task.yaml |  |
-| opcli spread run | Expands the virtual backend in spread.yaml and runs spread as a subprocess, passing the same arguments as received. | As in craft-application, the CI env var defines whether to run locally or in the pipeline. All arguments are passed to the spread subprocess. |
+| opcli spread run | Expands the virtual backend in spread.yaml and runs spread as a subprocess, passing the same arguments as received. | As in craft-application, the CI env var defines whether to run locally or in the pipeline. All arguments after -- are passed verbatim to the spread subprocess. |
 | opcli spread expand | Prints the fully expanded spread.yaml | As in craft-application, the CI env var defines whether to run locally or in the pipeline |
+| opcli spread tasks | Prints the list of spread tasks/variants discovered in spread.yaml. | |
 
 ### **opcli pytest**
 
 | Command | Description | Extra options |
 | :---- | :---- | :---- |
-| opcli pytest run | Runs integration tests with tox with the arguments as in “opcli pytest args” | \-e tox environment. By default “integration”.  “- \-” passes extra arguments to pytest |
-| opcli pytest args | Prints the assembled tox/pytest flags to stdout without running it, using as input the file artifacts-generated.yaml. Useful for debugging/manual script invocation. Follows the same conventions as currently in operator-workflows. |  |
+| opcli pytest expand | Prints the full tox command assembled from artifacts-generated.yaml. Assembles --charm-file and resource flags following the same conventions as operator-workflows. Extra args after -- are forwarded into the printed command. Useful for debugging and scripting. | -e: tox environment name (default: integration). -- <args>: forwarded to pytest. |
 
 ## Design decisions
 


### PR DESCRIPTION
Resolves discrepancies between `docs/ISD277-redesign.md` / `.github/copilot-instructions.md` and the current code:

| Area | Was | Now |
|------|-----|-----|
| `artifacts.yaml` schema | `source:` field | `charmcraft-yaml`/`rockcraft-yaml`/`snapcraft-yaml` + optional `pack-dir` |
| `artifacts-generated.yaml` charms | `output.file` (single) | `output.files[]` (list of `{path, base}`) for multi-base |
| `artifacts-generated.yaml` rock/snap CI | not shown | `output.image` / `output.artifact+run-id` |
| `opcli artifacts` table | only `init` + `build` | adds `matrix`, `collect`, `fetch`, `localize` |
| `opcli artifacts build` | `--charm`, `--rock` only | adds `--snap` |
| `opcli provision` table | `run` + `load` only | adds `registry` |
| `opcli spread` table | `init`, `run`, `expand` | adds `tasks` |
| `opcli pytest` | `run` + `args` (not implemented) | `expand` (actual command) |
