### PR TITLE
feat: add multi-arch support to artifacts

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -70,9 +70,9 @@ jobs:
 
   # ── Job 2: build each artifact in parallel ─────────────────────────────────
   build:
-    name: "Build ${{ matrix.type }} ${{ matrix.name }}"
+    name: "Build ${{ matrix.type }} ${{ matrix.name }} (${{ matrix.arch }})"
     needs: build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(matrix.runner) }}
     permissions:
       contents: read
       packages: write
@@ -137,14 +137,14 @@ jobs:
         if: matrix.type != 'rock'
         uses: actions/upload-artifact@v4
         with:
-          name: built-${{ matrix.type }}-${{ matrix.name }}
+          name: built-${{ matrix.type }}-${{ matrix.name }}-${{ matrix.arch }}
           path: ${{ inputs.working-directory }}/**/*.${{ matrix.type }}
           if-no-files-found: error
 
       - name: Upload partial artifacts-generated.yaml
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-generated-${{ matrix.type }}-${{ matrix.name }}
+          name: artifacts-generated-${{ matrix.type }}-${{ matrix.name }}-${{ matrix.arch }}
           path: ${{ inputs.working-directory }}/artifacts-generated.yaml
           if-no-files-found: error
 

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -102,8 +102,11 @@ jobs:
       # No CI=true → spread uses the local: backend (LXD VM).
       # _LOCAL_PREPARE inside the VM runs concierge and opcli provision load.
       # Explicitly clear CI to override GitHub Actions' default CI=true.
+      # Set OPCLI_GIT_REF so the LXD VM installs the same opcli commit that
+      # produced artifacts-generated.yaml, keeping the format in sync.
       - name: Run spread (local/LXD)
         env:
           CI: ""
+          OPCLI_GIT_REF: ${{ github.sha }}
         run: opcli spread run -- -vv
 

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -301,7 +301,7 @@ artifact types.
 
 ---
 
-## 12. Multi-base charm output — `output.files` list instead of single `output.file`
+## 12. Multi-base charm output — `output[*].files` list inside each arch build
 
 **Spec:** The `artifacts-generated.yaml` schema shows a single `output.file`
 path for each charm entry:
@@ -313,23 +313,24 @@ charms:
       file: ./indico_ubuntu-22.04-amd64.charm
 ```
 
-**Implementation:** Charms use an `output.files` list of `{path, base}` objects
-because `charmcraft pack` produces **one `.charm` file per declared base** in a
-single invocation (e.g. ubuntu@20.04, ubuntu@22.04, ubuntu@24.04 with the same
-architecture each produce a separate file):
+**Implementation:** The `output:` field is now a **list of per-architecture build
+objects** (`CharmArchBuild`). Each `CharmArchBuild` has an `arch` field and a
+`files` list of `{path, base}` objects, because `charmcraft pack` produces
+**one `.charm` file per declared base** in a single invocation (e.g. ubuntu@20.04,
+ubuntu@22.04, ubuntu@24.04 with the same architecture each produce a separate file):
 
 ```yaml
 charms:
   - name: aproxy
-    charmcraft-yaml: charmcraft.yaml
     output:
-      files:
-        - path: ./aproxy_ubuntu-20.04-amd64.charm
-          base: ubuntu@20.04
-        - path: ./aproxy_ubuntu-22.04-amd64.charm
-          base: ubuntu@22.04
-        - path: ./aproxy_ubuntu-24.04-amd64.charm
-          base: ubuntu@24.04
+      - arch: amd64
+        files:
+          - path: ./aproxy_ubuntu-20.04-amd64.charm
+            base: ubuntu@20.04
+          - path: ./aproxy_ubuntu-22.04-amd64.charm
+            base: ubuntu@22.04
+          - path: ./aproxy_ubuntu-24.04-amd64.charm
+            base: ubuntu@24.04
 ```
 
 The `base` field is parsed best-effort from the filename
@@ -337,15 +338,14 @@ The `base` field is parsed best-effort from the filename
 `null` when the filename does not follow this convention.
 
 `opcli pytest expand` emits one `--charm-file=<path>` flag per entry in
-`output.files`.
+`files` for the arch matching the current machine.
 
-For CI-built charms, the `artifact` and `run-id` fields remain on
-`CharmArtifactOutput` alongside `files` (which is empty in that case).
+For CI-built charms, `artifact` and `run-id` fields replace `files` in the
+`CharmArchBuild` entry.
 
-**Rationale:** Rocks and snaps always produce exactly one file per
-architecture so their schema is unchanged. Only charms need the list because
-multi-base (same-arch) builds are a common pattern in the Canonical operator
-ecosystem.
+**Rationale:** Rocks and snaps always produce exactly one file per architecture.
+Only charms need the inner files list because multi-base (same-arch) builds
+are a common pattern in the Canonical operator ecosystem.
 
 ---
 
@@ -355,12 +355,12 @@ ecosystem.
 The spec does not describe any modification of `artifacts-generated.yaml`.
 
 **Implementation:** After successfully pushing each rock image,
-`opcli provision load` updates the corresponding `rock.output.image` field in
-`artifacts-generated.yaml` with the pushed image reference (e.g.
-`localhost:32000/myrock:latest`).
+`opcli provision load` updates the corresponding arch build entry's `image`
+field in `artifacts-generated.yaml` with the pushed image reference (e.g.
+`localhost:32000/myrock:amd64`).
 
 This means that after running `opcli provision load`, `opcli pytest expand`
-automatically emits `--<resource-name>=localhost:32000/myrock:latest` (the
+automatically emits `--<resource-name>=localhost:32000/myrock:amd64` (the
 live registry reference) for any charm resource linked to that rock, because
 pytest-args resolves image refs by looking up the rock — not by reading a
 separate field on the resource.
@@ -397,18 +397,29 @@ downside.
 **Implementation:** Two new commands support the parallel CI build pattern:
 
 - **`opcli artifacts matrix`** reads `artifacts.yaml` and prints a JSON object
-  suitable for use as a GitHub Actions `strategy.matrix`. Each artifact
-  (rocks, then charms, then snaps) becomes one entry with `name` and `type`:
+  suitable for use as a GitHub Actions `strategy.matrix`. Each matrix entry is
+  expanded per `builds:` target (one entry per `{artifact, arch}` pair) and
+  includes `name`, `type`, `arch`, and `runner` fields:
   ```json
-  {"include": [{"name": "my-rock", "type": "rock"}, {"name": "my-charm", "type": "charm"}]}
+  {"include": [
+    {"name": "my-rock",  "type": "rock",  "arch": "amd64", "runner": "[\"ubuntu-latest\"]"},
+    {"name": "my-charm", "type": "charm", "arch": "amd64", "runner": "[\"ubuntu-latest\"]"},
+    {"name": "my-charm", "type": "charm", "arch": "arm64", "runner": "[\"ubuntu-latest-arm64\"]"}
+  ]}
   ```
-  This drives the parallel `build` job in the reusable `build-artifacts.yml` workflow.
+  The `runner` value is a **JSON-encoded string** (not a nested array) so that
+  GitHub Actions `fromJSON(matrix.runner)` correctly converts it to a runner
+  label array at job execution time. This supports both single-label
+  (`'["ubuntu-latest"]'`) and multi-label (`'["self-hosted", "arm64"]'`) runner
+  specs. Workflow usage: `runs-on: ${{ fromJSON(matrix.runner) }}`.
 
 - **`opcli artifacts collect <partial1> <partial2> ...`** reads multiple partial
   `artifacts-generated.yaml` files (one per parallel build job) and merges them
-  into a single `artifacts-generated.yaml`. It validates that:
-  - No artifact name appears in more than one partial.
-  - Every rock referenced by a charm resource is present in the collected set.
+  into a single `artifacts-generated.yaml`. Each artifact can appear in multiple
+  partials as long as no two partials contain the same `(name, arch)` pair — this
+  enables multi-arch builds where each runner produces a partial for its arch and
+  the collect step merges the output lists. It also validates that every rock
+  referenced by a charm resource is present in the collected set.
 
 **Rationale:** Each parallel build job produces its own partial
 `artifacts-generated.yaml`. The collect step merges them into the single file

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -9,8 +9,10 @@
 from __future__ import annotations
 
 import glob as globmod
+import json
 import logging
 import os
+import platform
 import re
 import time
 from dataclasses import dataclass
@@ -31,14 +33,15 @@ from opcli.models.artifacts import (
     SnapArtifact,
 )
 from opcli.models.artifacts_generated import (
-    ArtifactOutput,
     ArtifactsGenerated,
-    CharmArtifactOutput,
+    CharmArchBuild,
     CharmFile,
     GeneratedCharm,
     GeneratedResource,
     GeneratedRock,
     GeneratedSnap,
+    RockArchBuild,
+    SnapArchBuild,
 )
 
 logger = logging.getLogger(__name__)
@@ -113,31 +116,50 @@ def _get_ci_context() -> _CIContext | None:
     return _CIContext(run_id=run_id, owner=owner, repo=repo, sha=sha[:7])
 
 
+def _current_arch() -> str:
+    """Return the normalised architecture of the current machine.
+
+    Maps ``x86_64`` → ``amd64`` and ``aarch64`` → ``arm64``.
+    All other values are returned as-is (lower-cased).
+    """
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        return "amd64"
+    if machine in ("aarch64", "arm64"):
+        return "arm64"
+    return machine
+
+
 def _push_rock_to_ghcr(
     rock: GeneratedRock, ci: _CIContext, root: Path
 ) -> GeneratedRock:
     """Push a locally-built rock to GHCR and return an updated ``GeneratedRock``.
 
     The rock ``.rock`` file is pushed to
-    ``ghcr.io/<owner>/<repo>/<name>:<sha7>`` using ``skopeo copy``.
-    The returned object has ``output.image`` set and no ``output.file``.
+    ``ghcr.io/<owner>/<repo>/<name>:<sha7>-<arch>`` using ``skopeo copy``.
+    The returned object has its ``output`` rewritten to a single
+    :class:`RockArchBuild` with ``image`` set and no ``file``.
 
     Raises:
-        OpcliError: If the rock file does not exist.
+        OpcliError: If the rock output list is empty or has no local file.
         SubprocessError: If the skopeo push fails.
     """
-    if not rock.output.file:
+    if not rock.output:
+        msg = f"Rock '{rock.name}' has no build output to push to GHCR."
+        raise OpcliError(msg)
+    build = rock.output[0]
+    if not build.file:
         msg = f"Rock '{rock.name}' has no local file to push to GHCR."
         raise OpcliError(msg)
 
-    rock_path = Path(rock.output.file)
+    rock_path = Path(build.file)
     if not rock_path.is_absolute():
         rock_path = (root / rock_path).resolve()
     if not rock_path.exists():
         msg = f"Rock file not found: {rock_path}"
         raise OpcliError(msg)
 
-    image_ref = f"ghcr.io/{ci.owner}/{ci.repo}/{rock.name}:{ci.sha}"
+    image_ref = f"ghcr.io/{ci.owner}/{ci.repo}/{rock.name}:{ci.sha}-{build.arch}"
     run_command(
         [
             "skopeo",
@@ -152,30 +174,52 @@ def _push_rock_to_ghcr(
     return GeneratedRock(
         name=rock.name,
         **{"rockcraft-yaml": rock.rockcraft_yaml},
-        output=ArtifactOutput(image=image_ref),
+        output=[RockArchBuild(arch=build.arch, image=image_ref)],
     )
 
 
 def _to_ci_charm(charm: GeneratedCharm, ci: _CIContext) -> GeneratedCharm:
-    """Return a copy of *charm* with CI artifact-reference output."""
+    """Return a copy of *charm* with CI artifact-reference output.
+
+    The artifact name includes the architecture so parallel multi-arch builds
+    produce distinct artifact names (e.g. ``built-charm-my-charm-amd64``).
+    """
+    arch = charm.output[0].arch if charm.output else _current_arch()
     return GeneratedCharm(
         name=charm.name,
         **{"charmcraft-yaml": charm.charmcraft_yaml},
-        output=CharmArtifactOutput.model_validate(
-            {"artifact": f"built-charm-{charm.name}", "run-id": ci.run_id}
-        ),
+        output=[
+            CharmArchBuild.model_validate(
+                {
+                    "arch": arch,
+                    "artifact": f"built-charm-{charm.name}-{arch}",
+                    "run-id": ci.run_id,
+                }
+            )
+        ],
         resources=charm.resources,
     )
 
 
 def _to_ci_snap(snap: GeneratedSnap, ci: _CIContext) -> GeneratedSnap:
-    """Return a copy of *snap* with CI artifact-reference output."""
+    """Return a copy of *snap* with CI artifact-reference output.
+
+    The artifact name includes the architecture so parallel multi-arch builds
+    produce distinct artifact names (e.g. ``built-snap-my-snap-amd64``).
+    """
+    arch = snap.output[0].arch if snap.output else _current_arch()
     return GeneratedSnap(
         name=snap.name,
         **{"snapcraft-yaml": snap.snapcraft_yaml},
-        output=ArtifactOutput.model_validate(
-            {"artifact": f"built-snap-{snap.name}", "run-id": ci.run_id}
-        ),
+        output=[
+            SnapArchBuild.model_validate(
+                {
+                    "arch": arch,
+                    "artifact": f"built-snap-{snap.name}-{arch}",
+                    "run-id": ci.run_id,
+                }
+            )
+        ],
     )
 
 
@@ -268,9 +312,9 @@ def _relative_to_root(path_str: str, root: Path) -> str:
 
 
 # Pattern: {name}_{distro}-{version}-{arch}.charm
-# e.g. aproxy_ubuntu-22.04-amd64.charm → distro=ubuntu, version=22.04
+# e.g. aproxy_ubuntu-22.04-amd64.charm → distro=ubuntu, version=22.04, arch=amd64
 _CHARM_FILENAME_RE = re.compile(
-    r"^.+_(?P<distro>[a-z]+)-(?P<version>\d+\.\d+)-[^.]+\.charm$"
+    r"^.+_(?P<distro>[a-z]+)-(?P<version>\d+\.\d+)-(?P<arch>[^.]+)\.charm$"
 )
 
 
@@ -285,6 +329,30 @@ def _parse_base_from_charm_path(path: str) -> str | None:
     if not m:
         return None
     return f"{m.group('distro')}@{m.group('version')}"
+
+
+def _parse_arch_from_charm_path(path: str) -> str | None:
+    """Return the arch (e.g. ``amd64``) parsed from a charm filename.
+
+    Returns ``None`` if the filename does not follow the expected convention.
+    """
+    filename = Path(path).name
+    m = _CHARM_FILENAME_RE.match(filename)
+    return m.group("arch") if m else None
+
+
+# Pattern: {name}_{version}_{arch}.snap  e.g. my-snap_1.0_amd64.snap
+_SNAP_FILENAME_RE = re.compile(r"^.+_[^_]+_(?P<arch>[^.]+)\.snap$")
+
+
+def _parse_arch_from_snap_path(path: str) -> str | None:
+    """Return the arch (e.g. ``amd64``) parsed from a snap filename.
+
+    Returns ``None`` if the filename does not follow the expected convention.
+    """
+    filename = Path(path).name
+    m = _SNAP_FILENAME_RE.match(filename)
+    return m.group("arch") if m else None
 
 
 def _pick_new_charm_outputs(
@@ -380,7 +448,7 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
     return GeneratedRock(
         name=rock.name,
         **{"rockcraft-yaml": rock.rockcraft_yaml},
-        output=ArtifactOutput(file=output_file),
+        output=[RockArchBuild(arch=_current_arch(), file=output_file)],
     )
 
 
@@ -419,7 +487,7 @@ def _build_charm(
     return GeneratedCharm(
         name=charm.name,
         **{"charmcraft-yaml": charm.charmcraft_yaml},
-        output=CharmArtifactOutput(files=charm_files),
+        output=[CharmArchBuild(arch=_current_arch(), files=charm_files)],
         resources=resources if resources else None,
     )
 
@@ -442,7 +510,7 @@ def _build_snap(snap: SnapArtifact, root: Path) -> GeneratedSnap:
     return GeneratedSnap(
         name=snap.name,
         **{"snapcraft-yaml": snap.snapcraft_yaml},
-        output=ArtifactOutput(file=output_file),
+        output=[SnapArchBuild(arch=_current_arch(), file=output_file)],
     )
 
 
@@ -509,12 +577,16 @@ def artifacts_build(
     return dest
 
 
-def artifacts_matrix(root: Path) -> dict[str, list[dict[str, str]]]:
+def artifacts_matrix(root: Path) -> dict[str, list[dict[str, object]]]:
     """Read ``artifacts.yaml`` and return a GitHub Actions matrix dict.
 
     The returned dict has a single key ``"include"`` whose value is a list of
-    entries — one per artifact — each with ``"name"`` and ``"type"`` keys.
-    Rocks come first, then charms, then snaps.
+    entries — one per (artifact, arch) combination — each with ``"name"``,
+    ``"type"``, ``"arch"``, and ``"runner"`` keys.  ``runner`` is a list of
+    GitHub runner label strings.
+
+    Rocks come first, then charms, then snaps.  Within each kind, entries are
+    ordered by artifact declaration order, then by ``builds`` order.
 
     The result is JSON-serialisable and suitable for use as a GitHub Actions
     ``strategy.matrix`` value via ``$GITHUB_OUTPUT``.
@@ -528,15 +600,72 @@ def artifacts_matrix(root: Path) -> dict[str, list[dict[str, str]]]:
         raise ConfigurationError(msg)
 
     plan = load_artifacts_plan(plan_path)
-    include: list[dict[str, str]] = []
+    include: list[dict[str, object]] = []
     for rock in plan.rocks:
-        include.append({"name": rock.name, "type": "rock"})
+        for build in rock.builds:
+            include.append(
+                {
+                    "name": rock.name,
+                    "type": "rock",
+                    "arch": build.arch,
+                    "runner": json.dumps(build.runner or ["ubuntu-latest"]),
+                }
+            )
     for charm in plan.charms:
-        include.append({"name": charm.name, "type": "charm"})
+        for build in charm.builds:
+            include.append(
+                {
+                    "name": charm.name,
+                    "type": "charm",
+                    "arch": build.arch,
+                    "runner": json.dumps(build.runner or ["ubuntu-latest"]),
+                }
+            )
     for snap in plan.snaps:
-        include.append({"name": snap.name, "type": "snap"})
+        for build in snap.builds:
+            include.append(
+                {
+                    "name": snap.name,
+                    "type": "snap",
+                    "arch": build.arch,
+                    "runner": json.dumps(build.runner or ["ubuntu-latest"]),
+                }
+            )
 
     return {"include": include}
+
+
+def _merge_artifact_outputs[T: (GeneratedRock, GeneratedCharm, GeneratedSnap)](
+    items: list[T],
+    kind: str,
+) -> list[T]:
+    """Merge artifacts with the same name by combining their output lists.
+
+    In a multi-arch CI build, each arch produces a separate partial file for
+    the same artifact but with a different arch entry in ``output``.  This
+    function groups them by name and concatenates the ``output`` lists so that
+    the collected file holds all arches for each artifact.
+
+    Raises :class:`ConfigurationError` if the same ``(name, arch)`` pair
+    appears in more than one partial (genuine conflict, not a multi-arch merge).
+    """
+    merged: dict[str, T] = {}
+    for item in items:
+        if item.name not in merged:
+            merged[item.name] = item
+        else:
+            existing = merged[item.name]
+            existing_arches = {b.arch for b in existing.output}
+            for build in item.output:
+                if build.arch in existing_arches:
+                    msg = (
+                        f"Duplicate {kind} '{item.name}' arch '{build.arch}' across "
+                        "collected partials. Each (artifact, arch) must appear in "
+                        "exactly one partial file."
+                    )
+                    raise ConfigurationError(msg)
+            existing.output.extend(item.output)
+    return list(merged.values())
 
 
 def artifacts_collect(root: Path, partial_paths: list[Path]) -> Path:
@@ -577,24 +706,15 @@ def artifacts_collect(root: Path, partial_paths: list[Path]) -> Path:
         all_charms.extend(partial.charms)
         all_snaps.extend(partial.snaps)
 
-    # Reject duplicate artifact names — each name must appear in exactly one partial.
-    for kind, names in (
-        ("rock", [r.name for r in all_rocks]),
-        ("charm", [c.name for c in all_charms]),
-        ("snap", [s.name for s in all_snaps]),
-    ):
-        dupes = {n for n in names if names.count(n) > 1}
-        if dupes:
-            msg = (
-                f"Duplicate {kind} name(s) across collected partials: "
-                f"{', '.join(sorted(dupes))}. Each artifact must appear in "
-                "exactly one partial file."
-            )
-            raise ConfigurationError(msg)
+    # Merge same-named artifacts: combine their output lists.
+    # Reject duplicate (name, arch) combinations across partials.
+    merged_rocks = _merge_artifact_outputs(all_rocks, "rock")
+    merged_charms = _merge_artifact_outputs(all_charms, "charm")
+    merged_snaps = _merge_artifact_outputs(all_snaps, "snap")
 
     # Validate that every rock referenced by a charm resource is present.
-    rocks_by_name: dict[str, GeneratedRock] = {r.name: r for r in all_rocks}
-    for charm in all_charms:
+    rocks_by_name: dict[str, GeneratedRock] = {r.name: r for r in merged_rocks}
+    for charm in merged_charms:
         for res_name, res in (charm.resources or {}).items():
             if res.rock and res.rock not in rocks_by_name:
                 msg = (
@@ -605,9 +725,9 @@ def artifacts_collect(root: Path, partial_paths: list[Path]) -> Path:
                 raise ConfigurationError(msg)
 
     generated = ArtifactsGenerated(
-        rocks=all_rocks,
-        charms=all_charms,
-        snaps=all_snaps,
+        rocks=merged_rocks,
+        charms=merged_charms,
+        snaps=merged_snaps,
     )
     dest = root / _ARTIFACTS_GENERATED_YAML
     dump_artifacts_generated(generated, dest)
@@ -635,14 +755,21 @@ def _filter_by_name[T: (RockArtifact, CharmArtifact, SnapArtifact)](
     return [item for item in items if item.name in name_set]
 
 
-def _find_local_file(root: Path, name: str, extension: str) -> str | None:
+def _find_local_file(
+    root: Path, name: str, extension: str, arch: str | None = None
+) -> str | None:
     """Find a single ``name_*.{extension}`` file under *root*.
+
+    When *arch* is given and the filename follows the expected naming
+    convention, only files whose parsed arch matches are considered.
 
     Returns the relative path (``./...``) on success, or ``None`` if no file
     is found.  Logs a warning when multiple matches exist and picks the first.
     """
     pattern = str(root / "**" / f"{name}_*.{extension}")
     matches = sorted(globmod.glob(pattern, recursive=True))
+    if arch is not None and extension == "snap":
+        matches = [m for m in matches if _parse_arch_from_snap_path(m) in (arch, None)]
     if not matches:
         return None
     if len(matches) > 1:
@@ -655,15 +782,20 @@ def _find_local_file(root: Path, name: str, extension: str) -> str | None:
     return "./" + str(Path(matches[0]).relative_to(root))
 
 
-def _find_local_charm_files(root: Path, name: str) -> list[CharmFile]:
+def _find_local_charm_files(
+    root: Path, name: str, arch: str | None = None
+) -> list[CharmFile]:
     """Find all ``name_*.charm`` files under *root* and return CharmFile list.
 
-    Returns an empty list when no files are found.  Multiple matches are
-    expected for multi-base charms — each file gets its base parsed from
-    the filename via :func:`_parse_base_from_charm_path`.
+    When *arch* is given, only files whose parsed arch matches (or whose arch
+    cannot be determined) are returned.  Returns an empty list when no files
+    are found.  Multiple matches are expected for multi-base charms — each
+    file gets its base parsed from the filename.
     """
     pattern = str(root / "**" / f"{name}_*.charm")
     matches = sorted(globmod.glob(pattern, recursive=True))
+    if arch is not None:
+        matches = [m for m in matches if _parse_arch_from_charm_path(m) in (arch, None)]
     return [
         CharmFile(
             path="./" + str(Path(m).relative_to(root)),
@@ -680,11 +812,11 @@ def artifacts_localize(root: Path) -> int:
     references.  Before running integration tests, the workflow downloads
     the artifacts to the working directory.  This command scans the project
     tree for ``.charm`` / ``.snap`` files and rewrites
-    ``artifacts-generated.yaml`` so that each artifact with only a CI
-    artifact reference gets an ``output.file(s)`` entry pointing to the
-    discovered local file.
+    ``artifacts-generated.yaml`` so that each :class:`CharmArchBuild` /
+    :class:`SnapArchBuild` with only a CI artifact reference gets a
+    ``files`` / ``file`` entry pointing to the discovered local file.
 
-    Returns the total number of artifacts that were localised.
+    Returns the total number of arch-builds that were localised.
 
     Raises:
         ConfigurationError: If ``artifacts-generated.yaml`` is not found or
@@ -701,28 +833,45 @@ def artifacts_localize(root: Path) -> int:
     missing: list[str] = []
 
     for charm in generated.charms:
-        if charm.output.files or not charm.output.artifact:
-            continue
-        charm_files = _find_local_charm_files(root, charm.name)
-        if not charm_files:
-            missing.append(charm.name)
-            logger.error("No .charm file found for charm '%s'.", charm.name)
-            continue
-        charm.output.files = charm_files
-        logger.info("Localised charm '%s' → %d file(s).", charm.name, len(charm_files))
-        updated += 1
+        for build in charm.output:
+            if build.files or not build.artifact:
+                continue
+            charm_files = _find_local_charm_files(root, charm.name, build.arch)
+            if not charm_files:
+                missing.append(f"{charm.name} ({build.arch})")
+                logger.error(
+                    "No .charm file found for charm '%s' arch '%s'.",
+                    charm.name,
+                    build.arch,
+                )
+                continue
+            build.files = charm_files
+            logger.info(
+                "Localised charm '%s' (%s) → %d file(s).",
+                charm.name,
+                build.arch,
+                len(charm_files),
+            )
+            updated += 1
 
     for snap in generated.snaps:
-        if snap.output.file or not snap.output.artifact:
-            continue
-        rel = _find_local_file(root, snap.name, "snap")
-        if rel is None:
-            missing.append(snap.name)
-            logger.error("No .snap file found for snap '%s'.", snap.name)
-            continue
-        snap.output.file = rel
-        logger.info("Localised snap '%s' → %s", snap.name, rel)
-        updated += 1
+        for snap_build in snap.output:
+            if snap_build.file or not snap_build.artifact:
+                continue
+            rel = _find_local_file(root, snap.name, "snap", snap_build.arch)
+            if rel is None:
+                missing.append(f"{snap.name} ({snap_build.arch})")
+                logger.error(
+                    "No .snap file found for snap '%s' arch '%s'.",
+                    snap.name,
+                    snap_build.arch,
+                )
+                continue
+            snap_build.file = rel
+            logger.info(
+                "Localised snap '%s' (%s) → %s", snap.name, snap_build.arch, rel
+            )
+            updated += 1
 
     if missing:
         msg = (
@@ -940,11 +1089,13 @@ def artifacts_fetch(
     # Download each charm / snap artifact archive (deduplicated)
     seen_artifacts: set[str] = set()
     for charm in generated.charms:
-        if charm.output.artifact:
-            seen_artifacts.add(charm.output.artifact)
+        for build in charm.output:
+            if build.artifact:
+                seen_artifacts.add(build.artifact)
     for snap in generated.snaps:
-        if snap.output.artifact:
-            seen_artifacts.add(snap.output.artifact)
+        for snap_build in snap.output:
+            if snap_build.artifact:
+                seen_artifacts.add(snap_build.artifact)
 
     for name in sorted(seen_artifacts):
         run_command(

--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -94,35 +94,36 @@ def provision_load(
     pushed: list[str] = []
 
     for rock in generated.rocks:
-        if not rock.output.file:
-            continue
+        for build in rock.output:
+            if not build.file:
+                continue
 
-        rock_path = Path(rock.output.file)
-        image_ref = f"{registry}/{rock.name}:latest"
+            rock_path = Path(build.file)
+            image_ref = f"{registry}/{rock.name}:{build.arch}"
 
-        if rock.output.image == image_ref:
-            logger.info("Already loaded %s, skipping", image_ref)
-            continue
+            if build.image == image_ref:
+                logger.info("Already loaded %s, skipping", image_ref)
+                continue
 
-        # Push directly from .rock archive to registry in one step — no Docker
-        # daemon needed (avoids failures in MicroK8s-only environments).
-        run_command(
-            [
-                "sudo",
-                "rockcraft.skopeo",
-                "--insecure-policy",
-                "copy",
-                "--dest-tls-verify=false",
-                f"oci-archive:{rock_path}",
-                f"docker://{image_ref}",
-            ],
-            cwd=str(root),
-        )
+            # Push directly from .rock archive to registry in one step — no Docker
+            # daemon needed (avoids failures in MicroK8s-only environments).
+            run_command(
+                [
+                    "sudo",
+                    "rockcraft.skopeo",
+                    "--insecure-policy",
+                    "copy",
+                    "--dest-tls-verify=false",
+                    f"oci-archive:{rock_path}",
+                    f"docker://{image_ref}",
+                ],
+                cwd=str(root),
+            )
 
-        rock.output.image = image_ref
+            build.image = image_ref
 
-        pushed.append(image_ref)
-        logger.info("Pushed %s", image_ref)
+            pushed.append(image_ref)
+            logger.info("Pushed %s", image_ref)
 
     if pushed:
         dump_artifacts_generated(generated, gen_path)

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -17,19 +17,83 @@ The ``KEY=VALUE`` form is required because some conftest.py files register
 ``--charm-file`` with ``nargs="+"``, which makes argparse greedy.  With the
 space-separated form, subsequent ``--charm-file`` tokens would be consumed as
 values of the first flag instead of starting a new flag.
+
+When the generated file contains multi-arch builds, flags are filtered to the
+current machine's architecture.  If no build matches the current arch, all
+available builds are used (graceful degradation for single-arch repos).
 """
 
 from __future__ import annotations
 
 import logging
+import platform
 from pathlib import Path
+from typing import overload
 
 from opcli.core.exceptions import ConfigurationError
 from opcli.core.yaml_io import load_artifacts_generated
+from opcli.models.artifacts_generated import (
+    CharmArchBuild,
+    RockArchBuild,
+    SnapArchBuild,
+)
 
 logger = logging.getLogger(__name__)
 
 _ARTIFACTS_GENERATED_YAML = "artifacts-generated.yaml"
+
+
+def _current_arch() -> str:
+    """Return the normalised architecture of the current machine."""
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        return "amd64"
+    if machine in ("aarch64", "arm64"):
+        return "arm64"
+    return machine
+
+
+@overload
+def _select_arch_builds(
+    builds: list[RockArchBuild], arch: str, artifact_name: str
+) -> list[RockArchBuild]: ...
+
+
+@overload
+def _select_arch_builds(
+    builds: list[CharmArchBuild], arch: str, artifact_name: str
+) -> list[CharmArchBuild]: ...
+
+
+@overload
+def _select_arch_builds(
+    builds: list[SnapArchBuild], arch: str, artifact_name: str
+) -> list[SnapArchBuild]: ...
+
+
+def _select_arch_builds(
+    builds: list[RockArchBuild] | list[CharmArchBuild] | list[SnapArchBuild],
+    arch: str,
+    artifact_name: str,
+) -> list[RockArchBuild] | list[CharmArchBuild] | list[SnapArchBuild]:
+    """Return the subset of *builds* matching *arch*, or all if none match.
+
+    When an exact arch match is found, only those builds are returned.
+    When no build matches the current arch (e.g. running arm64 tests against
+    an amd64-only artifact set), all builds are returned with a warning so
+    that single-arch repos continue to work.
+    """
+    matching = [b for b in builds if b.arch == arch]
+    if matching:
+        return matching  # type: ignore[return-value]
+    if builds:
+        logger.warning(
+            "No build for '%s' matches arch '%s'; using all available builds: %s",
+            artifact_name,
+            arch,
+            [b.arch for b in builds],
+        )
+    return builds
 
 
 def assemble_pytest_args(
@@ -52,6 +116,7 @@ def assemble_pytest_args(
         raise ConfigurationError(msg)
 
     generated = load_artifacts_generated(gen_path)
+    arch = _current_arch()
 
     args: list[str] = []
 
@@ -59,23 +124,29 @@ def assemble_pytest_args(
     # This runs unconditionally so no rock: annotation is needed on charm resources.
     rock_flag_names: set[str] = set()
     for rock in generated.rocks:
-        value = rock.output.image or rock.output.file
-        if value:
-            flag_name = f"{rock.name}-image"
-            rock_flag_names.add(flag_name)
-            args.append(f"--{flag_name}={value}")
+        rock_builds = _select_arch_builds(rock.output, arch, rock.name)
+        for rock_build in rock_builds:
+            value = rock_build.image or rock_build.file
+            if value:
+                flag_name = f"{rock.name}-image"
+                rock_flag_names.add(flag_name)
+                args.append(f"--{flag_name}={value}")
 
     for charm in generated.charms:
-        if charm.output.files:
-            for charm_file in charm.output.files:
-                args.append(f"--charm-file={charm_file.path}")
-        elif charm.output.artifact:
-            logger.warning(
-                "Skipping --charm-file for charm '%s': output is a CI artifact "
-                "(%s). Run 'opcli artifacts build' locally to get a local file.",
-                charm.name,
-                charm.output.artifact,
-            )
+        charm_builds = _select_arch_builds(charm.output, arch, charm.name)
+        for charm_build in charm_builds:
+            if charm_build.files:
+                for charm_file in charm_build.files:
+                    args.append(f"--charm-file={charm_file.path}")
+            elif charm_build.artifact:
+                logger.warning(
+                    "Skipping --charm-file for charm '%s' (%s): output is a CI "
+                    "artifact (%s). Run 'opcli artifacts build' locally to get "
+                    "a local file.",
+                    charm.name,
+                    charm_build.arch,
+                    charm_build.artifact,
+                )
 
         # Resources backed by a rock are already covered by the rock
         # iteration above. Resources without a rock link have no output info.

--- a/src/opcli/models/artifacts.py
+++ b/src/opcli/models/artifacts.py
@@ -10,6 +10,8 @@ Schema version: 1
 - An optional ``pack-dir`` field controls the working directory for the build
   tool (e.g. run ``rockcraft pack`` from the repo root when ``go.mod`` lives
   there but ``rockcraft.yaml`` is in a subdirectory).
+- An optional ``builds`` list declares the target architectures and GitHub
+  runner labels for each artifact.  Defaults to a single amd64 build.
 """
 
 from __future__ import annotations
@@ -28,6 +30,19 @@ class ArtifactResource(BaseModel):
     rock: str | None = None
 
 
+class BuildTarget(BaseModel):
+    """A single build target: an architecture and optional runner label(s)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    arch: str
+    runner: list[str] | None = None
+
+
+def _default_builds() -> list[BuildTarget]:
+    return [BuildTarget(arch="amd64")]
+
+
 class CharmArtifact(BaseModel):
     """A charm declared in artifacts.yaml."""
 
@@ -37,6 +52,7 @@ class CharmArtifact(BaseModel):
     charmcraft_yaml: str = Field(alias="charmcraft-yaml")
     pack_dir: str | None = Field(default=None, alias="pack-dir")
     resources: dict[str, ArtifactResource] = {}
+    builds: list[BuildTarget] = Field(default_factory=_default_builds)
 
 
 class RockArtifact(BaseModel):
@@ -47,6 +63,7 @@ class RockArtifact(BaseModel):
     name: str
     rockcraft_yaml: str = Field(alias="rockcraft-yaml")
     pack_dir: str | None = Field(default=None, alias="pack-dir")
+    builds: list[BuildTarget] = Field(default_factory=_default_builds)
 
 
 class SnapArtifact(BaseModel):
@@ -57,6 +74,7 @@ class SnapArtifact(BaseModel):
     name: str
     snapcraft_yaml: str = Field(alias="snapcraft-yaml")
     pack_dir: str | None = Field(default=None, alias="pack-dir")
+    builds: list[BuildTarget] = Field(default_factory=_default_builds)
 
 
 class ArtifactsPlan(BaseModel):

--- a/src/opcli/models/artifacts_generated.py
+++ b/src/opcli/models/artifacts_generated.py
@@ -6,11 +6,12 @@ Schema version: 1
 - Each artifact carries an explicit path to its craft YAML file
   (``rockcraft-yaml``, ``charmcraft-yaml``, ``snapcraft-yaml``).
 - Charm entries include a ``resources`` mapping with resolved output paths
-  (file or image), making ``artifacts-generated.yaml`` self-contained for
+  (image reference), making ``artifacts-generated.yaml`` self-contained for
   pytest flag assembly without needing to also read ``artifacts.yaml``.
-- Charm output uses ``files`` (a list of :class:`CharmFile` with path and
-  optional base annotation) rather than a single ``file``, because
-  ``charmcraft pack`` may produce one file per declared base.
+- ``output`` is always a **list of per-architecture builds** (:class:`RockArchBuild`,
+  :class:`CharmArchBuild`, or :class:`SnapArchBuild`), one entry per built arch.
+  Local builds produce ``file`` / ``files`` entries; CI builds produce ``image``
+  (rocks) or ``artifact`` + ``run-id`` (charms / snaps) entries.
 """
 
 from __future__ import annotations
@@ -18,27 +19,6 @@ from __future__ import annotations
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-
-
-class ArtifactOutput(BaseModel):
-    """Location of a built artifact — local file, OCI image, or GitHub artifact."""
-
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
-
-    file: str | None = None
-    image: str | None = None
-    artifact: str | None = None
-    run_id: str | None = Field(default=None, alias="run-id")
-
-    @model_validator(mode="after")
-    def _at_least_one_output(self) -> ArtifactOutput:
-        if not any([self.file, self.image, self.artifact]):
-            msg = "ArtifactOutput must specify at least one of file, image, or artifact"
-            raise ValueError(msg)
-        if self.artifact and not self.run_id:
-            msg = "run-id is required when artifact is set"
-            raise ValueError(msg)
-        return self
 
 
 class CharmFile(BaseModel):
@@ -56,23 +36,70 @@ class CharmFile(BaseModel):
     base: str | None = None
 
 
-class CharmArtifactOutput(BaseModel):
-    """Output of a charm build — local files or a CI artifact reference.
+class RockArchBuild(BaseModel):
+    """Rock output for a specific architecture.
+
+    Local builds populate ``file``; CI builds populate ``image``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    arch: str
+    file: str | None = None
+    image: str | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one_output(self) -> RockArchBuild:
+        if not self.file and not self.image:
+            msg = "RockArchBuild must specify file or image"
+            raise ValueError(msg)
+        return self
+
+
+class CharmArchBuild(BaseModel):
+    """Charm output for a specific architecture.
 
     Local builds populate ``files`` (one :class:`CharmFile` per built base).
     CI builds populate ``artifact`` and ``run-id`` instead.
+    Localised CI builds (after ``artifacts localize``) populate both.
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
+    arch: str
     files: list[CharmFile] = []
     artifact: str | None = None
     run_id: str | None = Field(default=None, alias="run-id")
 
     @model_validator(mode="after")
-    def _at_least_one_output(self) -> CharmArtifactOutput:
+    def _at_least_one_output(self) -> CharmArchBuild:
         if not self.files and not self.artifact:
-            msg = "CharmArtifactOutput must specify files or artifact"
+            msg = "CharmArchBuild must specify files or artifact"
+            raise ValueError(msg)
+        if self.artifact and not self.run_id:
+            msg = "run-id is required when artifact is set"
+            raise ValueError(msg)
+        return self
+
+
+class SnapArchBuild(BaseModel):
+    """Snap output for a specific architecture.
+
+    Local builds populate ``file``; CI builds populate ``artifact`` + ``run-id``.
+    Localised CI builds (after ``artifacts localize``) populate both.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    arch: str
+    file: str | None = None
+    artifact: str | None = None
+    run_id: str | None = Field(default=None, alias="run-id")
+
+    @model_validator(mode="after")
+    def _at_least_one_output(self) -> SnapArchBuild:
+        if not self.file and not self.artifact:
+            msg = "SnapArchBuild must specify file or artifact"
             raise ValueError(msg)
         if self.artifact and not self.run_id:
             msg = "run-id is required when artifact is set"
@@ -94,34 +121,34 @@ class GeneratedResource(BaseModel):
 
 
 class GeneratedRock(BaseModel):
-    """A rock with its build output."""
+    """A rock with its per-architecture build output."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     name: str
     rockcraft_yaml: str = Field(alias="rockcraft-yaml")
-    output: ArtifactOutput
+    output: list[RockArchBuild]
 
 
 class GeneratedCharm(BaseModel):
-    """A charm with its build output and resolved resource paths."""
+    """A charm with its per-architecture build output and resolved resource paths."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     name: str
     charmcraft_yaml: str = Field(alias="charmcraft-yaml")
-    output: CharmArtifactOutput
+    output: list[CharmArchBuild]
     resources: dict[str, GeneratedResource] | None = None
 
 
 class GeneratedSnap(BaseModel):
-    """A snap with its build output."""
+    """A snap with its per-architecture build output."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     name: str
     snapcraft_yaml: str = Field(alias="snapcraft-yaml")
-    output: ArtifactOutput
+    output: list[SnapArchBuild]
 
 
 class ArtifactsGenerated(BaseModel):

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -94,9 +94,9 @@ class TestArtifactsBuild:
         gen = load_artifacts_generated(result)
         assert len(gen.charms) == 1
         assert gen.charms[0].name == "mycharm"
-        assert len(gen.charms[0].output.files) == 1
-        assert gen.charms[0].output.files[0].path.startswith("./")
-        assert gen.charms[0].output.files[0].path.endswith(".charm")
+        assert len(gen.charms[0].output[0].files) == 1
+        assert gen.charms[0].output[0].files[0].path.startswith("./")
+        assert gen.charms[0].output[0].files[0].path.endswith(".charm")
 
     def test_build_multi_base_charm(self, tmp_path: Path) -> None:
         """Multi-base charm: all produced files appear in output.files."""
@@ -114,7 +114,7 @@ class TestArtifactsBuild:
             result = artifacts_build(tmp_path)
 
         gen = load_artifacts_generated(result)
-        files = gen.charms[0].output.files
+        files = gen.charms[0].output[0].files
         expected_count = 3
         assert len(files) == expected_count
         paths = {f.path for f in files}
@@ -147,7 +147,7 @@ class TestArtifactsBuild:
             result = artifacts_build(tmp_path)
 
         gen = load_artifacts_generated(result)
-        files = gen.charms[0].output.files
+        files = gen.charms[0].output[0].files
         expected_count = 2
         assert len(files) == expected_count
         paths = {f.path for f in files}
@@ -172,8 +172,8 @@ class TestArtifactsBuild:
         assert "rockcraft" in mock_run.call_args[0][0]
         gen = load_artifacts_generated(result)
         assert len(gen.rocks) == 1
-        assert gen.rocks[0].output.file is not None
-        assert gen.rocks[0].output.file.startswith("./")
+        assert gen.rocks[0].output[0].file is not None
+        assert gen.rocks[0].output[0].file.startswith("./")
 
     def test_build_rock_sets_experimental_extensions_env(self, tmp_path: Path) -> None:
         """rockcraft pack must always pass ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS."""
@@ -386,7 +386,7 @@ class TestArtifactsBuild:
         # Symlink must be removed after build
         assert not (tmp_path / "rockcraft.yaml").exists()
         gen = load_artifacts_generated(result)
-        assert gen.rocks[0].output.file is not None
+        assert gen.rocks[0].output[0].file is not None
 
     def test_build_rock_pack_dir_real_file_raises(self, tmp_path: Path) -> None:
         """A real rockcraft.yaml at pack-dir raises ConfigurationError."""
@@ -437,7 +437,7 @@ class TestArtifactsBuild:
         # Symlink removed after build
         assert not existing_symlink.exists()
         gen = load_artifacts_generated(result)
-        assert gen.rocks[0].output.file is not None
+        assert gen.rocks[0].output[0].file is not None
 
     def test_build_rock_nonstandard_yaml_name_creates_symlink(
         self, tmp_path: Path
@@ -476,7 +476,7 @@ class TestArtifactsBuild:
         )
         assert not (tmp_path / "rockcraft.yaml").exists(), "symlink removed after build"
         gen = load_artifacts_generated(result)
-        assert gen.rocks[0].output.file is not None
+        assert gen.rocks[0].output[0].file is not None
 
     def test_build_rock_standard_yaml_name_no_symlink(self, tmp_path: Path) -> None:
         """When yaml is already named rockcraft.yaml in pack-dir, no symlink needed."""
@@ -559,7 +559,7 @@ class TestArtifactsBuild:
             result = artifacts_build(tmp_path)
 
         gen = load_artifacts_generated(result)
-        files = gen.charms[0].output.files
+        files = gen.charms[0].output[0].files
         expected_count = 2
         assert len(files) == expected_count
         paths = {f.path for f in files}
@@ -583,9 +583,24 @@ class TestArtifactsMatrix:
 
         assert result == {
             "include": [
-                {"name": "my-rock", "type": "rock"},
-                {"name": "my-charm", "type": "charm"},
-                {"name": "my-snap", "type": "snap"},
+                {
+                    "name": "my-rock",
+                    "type": "rock",
+                    "arch": "amd64",
+                    "runner": '["ubuntu-latest"]',
+                },
+                {
+                    "name": "my-charm",
+                    "type": "charm",
+                    "arch": "amd64",
+                    "runner": '["ubuntu-latest"]',
+                },
+                {
+                    "name": "my-snap",
+                    "type": "snap",
+                    "arch": "amd64",
+                    "runner": '["ubuntu-latest"]',
+                },
             ]
         }
 
@@ -598,7 +613,16 @@ class TestArtifactsMatrix:
 
         result = artifacts_matrix(tmp_path)
 
-        assert result == {"include": [{"name": "my-charm", "type": "charm"}]}
+        assert result == {
+            "include": [
+                {
+                    "name": "my-charm",
+                    "type": "charm",
+                    "arch": "amd64",
+                    "runner": '["ubuntu-latest"]',
+                }
+            ]
+        }
 
     def test_empty_artifacts_yaml_returns_empty_include(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts.yaml", "version: 1\n")
@@ -644,14 +668,14 @@ class TestArtifactsCollect:
             "rock-job",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n    file: ./my-rock_1.0_amd64.rock\n",
+            "  output:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
         )
         charm_partial = self._partial(
             tmp_path,
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    files:\n"
+            "  output:\n  - arch: amd64\n    files:\n"
             "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
             "      base: ubuntu@24.04\n",
         )
@@ -672,14 +696,14 @@ class TestArtifactsCollect:
             "rock-job",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n    file: ./my-rock_1.0_amd64.rock\n",
+            "  output:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
         )
         charm_partial = self._partial(
             tmp_path,
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    files:\n"
+            "  output:\n  - arch: amd64\n    files:\n"
             "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
             "      base: ubuntu@24.04\n"
             "  resources:\n"
@@ -692,7 +716,7 @@ class TestArtifactsCollect:
 
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
         # Image lives on the rock, not on the resource
-        assert gen.rocks[0].output.file == "./my-rock_1.0_amd64.rock"
+        assert gen.rocks[0].output[0].file == "./my-rock_1.0_amd64.rock"
         resource = gen.charms[0].resources["my-rock-image"]  # type: ignore[index]
         assert resource.rock == "my-rock"
 
@@ -702,14 +726,14 @@ class TestArtifactsCollect:
             "rock1-job",
             "version: 1\n"
             "rocks:\n- name: rock-a\n  rockcraft-yaml: rock-a/rockcraft.yaml\n"
-            "  output:\n    file: ./rock-a_1.0_amd64.rock\n",
+            "  output:\n  - arch: amd64\n    file: ./rock-a_1.0_amd64.rock\n",
         )
         rock2 = self._partial(
             tmp_path,
             "rock2-job",
             "version: 1\n"
             "rocks:\n- name: rock-b\n  rockcraft-yaml: rock-b/rockcraft.yaml\n"
-            "  output:\n    file: ./rock-b_1.0_amd64.rock\n",
+            "  output:\n  - arch: amd64\n    file: ./rock-b_1.0_amd64.rock\n",
         )
 
         artifacts_collect(tmp_path, [rock1, rock2])
@@ -735,7 +759,7 @@ class TestArtifactsCollect:
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    files:\n"
+            "  output:\n  - arch: amd64\n    files:\n"
             "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
             "      base: ubuntu@24.04\n"
             "  resources:\n"
@@ -754,18 +778,103 @@ class TestArtifactsCollect:
             "rock-job-1",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n    file: ./my-rock_1.0_amd64.rock\n",
+            "  output:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
         )
         rock2 = self._partial(
             tmp_path,
             "rock-job-2",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n    file: ./my-rock_2.0_amd64.rock\n",
+            "  output:\n  - arch: amd64\n    file: ./my-rock_2.0_amd64.rock\n",
         )
 
         with pytest.raises(ConfigurationError, match="my-rock"):
             artifacts_collect(tmp_path, [rock1, rock2])
+
+    def test_merges_same_rock_different_arches(self, tmp_path: Path) -> None:
+        """Same rock name, different arches → output lists are merged."""
+        rock_amd64 = self._partial(
+            tmp_path,
+            "rock-amd64-job",
+            "version: 1\n"
+            "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
+            "  output:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
+        )
+        rock_arm64 = self._partial(
+            tmp_path,
+            "rock-arm64-job",
+            "version: 1\n"
+            "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
+            "  output:\n  - arch: arm64\n    file: ./my-rock_1.0_arm64.rock\n",
+        )
+
+        artifacts_collect(tmp_path, [rock_amd64, rock_arm64])
+
+        gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        assert len(gen.rocks) == 1
+        assert gen.rocks[0].name == "my-rock"
+        expected_arch_count = 2
+        assert len(gen.rocks[0].output) == expected_arch_count
+        arches = {b.arch for b in gen.rocks[0].output}
+        assert arches == {"amd64", "arm64"}
+
+    def test_merges_same_charm_different_arches(self, tmp_path: Path) -> None:
+        """Same charm name, different arches → output lists are merged."""
+        charm_amd64 = self._partial(
+            tmp_path,
+            "charm-amd64-job",
+            "version: 1\n"
+            "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
+            "  output:\n  - arch: amd64\n    files:\n"
+            "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
+            "      base: ubuntu@24.04\n",
+        )
+        charm_arm64 = self._partial(
+            tmp_path,
+            "charm-arm64-job",
+            "version: 1\n"
+            "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
+            "  output:\n  - arch: arm64\n    files:\n"
+            "    - path: ./my-charm_ubuntu-24.04-arm64.charm\n"
+            "      base: ubuntu@24.04\n",
+        )
+
+        artifacts_collect(tmp_path, [charm_amd64, charm_arm64])
+
+        gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        assert len(gen.charms) == 1
+        assert gen.charms[0].name == "my-charm"
+        expected_arch_count = 2
+        assert len(gen.charms[0].output) == expected_arch_count
+        arches = {b.arch for b in gen.charms[0].output}
+        assert arches == {"amd64", "arm64"}
+
+    def test_merges_same_snap_different_arches(self, tmp_path: Path) -> None:
+        """Same snap name, different arches → output lists are merged."""
+        snap_amd64 = self._partial(
+            tmp_path,
+            "snap-amd64-job",
+            "version: 1\n"
+            "snaps:\n- name: my-snap\n  snapcraft-yaml: snap/snapcraft.yaml\n"
+            "  output:\n  - arch: amd64\n    file: ./my-snap_1.0_amd64.snap\n",
+        )
+        snap_arm64 = self._partial(
+            tmp_path,
+            "snap-arm64-job",
+            "version: 1\n"
+            "snaps:\n- name: my-snap\n  snapcraft-yaml: snap/snapcraft.yaml\n"
+            "  output:\n  - arch: arm64\n    file: ./my-snap_1.0_arm64.snap\n",
+        )
+
+        artifacts_collect(tmp_path, [snap_amd64, snap_arm64])
+
+        gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
+        assert len(gen.snaps) == 1
+        assert gen.snaps[0].name == "my-snap"
+        expected_arch_count = 2
+        assert len(gen.snaps[0].output) == expected_arch_count
+        arches = {b.arch for b in gen.snaps[0].output}
+        assert arches == {"amd64", "arm64"}
 
 
 class TestArtifactsBuildCIMode:
@@ -801,15 +910,16 @@ class TestArtifactsBuildCIMode:
         gen = load_artifacts_generated(result)
         assert len(gen.rocks) == 1
         rock_out = gen.rocks[0].output
-        assert rock_out.file is None
-        assert rock_out.image == "ghcr.io/myorg/my-repo/my-rock:abc1234"
+        assert rock_out[0].file is None
+        assert rock_out[0].image == "ghcr.io/myorg/my-repo/my-rock:abc1234-amd64"
 
         # Verify skopeo was called to push to GHCR
         skopeo_calls = [c for c in mock_run.call_args_list if "skopeo" in str(c)]
         assert len(skopeo_calls) == 1
         skopeo_args = skopeo_calls[0][0][0]
         assert "skopeo" in skopeo_args
-        assert any("ghcr.io/myorg/my-repo/my-rock:abc1234" in a for a in skopeo_args)
+        image_ref = "ghcr.io/myorg/my-repo/my-rock:abc1234-amd64"
+        assert any(image_ref in a for a in skopeo_args)
 
     def test_charm_build_writes_artifact_ref(self, tmp_path: Path) -> None:
         """In CI, charm output should be a GitHub artifact reference."""
@@ -833,9 +943,9 @@ class TestArtifactsBuildCIMode:
         gen = load_artifacts_generated(result)
         assert len(gen.charms) == 1
         charm_out = gen.charms[0].output
-        assert charm_out.files == []
-        assert charm_out.artifact == "built-charm-my-charm"
-        assert charm_out.run_id == "9876543210"
+        assert charm_out[0].files == []
+        assert charm_out[0].artifact == "built-charm-my-charm-amd64"
+        assert charm_out[0].run_id == "9876543210"
 
     def test_snap_build_writes_artifact_ref(self, tmp_path: Path) -> None:
         """In CI, snap output should be a GitHub artifact reference."""
@@ -857,9 +967,9 @@ class TestArtifactsBuildCIMode:
         gen = load_artifacts_generated(result)
         assert len(gen.snaps) == 1
         snap_out = gen.snaps[0].output
-        assert snap_out.file is None
-        assert snap_out.artifact == "built-snap-my-snap"
-        assert snap_out.run_id == "9876543210"
+        assert snap_out[0].file is None
+        assert snap_out[0].artifact == "built-snap-my-snap-amd64"
+        assert snap_out[0].run_id == "9876543210"
 
     def test_local_build_unchanged_when_no_github_actions(self, tmp_path: Path) -> None:
         """Without GITHUB_ACTIONS=true, build produces local file refs."""
@@ -882,9 +992,9 @@ class TestArtifactsBuildCIMode:
 
         gen = load_artifacts_generated(result)
         charm_out = gen.charms[0].output
-        assert charm_out.artifact is None
-        assert len(charm_out.files) == 1
-        assert "my-charm_ubuntu-24.04-amd64.charm" in charm_out.files[0].path
+        assert charm_out[0].artifact is None
+        assert len(charm_out[0].files) == 1
+        assert "my-charm_ubuntu-24.04-amd64.charm" in charm_out[0].files[0].path
 
     def test_ci_missing_env_vars_raises(self, tmp_path: Path) -> None:
         """GITHUB_ACTIONS=true with missing env vars raises ConfigurationError."""
@@ -934,9 +1044,9 @@ class TestArtifactsBuildCIMode:
             result = artifacts_build(tmp_path, rock_names=["my-rock"])
 
         gen = load_artifacts_generated(result)
-        assert gen.rocks[0].output.image is not None
-        assert "MyOrg" not in gen.rocks[0].output.image
-        assert "myorg" in gen.rocks[0].output.image
+        assert gen.rocks[0].output[0].image is not None
+        assert "MyOrg" not in gen.rocks[0].output[0].image
+        assert "myorg" in gen.rocks[0].output[0].image
 
 
 class TestArtifactsCollectCIMode:
@@ -957,14 +1067,16 @@ class TestArtifactsCollectCIMode:
             "rock-job",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n    image: ghcr.io/myorg/my-repo/my-rock:abc1234\n",
+            "  output:\n  - arch: amd64\n"
+            "    image: ghcr.io/myorg/my-repo/my-rock:abc1234\n",
         )
         charm_partial = self._partial(
             tmp_path,
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    artifact: built-charm-my-charm\n    run-id: '9876543210'\n"
+            "  output:\n  - arch: amd64\n    artifact: built-charm-my-charm\n"
+            "    run-id: '9876543210'\n"
             "  resources:\n"
             "    my-rock-image:\n"
             "      type: oci-image\n"
@@ -974,13 +1086,13 @@ class TestArtifactsCollectCIMode:
         artifacts_collect(tmp_path, [rock_partial, charm_partial])
 
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
-        assert gen.rocks[0].output.image == "ghcr.io/myorg/my-repo/my-rock:abc1234"
+        assert gen.rocks[0].output[0].image == "ghcr.io/myorg/my-repo/my-rock:abc1234"
         resource = gen.charms[0].resources["my-rock-image"]  # type: ignore[index]
         # Resource carries the rock reference; image resolved from rock.output.image
         assert resource.rock == "my-rock"
         # Charm itself still has artifact ref
-        assert gen.charms[0].output.artifact == "built-charm-my-charm"
-        assert gen.charms[0].output.run_id == "9876543210"
+        assert gen.charms[0].output[0].artifact == "built-charm-my-charm"
+        assert gen.charms[0].output[0].run_id == "9876543210"
 
 
 class TestArtifactsLocalize:
@@ -992,6 +1104,7 @@ class TestArtifactsLocalize:
         "- name: my-charm\n"
         "  charmcraft-yaml: charmcraft.yaml\n"
         "  output:\n"
+        "  - arch: amd64\n"
         "    artifact: built-charm-my-charm\n"
         "    run-id: '9876543210'\n"
     )
@@ -1007,9 +1120,9 @@ class TestArtifactsLocalize:
 
         assert count == 1
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
-        assert gen.charms[0].output.files is not None
-        assert len(gen.charms[0].output.files) == 1
-        path = gen.charms[0].output.files[0].path
+        assert gen.charms[0].output[0].files is not None
+        assert len(gen.charms[0].output[0].files) == 1
+        path = gen.charms[0].output[0].files[0].path
         assert path.endswith(".charm")
         assert path.startswith("./"), f"Expected relative path, got: {path}"
         assert "/home/" not in path, f"Expected no absolute home path, got: {path}"
@@ -1023,6 +1136,7 @@ class TestArtifactsLocalize:
             "- name: my-charm\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
             "  output:\n"
+            "  - arch: amd64\n"
             "    files:\n"
             "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
         )
@@ -1057,6 +1171,7 @@ class TestArtifactsLocalize:
             "- name: my-charm\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
             "  output:\n"
+            "  - arch: amd64\n"
             "    files:\n"
             "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
         )
@@ -1089,11 +1204,11 @@ class TestArtifactsLocalize:
 
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
         charm = gen.charms[0]
-        assert len(charm.output.files) == 2  # noqa: PLR2004
-        paths = {f.path for f in charm.output.files}
+        assert len(charm.output[0].files) == 2  # noqa: PLR2004
+        paths = {f.path for f in charm.output[0].files}
         assert any("22.04" in p for p in paths)
         assert any("24.04" in p for p in paths)
-        bases = {f.base for f in charm.output.files}
+        bases = {f.base for f in charm.output[0].files}
         assert "ubuntu@22.04" in bases
         assert "ubuntu@24.04" in bases
 
@@ -1107,23 +1222,27 @@ class TestArtifactsFetch:
         "- name: my-rock\n"
         "  rockcraft-yaml: rock/rockcraft.yaml\n"
         "  output:\n"
-        "    image: ghcr.io/owner/repo/my-rock:abc1234\n"
+        "  - arch: amd64\n"
+        "    image: ghcr.io/owner/repo/my-rock:abc1234-amd64\n"
         "charms:\n"
         "- name: my-charm\n"
         "  charmcraft-yaml: charmcraft.yaml\n"
         "  output:\n"
-        "    artifact: built-charm-my-charm\n"
+        "  - arch: amd64\n"
+        "    artifact: built-charm-my-charm-amd64\n"
         "    run-id: '99887766'\n"
         "- name: other-charm\n"
         "  charmcraft-yaml: other/charmcraft.yaml\n"
         "  output:\n"
-        "    artifact: built-charm-other-charm\n"
+        "  - arch: amd64\n"
+        "    artifact: built-charm-other-charm-amd64\n"
         "    run-id: '99887766'\n"
         "snaps:\n"
         "- name: my-snap\n"
         "  snapcraft-yaml: snap/snapcraft.yaml\n"
         "  output:\n"
-        "    artifact: built-snap-my-snap\n"
+        "  - arch: amd64\n"
+        "    artifact: built-snap-my-snap-amd64\n"
         "    run-id: '99887766'\n"
     )
 
@@ -1136,16 +1255,16 @@ class TestArtifactsFetch:
 
     def _make_charm_files(self, tmp_path: Path) -> None:
         """Create dummy .charm files so localize succeeds."""
-        d1 = tmp_path / "built-charm-my-charm"
+        d1 = tmp_path / "built-charm-my-charm-amd64"
         d1.mkdir()
         (d1 / "my-charm_ubuntu-24.04-amd64.charm").write_bytes(b"")
-        d2 = tmp_path / "built-charm-other-charm"
+        d2 = tmp_path / "built-charm-other-charm-amd64"
         d2.mkdir()
         (d2 / "other-charm_ubuntu-24.04-amd64.charm").write_bytes(b"")
 
     def _make_snap_files(self, tmp_path: Path) -> None:
         """Create dummy .snap file so localize succeeds for snaps."""
-        d = tmp_path / "built-snap-my-snap"
+        d = tmp_path / "built-snap-my-snap-amd64"
         d.mkdir(exist_ok=True)
         (d / "my-snap_amd64.snap").write_bytes(b"")
 
@@ -1180,9 +1299,9 @@ class TestArtifactsFetch:
         # Subsequent calls: one per charm/snap artifact (rocks are skipped)
         artifact_names = {c.args[0][7] for c in calls[1:]}
         assert artifact_names == {
-            "built-charm-my-charm",
-            "built-charm-other-charm",
-            "built-snap-my-snap",
+            "built-charm-my-charm-amd64",
+            "built-charm-other-charm-amd64",
+            "built-snap-my-snap-amd64",
         }
 
     def test_skips_rocks_no_download(self, tmp_path: Path) -> None:
@@ -1275,11 +1394,11 @@ class TestArtifactsFetch:
 
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
         for charm in gen.charms:
-            assert charm.output.files, f"Charm '{charm.name}' was not localised"
-            assert charm.output.files[0].path.endswith(".charm")
+            assert charm.output[0].files, f"Charm '{charm.name}' was not localised"
+            assert charm.output[0].files[0].path.endswith(".charm")
         for snap in gen.snaps:
-            assert snap.output.file, f"Snap '{snap.name}' was not localised"
-            assert snap.output.file.endswith(".snap")
+            assert snap.output[0].file, f"Snap '{snap.name}' was not localised"
+            assert snap.output[0].file.endswith(".snap")
 
     def test_wait_retries_until_artifact_appears(self, tmp_path: Path) -> None:
         """With wait=True, retries the initial download and succeeds on 2nd attempt."""
@@ -1336,6 +1455,7 @@ class TestArtifactsFetch:
             "- name: my-rock\n"
             "  rockcraft-yaml: rock/rockcraft.yaml\n"
             "  output:\n"
+            "  - arch: amd64\n"
             "    image: ghcr.io/owner/repo/my-rock:abc1234\n"
         )
         _write(tmp_path / "artifacts-generated.yaml", rocks_only)
@@ -1370,6 +1490,7 @@ class TestArtifactsFetch:
             "- name: my-rock\n"
             "  rockcraft-yaml: rock/rockcraft.yaml\n"
             "  output:\n"
+            "  - arch: amd64\n"
             "    image: ghcr.io/owner/repo/my-rock:abc1234\n"
         )
         _write(tmp_path / "artifacts-generated.yaml", rocks_only)

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -16,9 +16,11 @@ from opcli.core.yaml_io import (
 )
 from opcli.models.artifacts import ArtifactsPlan
 from opcli.models.artifacts_generated import (
-    ArtifactOutput,
     ArtifactsGenerated,
+    CharmArchBuild,
+    GeneratedCharm,
     GeneratedRock,
+    RockArchBuild,
 )
 
 
@@ -211,7 +213,7 @@ class TestYamlIO:
                 GeneratedRock(
                     name="r1",
                     rockcraft_yaml="rd/rockcraft.yaml",
-                    output=ArtifactOutput(file="./r1.rock"),
+                    output=[RockArchBuild(arch="amd64", file="./r1.rock")],
                 )
             ],
         )
@@ -222,11 +224,11 @@ class TestYamlIO:
 
     def test_run_id_alias_survives_round_trip(self, tmp_path: Path) -> None:
         gen = ArtifactsGenerated(
-            rocks=[
-                GeneratedRock(
-                    name="r1",
-                    rockcraft_yaml="rd/rockcraft.yaml",
-                    output=ArtifactOutput(artifact="a1", run_id="42"),
+            charms=[
+                GeneratedCharm(
+                    name="c1",
+                    charmcraft_yaml="charmcraft.yaml",
+                    output=[CharmArchBuild(arch="amd64", artifact="a1", run_id="42")],
                 )
             ],
         )
@@ -235,7 +237,7 @@ class TestYamlIO:
         raw = path.read_text()
         assert "run-id" in raw
         loaded = load_artifacts_generated(path)
-        assert loaded.rocks[0].output.run_id == "42"
+        assert loaded.charms[0].output[0].run_id == "42"
 
     def test_load_invalid_yaml_raises(self, tmp_path: Path) -> None:
         path = tmp_path / "bad.yaml"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -8,17 +8,19 @@ from pydantic import ValidationError
 from opcli.models.artifacts import (
     ArtifactResource,
     ArtifactsPlan,
+    BuildTarget,
     CharmArtifact,
     RockArtifact,
 )
 from opcli.models.artifacts_generated import (
-    ArtifactOutput,
     ArtifactsGenerated,
-    CharmArtifactOutput,
+    CharmArchBuild,
     CharmFile,
     GeneratedCharm,
     GeneratedRock,
     GeneratedSnap,
+    RockArchBuild,
+    SnapArchBuild,
 )
 
 
@@ -145,35 +147,35 @@ class TestArtifactsGenerated:
     """Validation tests for artifacts-generated.yaml models."""
 
     def test_local_output(self) -> None:
-        out = ArtifactOutput(file="./myrock.rock")
+        out = RockArchBuild(arch="amd64", file="./myrock.rock")
         assert out.file == "./myrock.rock"
         assert out.image is None
 
     def test_ci_output_with_image(self) -> None:
-        out = ArtifactOutput(image="ghcr.io/canonical/indico:abc1234")
+        out = RockArchBuild(arch="amd64", image="ghcr.io/canonical/indico:abc1234")
         assert out.image is not None
 
     def test_ci_output_artifact_requires_run_id(self) -> None:
         with pytest.raises(ValidationError, match="run-id is required"):
-            ArtifactOutput(artifact="charm-indico")
+            CharmArchBuild(arch="amd64", artifact="charm-indico")
 
     def test_ci_output_artifact_with_run_id(self) -> None:
-        out = ArtifactOutput(artifact="charm-indico", run_id="123456")
+        out = CharmArchBuild(arch="amd64", artifact="charm-indico", run_id="123456")
         assert out.artifact == "charm-indico"
         assert out.run_id == "123456"
 
     def test_empty_output_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="at least one"):
-            ArtifactOutput()
+        with pytest.raises(ValidationError, match="must specify file or image"):
+            RockArchBuild(arch="amd64")
 
     def test_run_id_alias_from_yaml(self) -> None:
         """YAML uses ``run-id`` (hyphen), Python uses ``run_id``."""
-        data = {"artifact": "charm-x", "run-id": "999"}
-        out = ArtifactOutput.model_validate(data)
+        data = {"arch": "amd64", "artifact": "charm-x", "run-id": "999"}
+        out = CharmArchBuild.model_validate(data)
         assert out.run_id == "999"
 
     def test_run_id_serialized_with_hyphen(self) -> None:
-        out = ArtifactOutput(artifact="charm-x", run_id="999")
+        out = CharmArchBuild(arch="amd64", artifact="charm-x", run_id="999")
         dumped = out.model_dump(by_alias=True, exclude_none=True)
         assert "run-id" in dumped
         assert "run_id" not in dumped
@@ -184,21 +186,26 @@ class TestArtifactsGenerated:
                 GeneratedRock(
                     name="indico",
                     rockcraft_yaml="indico_rock/rockcraft.yaml",
-                    output=ArtifactOutput(file="./indico.rock"),
+                    output=[RockArchBuild(arch="amd64", file="./indico.rock")],
                 )
             ],
             charms=[
                 GeneratedCharm(
                     name="indico",
                     charmcraft_yaml="charmcraft.yaml",
-                    output=CharmArtifactOutput(
-                        files=[CharmFile(path="./indico.charm", base="ubuntu@22.04")]
-                    ),
+                    output=[
+                        CharmArchBuild(
+                            arch="amd64",
+                            files=[
+                                CharmFile(path="./indico.charm", base="ubuntu@22.04")
+                            ],
+                        )
+                    ],
                 )
             ],
         )
-        assert gen.rocks[0].output.file == "./indico.rock"
-        assert gen.charms[0].output.files[0].path == "./indico.charm"
+        assert gen.rocks[0].output[0].file == "./indico.rock"
+        assert gen.charms[0].output[0].files[0].path == "./indico.charm"
 
     def test_generated_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError, match="Extra inputs"):
@@ -210,54 +217,120 @@ class TestArtifactsGenerated:
                 GeneratedSnap(
                     name="mysnap",
                     snapcraft_yaml="snap/snapcraft.yaml",
-                    output=ArtifactOutput(file="./mysnap.snap"),
+                    output=[SnapArchBuild(arch="amd64", file="./mysnap.snap")],
                 )
             ],
         )
         assert gen.snaps[0].name == "mysnap"
 
 
-class TestCharmArtifactOutput:
-    """Validation tests for CharmArtifactOutput and CharmFile models."""
+class TestCharmArchBuild:
+    """Validation tests for CharmArchBuild and CharmFile models."""
 
     def test_local_single_base(self) -> None:
-        out = CharmArtifactOutput(
+        out = CharmArchBuild(
+            arch="amd64",
             files=[
                 CharmFile(path="./aproxy_ubuntu-22.04-amd64.charm", base="ubuntu@22.04")
-            ]
+            ],
         )
         assert len(out.files) == 1
         assert out.files[0].base == "ubuntu@22.04"
 
     def test_local_multi_base(self) -> None:
-        out = CharmArtifactOutput(
+        out = CharmArchBuild(
+            arch="amd64",
             files=[
                 CharmFile(path="./a_ubuntu-20.04-amd64.charm", base="ubuntu@20.04"),
                 CharmFile(path="./a_ubuntu-22.04-amd64.charm", base="ubuntu@22.04"),
-            ]
+            ],
         )
         expected_count = 2
         assert len(out.files) == expected_count
 
     def test_ci_artifact_output(self) -> None:
-        out = CharmArtifactOutput(artifact="charm-aproxy", run_id="999")
+        out = CharmArchBuild(arch="amd64", artifact="charm-aproxy", run_id="999")
         assert out.artifact == "charm-aproxy"
         assert out.run_id == "999"
         assert out.files == []
 
     def test_ci_artifact_yaml_alias(self) -> None:
-        out = CharmArtifactOutput.model_validate({"artifact": "charm-x", "run-id": "1"})
+        out = CharmArchBuild.model_validate(
+            {"arch": "amd64", "artifact": "charm-x", "run-id": "1"}
+        )
         assert out.run_id == "1"
 
     def test_empty_output_rejected(self) -> None:
         with pytest.raises(ValidationError, match="files or artifact"):
-            CharmArtifactOutput()
+            CharmArchBuild(arch="amd64")
 
     def test_artifact_without_run_id_rejected(self) -> None:
         with pytest.raises(ValidationError, match="run-id"):
-            CharmArtifactOutput(artifact="charm-x")
+            CharmArchBuild(arch="amd64", artifact="charm-x")
 
     def test_base_none_allowed(self) -> None:
         """Base can be None when filename does not follow convention."""
-        out = CharmArtifactOutput(files=[CharmFile(path="./mycharm.charm")])
+        out = CharmArchBuild(arch="amd64", files=[CharmFile(path="./mycharm.charm")])
         assert out.files[0].base is None
+
+
+class TestBuildTarget:
+    """Validation tests for BuildTarget model."""
+
+    def test_build_target_defaults_no_runner(self) -> None:
+        bt = BuildTarget(arch="amd64")
+        assert bt.runner is None
+
+    def test_build_target_with_runner(self) -> None:
+        bt = BuildTarget(arch="amd64", runner=["ubuntu-latest"])
+        assert bt.runner == ["ubuntu-latest"]
+
+
+class TestRockArchBuild:
+    """Validation tests for RockArchBuild model."""
+
+    def test_rock_local_build(self) -> None:
+        build = RockArchBuild(arch="amd64", file="./my.rock")
+        assert build.arch == "amd64"
+        assert build.file == "./my.rock"
+        assert build.image is None
+
+    def test_rock_ci_build(self) -> None:
+        build = RockArchBuild(arch="amd64", image="ghcr.io/canonical/my-rock:abc123")
+        assert build.image == "ghcr.io/canonical/my-rock:abc123"
+        assert build.file is None
+
+    def test_rock_empty_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            RockArchBuild(arch="amd64")
+
+    def test_rock_extra_fields_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="Extra inputs"):
+            RockArchBuild.model_validate(
+                {"arch": "amd64", "file": "./my.rock", "unknown": "x"}
+            )
+
+
+class TestSnapArchBuild:
+    """Validation tests for SnapArchBuild model."""
+
+    def test_snap_local_build(self) -> None:
+        build = SnapArchBuild(arch="amd64", file="./my.snap")
+        assert build.arch == "amd64"
+        assert build.file == "./my.snap"
+        assert build.artifact is None
+
+    def test_snap_ci_build(self) -> None:
+        build = SnapArchBuild(
+            arch="amd64", artifact="built-snap-my-snap-amd64", run_id="123"
+        )
+        assert build.artifact == "built-snap-my-snap-amd64"
+        assert build.run_id == "123"
+
+    def test_snap_empty_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SnapArchBuild(arch="amd64")
+
+    def test_snap_artifact_without_run_id_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="run-id"):
+            SnapArchBuild(arch="amd64", artifact="built-snap-my-snap")

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -24,15 +24,18 @@ rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
   output:
+  - arch: amd64
     file: ./rock_dir/myrock.rock
 - name: otherrock
   rockcraft-yaml: other/rockcraft.yaml
   output:
+  - arch: amd64
     image: ghcr.io/canonical/otherrock:abc
 charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
   output:
+  - arch: amd64
     files:
     - path: ./mycharm_ubuntu-22.04-amd64.charm
       base: ubuntu@22.04
@@ -44,15 +47,18 @@ rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
   output:
+  - arch: amd64
     file: ./rock_dir/myrock.rock
 - name: otherrock
   rockcraft-yaml: other_dir/rockcraft.yaml
   output:
+  - arch: amd64
     image: ghcr.io/canonical/otherrock:abc
 charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
   output:
+  - arch: amd64
     files:
     - path: ./mycharm_ubuntu-22.04-amd64.charm
       base: ubuntu@22.04
@@ -131,7 +137,7 @@ class TestProvisionLoad:
             tmp_path / "artifacts-generated.yaml",
             "version: 1\n"
             "rocks:\n- name: r1\n  rockcraft-yaml: rd/rockcraft.yaml\n"
-            "  output:\n    image: ghcr.io/r1:v1\n",
+            "  output:\n  - arch: amd64\n    image: ghcr.io/r1:v1\n",
         )
 
         with patch("opcli.core.provision.run_command") as mock_run:
@@ -173,8 +179,8 @@ class TestProvisionLoad:
 
         updated = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
         myrock = next(r for r in updated.rocks if r.name == "myrock")
-        assert myrock.output.image == "localhost:32000/myrock:latest"
-        assert myrock.output.file == "./rock_dir/myrock.rock"
+        assert myrock.output[0].image == "localhost:32000/myrock:amd64"
+        assert myrock.output[0].file == "./rock_dir/myrock.rock"
 
     def test_updates_charm_resources_for_pushed_rock(self, tmp_path: Path) -> None:
         """provision_load pushes rocks; charm resources reference via rock: field."""
@@ -189,7 +195,7 @@ class TestProvisionLoad:
         updated = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
         # Rock output.image is updated after push
         myrock = next(r for r in updated.rocks if r.name == "myrock")
-        assert myrock.output.image == "localhost:32000/myrock:latest"
+        assert myrock.output[0].image == "localhost:32000/myrock:amd64"
         # Charm resources still only carry the rock reference, not a duplicated image
         charm = updated.charms[0]
         assert charm.resources is not None
@@ -202,8 +208,8 @@ class TestProvisionLoad:
             tmp_path / "artifacts-generated.yaml",
             "version: 1\n"
             "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
-            "  output:\n    file: ./rock_dir/myrock.rock\n"
-            "    image: localhost:32000/myrock:latest\n",
+            "  output:\n  - arch: amd64\n    file: ./rock_dir/myrock.rock\n"
+            "    image: localhost:32000/myrock:amd64\n",
         )
 
         with patch("opcli.core.provision.run_command") as mock_run:

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -28,11 +28,13 @@ rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
   output:
+  - arch: amd64
     file: ./rock_dir/myrock.rock
 charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
   output:
+  - arch: amd64
     files:
     - path: ./mycharm_ubuntu-22.04-amd64.charm
       base: ubuntu@22.04
@@ -48,11 +50,13 @@ rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
   output:
+  - arch: amd64
     image: ghcr.io/canonical/myrock:abc123
 charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
   output:
+  - arch: amd64
     artifact: charm-mycharm
     run-id: "999"
   resources:
@@ -67,6 +71,7 @@ charms:
 - name: simple
   charmcraft-yaml: charmcraft.yaml
   output:
+  - arch: amd64
     files:
     - path: ./simple_ubuntu-22.04-amd64.charm
       base: ubuntu@22.04
@@ -84,7 +89,8 @@ class TestAssemblePytestArgs:
         _write(
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: c\n  source: .\n"
-            "  output:\n    files:\n    - path: ./c.charm\n      base: ubuntu@22.04\n",
+            "  output:\n  - arch: amd64\n    files:\n"
+            "    - path: ./c.charm\n      base: ubuntu@22.04\n",
         )
         with pytest.raises(Exception, match=_V1_ERROR_MATCH):
             assemble_pytest_args(tmp_path)
@@ -138,7 +144,7 @@ class TestAssemblePytestArgs:
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: aproxy\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    files:\n"
+            "  output:\n  - arch: amd64\n    files:\n"
             "    - path: ./aproxy_ubuntu-20.04-amd64.charm\n      base: ubuntu@20.04\n"
             "    - path: ./aproxy_ubuntu-22.04-amd64.charm\n      base: ubuntu@22.04\n"
             "    - path: ./aproxy_ubuntu-24.04-amd64.charm\n      base: ubuntu@24.04\n",
@@ -162,7 +168,8 @@ class TestAssemblePytestArgs:
         _write(
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    files:\n    - path: ./c_ubuntu-22.04-amd64.charm\n"
+            "  output:\n  - arch: amd64\n    files:\n"
+            "    - path: ./c_ubuntu-22.04-amd64.charm\n"
             "      base: ubuntu@22.04\n"
             "  resources:\n    img:\n      type: oci-image\n      rock: myrock\n",
         )
@@ -178,10 +185,11 @@ class TestAssemblePytestArgs:
             tmp_path / "artifacts-generated.yaml",
             "version: 1\n"
             "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
-            "  output:\n    file: ./rock_dir/myrock.rock\n"
+            "  output:\n  - arch: amd64\n    file: ./rock_dir/myrock.rock\n"
             "    image: localhost:32000/myrock:latest\n"
             "charms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    files:\n    - path: ./c_ubuntu-22.04-amd64.charm\n"
+            "  output:\n  - arch: amd64\n    files:\n"
+            "    - path: ./c_ubuntu-22.04-amd64.charm\n"
             "      base: ubuntu@22.04\n"
             "  resources:\n    myrock-image:\n      type: oci-image\n"
             "      rock: myrock\n",
@@ -203,10 +211,10 @@ class TestAssemblePytestArgs:
             tmp_path / "artifacts-generated.yaml",
             "version: 1\n"
             "rocks:\n- name: expressjs-app\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n    file: ./expressjs-app_1.0_amd64.rock\n"
+            "  output:\n  - arch: amd64\n    file: ./expressjs-app_1.0_amd64.rock\n"
             "charms:\n- name: expressjs-k8s\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    files:\n"
+            "  output:\n  - arch: amd64\n    files:\n"
             "    - path: ./expressjs-k8s_ubuntu-22.04-amd64.charm\n"
             "      base: ubuntu@22.04\n"
             "  resources:\n    app-image:\n      type: oci-image\n"
@@ -229,11 +237,11 @@ class TestAssemblePytestArgs:
             "version: 1\n"
             "rocks:\n"
             "- name: expressjs-app\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n    file: ./expressjs-app_1.0_amd64.rock\n"
+            "  output:\n  - arch: amd64\n    file: ./expressjs-app_1.0_amd64.rock\n"
             "- name: fastapi-app\n  rockcraft-yaml: fastapi/rockcraft.yaml\n"
-            "  output:\n    file: ./fastapi-app_1.0_amd64.rock\n"
+            "  output:\n  - arch: amd64\n    file: ./fastapi-app_1.0_amd64.rock\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    files:\n"
+            "  output:\n  - arch: amd64\n    files:\n"
             "    - path: ./my-charm_ubuntu-22.04-amd64.charm\n"
             "      base: ubuntu@22.04\n",
         )
@@ -249,7 +257,7 @@ class TestAssemblePytestArgs:
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: mycharm\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n    files:\n"
+            "  output:\n  - arch: amd64\n    files:\n"
             "    - path: ./mycharm_ubuntu-22.04-amd64.charm\n"
             "      base: ubuntu@22.04\n"
             "  resources:\n    standalone-image:\n      type: oci-image\n",


### PR DESCRIPTION
## Summary

Implements multi-arch support for all artifact types as discussed in issue #100.

### Changes

**Models:**
- Added `BuildTarget(arch, runner)` to `artifacts.yaml` — `builds:` list defaults to `[{arch: amd64}]` on all artifact types
- Replaced flat `output:` object with `output: list[ArchBuild]` in `artifacts-generated.yaml`; each entry carries `arch` plus type-specific fields (`RockArchBuild`, `CharmArchBuild`, `SnapArchBuild`)
- Charms keep the per-base `files` list inside each `CharmArchBuild`

**Core logic:**
- `artifacts_matrix` now emits `arch` and `runner` fields per build target
- `artifacts_collect` merges same-named artifacts across arches; errors on duplicate `(name, arch)` pairs
- CI artifact names include arch: `built-{type}-{name}-{arch}`, GHCR images tagged `{sha7}-{arch}`
- `provision load` uses `{registry}/{name}:{arch}` image tags
- pytest expand filters to current machine arch

**Workflow:**
- `build-artifacts.yml` uses `runs-on: ${{ fromJSON(matrix.runner) }}`
- Artifact upload names include arch suffix

**Docs:**
- Updated divergences #12, #13, #15 for new schema

All 297 unit tests pass. Lint and mypy clean.