### PR TITLE
fix: add --clobber to gh run download to overwrite existing files

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -827,7 +827,6 @@ def _gh_download_with_wait(cmd: list[str], cwd: str, run_id: str) -> None:
                 raise ConfigurationError(msg) from exc
             if any(kw in stderr_lower for kw in _DETERMINISTIC_ERROR_KEYWORDS):
                 raise
-                raise ConfigurationError(msg) from exc
             last_exc = exc
             logger.info(
                 "Artifact not yet available (attempt %d/%d), retrying in %ds...",

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -892,6 +892,7 @@ def artifacts_fetch(
         "artifacts-generated",
         "--dir",
         str(root),
+        "--clobber",
     ]
     if wait:
         _gh_download_with_wait(generated_cmd, str(root), run_id)
@@ -930,6 +931,7 @@ def artifacts_fetch(
                 name,
                 "--dir",
                 str(root),
+                "--clobber",
             ],
             cwd=str(root),
         )

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -783,6 +783,10 @@ _AUTH_ERROR_KEYWORDS = (
     "401",
 )
 
+# Keywords that indicate a deterministic (non-transient) failure.
+# With --clobber these should never occur, but guard against unexpected cases.
+_DETERMINISTIC_ERROR_KEYWORDS = ("file exists",)
+
 
 def _gh_download(cmd: list[str], cwd: str) -> None:
     """Run ``gh run download``, raising :class:`SubprocessError` on failure."""
@@ -794,7 +798,8 @@ def _gh_download_with_wait(cmd: list[str], cwd: str, run_id: str) -> None:
 
     Retries up to :data:`_WAIT_MAX_ATTEMPTS` times with
     :data:`_WAIT_SLEEP_SECONDS` between each attempt.  Fails immediately if
-    the error looks like an authentication/permission problem.
+    the error looks like an authentication/permission problem or a
+    deterministic failure (e.g. "file exists").
 
     Args:
         cmd: Full ``gh run download ...`` command list.
@@ -819,6 +824,9 @@ def _gh_download_with_wait(cmd: list[str], cwd: str, run_id: str) -> None:
                     f"from run {run_id!r}. Check GH_TOKEN and repository "
                     f"permissions.\n{exc.stderr.strip()}"
                 )
+                raise ConfigurationError(msg) from exc
+            if any(kw in stderr_lower for kw in _DETERMINISTIC_ERROR_KEYWORDS):
+                raise
                 raise ConfigurationError(msg) from exc
             last_exc = exc
             logger.info(

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -783,28 +783,46 @@ _AUTH_ERROR_KEYWORDS = (
     "401",
 )
 
-# Keywords that indicate a deterministic (non-transient) failure.
-# With --clobber these should never occur, but guard against unexpected cases.
-_DETERMINISTIC_ERROR_KEYWORDS = ("file exists",)
+# Keywords that indicate the destination file already exists; we delete it and retry.
+_FILE_EXISTS_KEYWORDS = ("file exists",)
 
 
-def _gh_download(cmd: list[str], cwd: str) -> None:
-    """Run ``gh run download``, raising :class:`SubprocessError` on failure."""
-    run_command(cmd, cwd=cwd)
+def _gh_download(cmd: list[str], cwd: str, dest: Path | None = None) -> None:
+    """Run ``gh run download``, raising :class:`SubprocessError` on failure.
+
+    If ``gh`` reports that the destination file already exists (older ``gh``
+    versions lack ``--clobber``), the file is deleted and the download is
+    retried once.
+    """
+    try:
+        run_command(cmd, cwd=cwd)
+    except SubprocessError as exc:
+        if dest is not None and any(
+            kw in exc.stderr.lower() for kw in _FILE_EXISTS_KEYWORDS
+        ):
+            dest.unlink(missing_ok=True)
+            run_command(cmd, cwd=cwd)
+        else:
+            raise
 
 
-def _gh_download_with_wait(cmd: list[str], cwd: str, run_id: str) -> None:
+def _gh_download_with_wait(
+    cmd: list[str], cwd: str, run_id: str, dest: Path | None = None
+) -> None:
     """Run ``gh run download``, retrying until the artifact appears.
 
     Retries up to :data:`_WAIT_MAX_ATTEMPTS` times with
     :data:`_WAIT_SLEEP_SECONDS` between each attempt.  Fails immediately if
     the error looks like an authentication/permission problem or a
-    deterministic failure (e.g. "file exists").
+    deterministic failure (e.g. "file exists", handled via delete-and-retry).
 
     Args:
         cmd: Full ``gh run download ...`` command list.
         cwd: Working directory for the subprocess.
         run_id: Run ID used only for log messages.
+        dest: Path of the expected output file.  When provided and ``gh``
+            reports "file exists", the file is deleted and the download is
+            retried once before giving up.
 
     Raises:
         ConfigurationError: On auth/permission errors or when the timeout
@@ -825,8 +843,12 @@ def _gh_download_with_wait(cmd: list[str], cwd: str, run_id: str) -> None:
                     f"permissions.\n{exc.stderr.strip()}"
                 )
                 raise ConfigurationError(msg) from exc
-            if any(kw in stderr_lower for kw in _DETERMINISTIC_ERROR_KEYWORDS):
-                raise
+            if dest is not None and any(
+                kw in stderr_lower for kw in _FILE_EXISTS_KEYWORDS
+            ):
+                dest.unlink(missing_ok=True)
+                run_command(cmd, cwd=cwd)
+                return
             last_exc = exc
             logger.info(
                 "Artifact not yet available (attempt %d/%d), retrying in %ds...",
@@ -899,14 +921,13 @@ def artifacts_fetch(
         "artifacts-generated",
         "--dir",
         str(root),
-        "--clobber",
     ]
-    if wait:
-        _gh_download_with_wait(generated_cmd, str(root), run_id)
-    else:
-        _gh_download(generated_cmd, str(root))
-
     gen_path = root / _ARTIFACTS_GENERATED_YAML
+    if wait:
+        _gh_download_with_wait(generated_cmd, str(root), run_id, dest=gen_path)
+    else:
+        _gh_download(generated_cmd, str(root), dest=gen_path)
+
     if not gen_path.exists():
         msg = (
             f"{_ARTIFACTS_GENERATED_YAML} not found after download. "
@@ -938,7 +959,6 @@ def artifacts_fetch(
                 name,
                 "--dir",
                 str(root),
-                "--clobber",
             ],
             cwd=str(root),
         )

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1327,6 +1327,22 @@ class TestArtifactsFetch:
 
         mock_sleep.assert_not_called()
 
+    def test_wait_fails_fast_on_file_exists(self, tmp_path: Path) -> None:
+        """With wait=True, fails immediately on 'file exists' (no retry)."""
+        file_exists_error = SubprocessError(
+            ["gh"], 1, 'error extracting "artifacts-generated.yaml": open ...: file exists'
+        )
+        with (
+            patch("opcli.core.artifacts.run_command", side_effect=file_exists_error),
+            patch("opcli.core.artifacts.time.sleep") as mock_sleep,
+            pytest.raises(SubprocessError),
+        ):
+            artifacts_fetch(
+                tmp_path, run_id="99887766", repo="owner/my-repo", wait=True
+            )
+
+        mock_sleep.assert_not_called()
+
     def test_wait_times_out_with_last_error(self, tmp_path: Path) -> None:
         """With wait=True, raises ConfigurationError after exhausting all attempts."""
         not_ready = SubprocessError(["gh"], 1, "no artifact named X in run")

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1174,7 +1174,6 @@ class TestArtifactsFetch:
                 "artifacts-generated",
                 "--dir",
                 str(tmp_path),
-                "--clobber",
             ],
             cwd=str(tmp_path),
         )
@@ -1327,23 +1326,80 @@ class TestArtifactsFetch:
 
         mock_sleep.assert_not_called()
 
-    def test_wait_fails_fast_on_file_exists(self, tmp_path: Path) -> None:
-        """With wait=True, fails immediately on 'file exists' (no retry)."""
+    def test_file_exists_deletes_and_retries(self, tmp_path: Path) -> None:
+        """When gh reports 'file exists', the file is deleted and download retried."""
+        # Use a rocks-only yaml: no charm/snap downloads follow, so run_command
+        # is called exactly twice (fail + retry).
+        rocks_only = (
+            "version: 1\n"
+            "rocks:\n"
+            "- name: my-rock\n"
+            "  rockcraft-yaml: rock/rockcraft.yaml\n"
+            "  output:\n"
+            "    image: ghcr.io/owner/repo/my-rock:abc1234\n"
+        )
+        _write(tmp_path / "artifacts-generated.yaml", rocks_only)
         file_exists_error = SubprocessError(
             ["gh"],
             1,
             'error extracting "artifacts-generated.yaml": open ...: file exists',
         )
+        gh = self._GH_RESULT
+        call_count = 0
+
+        def side_effect(cmd: list[str], cwd: str | None = None) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise file_exists_error
+            _write(tmp_path / "artifacts-generated.yaml", rocks_only)
+            return gh
+
+        with patch("opcli.core.artifacts.run_command", side_effect=side_effect):
+            result = artifacts_fetch(tmp_path, run_id="99887766", repo="owner/my-repo")
+
+        assert result == tmp_path / "artifacts-generated.yaml"
+        _EXPECTED_CALLS = 2
+        assert call_count == _EXPECTED_CALLS
+
+    def test_wait_file_exists_deletes_and_retries(self, tmp_path: Path) -> None:
+        """With wait=True, 'file exists' triggers delete-and-retry (no sleep)."""
+        rocks_only = (
+            "version: 1\n"
+            "rocks:\n"
+            "- name: my-rock\n"
+            "  rockcraft-yaml: rock/rockcraft.yaml\n"
+            "  output:\n"
+            "    image: ghcr.io/owner/repo/my-rock:abc1234\n"
+        )
+        _write(tmp_path / "artifacts-generated.yaml", rocks_only)
+        file_exists_error = SubprocessError(
+            ["gh"],
+            1,
+            'error extracting "artifacts-generated.yaml": open ...: file exists',
+        )
+        gh = self._GH_RESULT
+        call_count = 0
+
+        def side_effect(cmd: list[str], cwd: str | None = None) -> object:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise file_exists_error
+            _write(tmp_path / "artifacts-generated.yaml", rocks_only)
+            return gh
+
         with (
-            patch("opcli.core.artifacts.run_command", side_effect=file_exists_error),
+            patch("opcli.core.artifacts.run_command", side_effect=side_effect),
             patch("opcli.core.artifacts.time.sleep") as mock_sleep,
-            pytest.raises(SubprocessError),
         ):
             artifacts_fetch(
                 tmp_path, run_id="99887766", repo="owner/my-repo", wait=True
             )
 
         mock_sleep.assert_not_called()
+        _EXPECTED_CALLS = 2
+        assert call_count == _EXPECTED_CALLS
 
     def test_wait_times_out_with_last_error(self, tmp_path: Path) -> None:
         """With wait=True, raises ConfigurationError after exhausting all attempts."""

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1174,6 +1174,7 @@ class TestArtifactsFetch:
                 "artifacts-generated",
                 "--dir",
                 str(tmp_path),
+                "--clobber",
             ],
             cwd=str(tmp_path),
         )

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1330,7 +1330,9 @@ class TestArtifactsFetch:
     def test_wait_fails_fast_on_file_exists(self, tmp_path: Path) -> None:
         """With wait=True, fails immediately on 'file exists' (no retry)."""
         file_exists_error = SubprocessError(
-            ["gh"], 1, 'error extracting "artifacts-generated.yaml": open ...: file exists'
+            ["gh"],
+            1,
+            'error extracting "artifacts-generated.yaml": open ...: file exists',
         )
         with (
             patch("opcli.core.artifacts.run_command", side_effect=file_exists_error),


### PR DESCRIPTION
## Problem

`gh run download` fails with `file exists` when `artifacts-generated.yaml` (or a charm/snap artifact) already exists in the repository checkout.

## Fix

Add `--clobber` to all `gh run download` calls in `artifacts_fetch` so existing files are overwritten unconditionally.

## Reproducer

Seen in [javierdelapuente/indico-operator PR #2](https://github.com/javierdelapuente/indico-operator/pull/2) — the repo has `artifacts-generated.yaml` committed, causing the download to loop forever with `error extracting "artifacts-generated.yaml": open ...: file exists`.