### PR TITLE
refactor: use flat output format for charms in artifacts-generated.yaml

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -34,14 +34,13 @@ from opcli.models.artifacts import (
 )
 from opcli.models.artifacts_generated import (
     ArtifactsGenerated,
-    CharmArchBuild,
-    CharmFile,
+    CharmOutput,
     GeneratedCharm,
     GeneratedResource,
     GeneratedRock,
     GeneratedSnap,
-    RockArchBuild,
-    SnapArchBuild,
+    RockOutput,
+    SnapOutput,
 )
 
 logger = logging.getLogger(__name__)
@@ -174,7 +173,7 @@ def _push_rock_to_ghcr(
     return GeneratedRock(
         name=rock.name,
         **{"rockcraft-yaml": rock.rockcraft_yaml},
-        output=[RockArchBuild(arch=build.arch, image=image_ref)],
+        output=[RockOutput(arch=build.arch, image=image_ref)],
     )
 
 
@@ -189,7 +188,7 @@ def _to_ci_charm(charm: GeneratedCharm, ci: _CIContext) -> GeneratedCharm:
         name=charm.name,
         **{"charmcraft-yaml": charm.charmcraft_yaml},
         output=[
-            CharmArchBuild.model_validate(
+            CharmOutput.model_validate(
                 {
                     "arch": arch,
                     "artifact": f"built-charm-{charm.name}-{arch}",
@@ -212,7 +211,7 @@ def _to_ci_snap(snap: GeneratedSnap, ci: _CIContext) -> GeneratedSnap:
         name=snap.name,
         **{"snapcraft-yaml": snap.snapcraft_yaml},
         output=[
-            SnapArchBuild.model_validate(
+            SnapOutput.model_validate(
                 {
                     "arch": arch,
                     "artifact": f"built-snap-{snap.name}-{arch}",
@@ -448,7 +447,7 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
     return GeneratedRock(
         name=rock.name,
         **{"rockcraft-yaml": rock.rockcraft_yaml},
-        output=[RockArchBuild(arch=_current_arch(), file=output_file)],
+        output=[RockOutput(arch=_current_arch(), file=output_file)],
     )
 
 
@@ -469,8 +468,10 @@ def _build_charm(
     run_command([*_PACK_COMMANDS["charm"]], cwd=str(pack_dir))
     after = _snapshot_outputs(pack_dir, "charm")
     new_outputs = _pick_new_charm_outputs(before, after, pack_dir)
-    charm_files = [
-        CharmFile(
+    arch = _current_arch()
+    charm_outputs = [
+        CharmOutput(
+            arch=arch,
             path=_relative_to_root(p, root),
             base=_parse_base_from_charm_path(p),
         )
@@ -487,7 +488,7 @@ def _build_charm(
     return GeneratedCharm(
         name=charm.name,
         **{"charmcraft-yaml": charm.charmcraft_yaml},
-        output=[CharmArchBuild(arch=_current_arch(), files=charm_files)],
+        output=charm_outputs,
         resources=resources if resources else None,
     )
 
@@ -510,7 +511,7 @@ def _build_snap(snap: SnapArtifact, root: Path) -> GeneratedSnap:
     return GeneratedSnap(
         name=snap.name,
         **{"snapcraft-yaml": snap.snapcraft_yaml},
-        output=[SnapArchBuild(arch=_current_arch(), file=output_file)],
+        output=[SnapOutput(arch=_current_arch(), file=output_file)],
     )
 
 
@@ -635,6 +636,21 @@ def artifacts_matrix(root: Path) -> dict[str, list[dict[str, object]]]:
     return {"include": include}
 
 
+def _output_key(
+    build: RockOutput | CharmOutput | SnapOutput,
+) -> tuple[object, ...]:
+    """Return a hashable key that uniquely identifies a build output entry.
+
+    For :class:`CharmOutput` (flat format), multiple entries per arch are valid
+    (different bases/paths), so the key includes ``path`` and ``artifact``.
+    For :class:`RockOutput` and :class:`SnapOutput`, ``arch`` alone is the
+    unique key since there is one entry per arch.
+    """
+    if isinstance(build, CharmOutput):
+        return (build.arch, build.path, build.artifact)
+    return (build.arch,)
+
+
 def _merge_artifact_outputs[T: (GeneratedRock, GeneratedCharm, GeneratedSnap)](
     items: list[T],
     kind: str,
@@ -646,8 +662,10 @@ def _merge_artifact_outputs[T: (GeneratedRock, GeneratedCharm, GeneratedSnap)](
     function groups them by name and concatenates the ``output`` lists so that
     the collected file holds all arches for each artifact.
 
-    Raises :class:`ConfigurationError` if the same ``(name, arch)`` pair
-    appears in more than one partial (genuine conflict, not a multi-arch merge).
+    For rocks and snaps, raises :class:`ConfigurationError` if the same
+    ``(name, arch)`` pair appears in more than one partial (genuine conflict).
+    For charms (flat format), raises if the same ``(arch, path, artifact)``
+    tuple appears in more than one partial.
     """
     merged: dict[str, T] = {}
     for item in items:
@@ -655,11 +673,12 @@ def _merge_artifact_outputs[T: (GeneratedRock, GeneratedCharm, GeneratedSnap)](
             merged[item.name] = item
         else:
             existing = merged[item.name]
-            existing_arches = {b.arch for b in existing.output}
+            existing_keys = {_output_key(b) for b in existing.output}
             for build in item.output:
-                if build.arch in existing_arches:
+                key = _output_key(build)
+                if key in existing_keys:
                     msg = (
-                        f"Duplicate {kind} '{item.name}' arch '{build.arch}' across "
+                        f"Duplicate {kind} '{item.name}' output {key!r} across "
                         "collected partials. Each (artifact, arch) must appear in "
                         "exactly one partial file."
                     )
@@ -784,8 +803,8 @@ def _find_local_file(
 
 def _find_local_charm_files(
     root: Path, name: str, arch: str | None = None
-) -> list[CharmFile]:
-    """Find all ``name_*.charm`` files under *root* and return CharmFile list.
+) -> list[tuple[str, str | None]]:
+    """Find all ``name_*.charm`` files under *root* and return (path, base) pairs.
 
     When *arch* is given, only files whose parsed arch matches (or whose arch
     cannot be determined) are returned.  Returns an empty list when no files
@@ -797,12 +816,67 @@ def _find_local_charm_files(
     if arch is not None:
         matches = [m for m in matches if _parse_arch_from_charm_path(m) in (arch, None)]
     return [
-        CharmFile(
-            path="./" + str(Path(m).relative_to(root)),
-            base=_parse_base_from_charm_path(m),
+        (
+            "./" + str(Path(m).relative_to(root)),
+            _parse_base_from_charm_path(m),
         )
         for m in matches
     ]
+
+
+def _localize_charm(
+    charm: GeneratedCharm,
+    root: Path,
+    missing: list[str],
+) -> int:
+    """Localize CI-only charm entries by replacing them with local file entries.
+
+    Returns the number of arch-groups that were localized.
+    """
+    indices_to_replace: list[int] = []
+    new_entries: list[CharmOutput] = []
+    localized = 0
+
+    for idx, build in enumerate(charm.output):
+        if build.path or not build.artifact:
+            continue
+        charm_files = _find_local_charm_files(root, charm.name, build.arch)
+        if not charm_files:
+            missing.append(f"{charm.name} ({build.arch})")
+            logger.error(
+                "No .charm file found for charm '%s' arch '%s'.",
+                charm.name,
+                build.arch,
+            )
+            continue
+        indices_to_replace.append(idx)
+        for path, base in charm_files:
+            new_entries.append(
+                CharmOutput.model_validate(
+                    {
+                        "arch": build.arch,
+                        "path": path,
+                        "base": base,
+                        "artifact": build.artifact,
+                        "run-id": build.run_id,
+                    }
+                )
+            )
+        logger.info(
+            "Localised charm '%s' (%s) → %d file(s).",
+            charm.name,
+            build.arch,
+            len(charm_files),
+        )
+        localized += 1
+
+    if indices_to_replace:
+        replace_set = set(indices_to_replace)
+        charm.output = [
+            b for i, b in enumerate(charm.output) if i not in replace_set
+        ] + new_entries
+
+    return localized
 
 
 def artifacts_localize(root: Path) -> int:
@@ -812,9 +886,9 @@ def artifacts_localize(root: Path) -> int:
     references.  Before running integration tests, the workflow downloads
     the artifacts to the working directory.  This command scans the project
     tree for ``.charm`` / ``.snap`` files and rewrites
-    ``artifacts-generated.yaml`` so that each :class:`CharmArchBuild` /
-    :class:`SnapArchBuild` with only a CI artifact reference gets a
-    ``files`` / ``file`` entry pointing to the discovered local file.
+    ``artifacts-generated.yaml`` so that each :class:`CharmOutput` with only
+    a CI artifact reference gets a ``path`` entry pointing to the discovered
+    local file, and each :class:`SnapOutput` gets a ``file`` entry.
 
     Returns the total number of arch-builds that were localised.
 
@@ -833,26 +907,7 @@ def artifacts_localize(root: Path) -> int:
     missing: list[str] = []
 
     for charm in generated.charms:
-        for build in charm.output:
-            if build.files or not build.artifact:
-                continue
-            charm_files = _find_local_charm_files(root, charm.name, build.arch)
-            if not charm_files:
-                missing.append(f"{charm.name} ({build.arch})")
-                logger.error(
-                    "No .charm file found for charm '%s' arch '%s'.",
-                    charm.name,
-                    build.arch,
-                )
-                continue
-            build.files = charm_files
-            logger.info(
-                "Localised charm '%s' (%s) → %d file(s).",
-                charm.name,
-                build.arch,
-                len(charm_files),
-            )
-            updated += 1
+        updated += _localize_charm(charm, root, missing)
 
     for snap in generated.snaps:
         for snap_build in snap.output:

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -33,9 +33,9 @@ from typing import overload
 from opcli.core.exceptions import ConfigurationError
 from opcli.core.yaml_io import load_artifacts_generated
 from opcli.models.artifacts_generated import (
-    CharmArchBuild,
-    RockArchBuild,
-    SnapArchBuild,
+    CharmOutput,
+    RockOutput,
+    SnapOutput,
 )
 
 logger = logging.getLogger(__name__)
@@ -55,27 +55,27 @@ def _current_arch() -> str:
 
 @overload
 def _select_arch_builds(
-    builds: list[RockArchBuild], arch: str, artifact_name: str
-) -> list[RockArchBuild]: ...
+    builds: list[RockOutput], arch: str, artifact_name: str
+) -> list[RockOutput]: ...
 
 
 @overload
 def _select_arch_builds(
-    builds: list[CharmArchBuild], arch: str, artifact_name: str
-) -> list[CharmArchBuild]: ...
+    builds: list[CharmOutput], arch: str, artifact_name: str
+) -> list[CharmOutput]: ...
 
 
 @overload
 def _select_arch_builds(
-    builds: list[SnapArchBuild], arch: str, artifact_name: str
-) -> list[SnapArchBuild]: ...
+    builds: list[SnapOutput], arch: str, artifact_name: str
+) -> list[SnapOutput]: ...
 
 
 def _select_arch_builds(
-    builds: list[RockArchBuild] | list[CharmArchBuild] | list[SnapArchBuild],
+    builds: list[RockOutput] | list[CharmOutput] | list[SnapOutput],
     arch: str,
     artifact_name: str,
-) -> list[RockArchBuild] | list[CharmArchBuild] | list[SnapArchBuild]:
+) -> list[RockOutput] | list[CharmOutput] | list[SnapOutput]:
     """Return the subset of *builds* matching *arch*, or all if none match.
 
     When an exact arch match is found, only those builds are returned.
@@ -135,9 +135,8 @@ def assemble_pytest_args(
     for charm in generated.charms:
         charm_builds = _select_arch_builds(charm.output, arch, charm.name)
         for charm_build in charm_builds:
-            if charm_build.files:
-                for charm_file in charm_build.files:
-                    args.append(f"--charm-file={charm_file.path}")
+            if charm_build.path:
+                args.append(f"--charm-file={charm_build.path}")
             elif charm_build.artifact:
                 logger.warning(
                     "Skipping --charm-file for charm '%s' (%s): output is a CI "

--- a/src/opcli/models/artifacts_generated.py
+++ b/src/opcli/models/artifacts_generated.py
@@ -8,9 +8,12 @@ Schema version: 1
 - Charm entries include a ``resources`` mapping with resolved output paths
   (image reference), making ``artifacts-generated.yaml`` self-contained for
   pytest flag assembly without needing to also read ``artifacts.yaml``.
-- ``output`` is always a **list of per-architecture builds** (:class:`RockArchBuild`,
-  :class:`CharmArchBuild`, or :class:`SnapArchBuild`), one entry per built arch.
-  Local builds produce ``file`` / ``files`` entries; CI builds produce ``image``
+- ``output`` is always a **flat list of per-file build entries** (:class:`RockOutput`,
+  :class:`CharmOutput`, or :class:`SnapOutput`).
+  Rocks and snaps have one entry per built arch.
+  Charms have one entry per produced ``.charm`` file (one per base per arch for local
+  builds, one per arch for CI builds).
+  Local builds produce ``file`` / ``path`` entries; CI builds produce ``image``
   (rocks) or ``artifact`` + ``run-id`` (charms / snaps) entries.
 """
 
@@ -21,23 +24,8 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-class CharmFile(BaseModel):
-    """A single charm file with its local path and optional base annotation.
-
-    The ``base`` field is parsed from the charmcraft output filename on a
-    best-effort basis (e.g. ``aproxy_ubuntu-22.04-amd64.charm`` →
-    ``ubuntu@22.04``).  It is ``None`` when the filename does not follow the
-    expected ``{name}_{distro}-{version}-{arch}.charm`` convention.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    path: str
-    base: str | None = None
-
-
-class RockArchBuild(BaseModel):
-    """Rock output for a specific architecture.
+class RockOutput(BaseModel):
+    """Rock build output entry.
 
     Local builds populate ``file``; CI builds populate ``image``.
     """
@@ -49,32 +37,35 @@ class RockArchBuild(BaseModel):
     image: str | None = None
 
     @model_validator(mode="after")
-    def _at_least_one_output(self) -> RockArchBuild:
+    def _at_least_one_output(self) -> RockOutput:
         if not self.file and not self.image:
-            msg = "RockArchBuild must specify file or image"
+            msg = "RockOutput must specify file or image"
             raise ValueError(msg)
         return self
 
 
-class CharmArchBuild(BaseModel):
-    """Charm output for a specific architecture.
+class CharmOutput(BaseModel):
+    """Charm build output entry.
 
-    Local builds populate ``files`` (one :class:`CharmFile` per built base).
-    CI builds populate ``artifact`` and ``run-id`` instead.
-    Localised CI builds (after ``artifacts localize``) populate both.
+    Local builds: one entry per produced ``.charm`` file, with ``arch``,
+    ``path``, and optional ``base``.
+    CI builds: one entry per arch with ``artifact`` and ``run-id`` (covers
+    all bases for that arch).
+    Localised CI builds (after ``artifacts localize``) carry all fields.
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     arch: str
-    files: list[CharmFile] = []
+    path: str | None = None
+    base: str | None = None
     artifact: str | None = None
     run_id: str | None = Field(default=None, alias="run-id")
 
     @model_validator(mode="after")
-    def _at_least_one_output(self) -> CharmArchBuild:
-        if not self.files and not self.artifact:
-            msg = "CharmArchBuild must specify files or artifact"
+    def _at_least_one_output(self) -> CharmOutput:
+        if not self.path and not self.artifact:
+            msg = "CharmOutput must specify path or artifact"
             raise ValueError(msg)
         if self.artifact and not self.run_id:
             msg = "run-id is required when artifact is set"
@@ -82,8 +73,8 @@ class CharmArchBuild(BaseModel):
         return self
 
 
-class SnapArchBuild(BaseModel):
-    """Snap output for a specific architecture.
+class SnapOutput(BaseModel):
+    """Snap build output entry.
 
     Local builds populate ``file``; CI builds populate ``artifact`` + ``run-id``.
     Localised CI builds (after ``artifacts localize``) populate both.
@@ -97,9 +88,9 @@ class SnapArchBuild(BaseModel):
     run_id: str | None = Field(default=None, alias="run-id")
 
     @model_validator(mode="after")
-    def _at_least_one_output(self) -> SnapArchBuild:
+    def _at_least_one_output(self) -> SnapOutput:
         if not self.file and not self.artifact:
-            msg = "SnapArchBuild must specify file or artifact"
+            msg = "SnapOutput must specify file or artifact"
             raise ValueError(msg)
         if self.artifact and not self.run_id:
             msg = "run-id is required when artifact is set"
@@ -127,17 +118,17 @@ class GeneratedRock(BaseModel):
 
     name: str
     rockcraft_yaml: str = Field(alias="rockcraft-yaml")
-    output: list[RockArchBuild]
+    output: list[RockOutput]
 
 
 class GeneratedCharm(BaseModel):
-    """A charm with its per-architecture build output and resolved resource paths."""
+    """A charm with its flat build output list and resolved resource paths."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     name: str
     charmcraft_yaml: str = Field(alias="charmcraft-yaml")
-    output: list[CharmArchBuild]
+    output: list[CharmOutput]
     resources: dict[str, GeneratedResource] | None = None
 
 
@@ -148,7 +139,7 @@ class GeneratedSnap(BaseModel):
 
     name: str
     snapcraft_yaml: str = Field(alias="snapcraft-yaml")
-    output: list[SnapArchBuild]
+    output: list[SnapOutput]
 
 
 class ArtifactsGenerated(BaseModel):

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -94,12 +94,12 @@ class TestArtifactsBuild:
         gen = load_artifacts_generated(result)
         assert len(gen.charms) == 1
         assert gen.charms[0].name == "mycharm"
-        assert len(gen.charms[0].output[0].files) == 1
-        assert gen.charms[0].output[0].files[0].path.startswith("./")
-        assert gen.charms[0].output[0].files[0].path.endswith(".charm")
+        assert len(gen.charms[0].output) == 1
+        assert gen.charms[0].output[0].path.startswith("./")
+        assert gen.charms[0].output[0].path.endswith(".charm")
 
     def test_build_multi_base_charm(self, tmp_path: Path) -> None:
-        """Multi-base charm: all produced files appear in output.files."""
+        """Multi-base charm: all produced files appear as flat output entries."""
         _write(
             tmp_path / "artifacts.yaml",
             "version: 1\ncharms:\n- name: aproxy\n  charmcraft-yaml: charmcraft.yaml\n",
@@ -114,14 +114,14 @@ class TestArtifactsBuild:
             result = artifacts_build(tmp_path)
 
         gen = load_artifacts_generated(result)
-        files = gen.charms[0].output[0].files
+        outputs = gen.charms[0].output
         expected_count = 3
-        assert len(files) == expected_count
-        paths = {f.path for f in files}
+        assert len(outputs) == expected_count
+        paths = {o.path for o in outputs}
         assert "./aproxy_ubuntu-20.04-amd64.charm" in paths
         assert "./aproxy_ubuntu-22.04-amd64.charm" in paths
         assert "./aproxy_ubuntu-24.04-amd64.charm" in paths
-        bases = {f.base for f in files}
+        bases = {o.base for o in outputs}
         assert "ubuntu@20.04" in bases
         assert "ubuntu@22.04" in bases
         assert "ubuntu@24.04" in bases
@@ -147,10 +147,10 @@ class TestArtifactsBuild:
             result = artifacts_build(tmp_path)
 
         gen = load_artifacts_generated(result)
-        files = gen.charms[0].output[0].files
+        outputs = gen.charms[0].output
         expected_count = 2
-        assert len(files) == expected_count
-        paths = {f.path for f in files}
+        assert len(outputs) == expected_count
+        paths = {o.path for o in outputs}
         assert "./aproxy_ubuntu-20.04-amd64.charm" in paths
         assert "./aproxy_ubuntu-22.04-amd64.charm" in paths
 
@@ -559,10 +559,10 @@ class TestArtifactsBuild:
             result = artifacts_build(tmp_path)
 
         gen = load_artifacts_generated(result)
-        files = gen.charms[0].output[0].files
+        outputs = gen.charms[0].output
         expected_count = 2
-        assert len(files) == expected_count
-        paths = {f.path for f in files}
+        assert len(outputs) == expected_count
+        paths = {o.path for o in outputs}
         assert "./mycharm_ubuntu-22.04-amd64.charm" in paths
         assert "./mycharm_ubuntu-24.04-amd64.charm" in paths
 
@@ -675,9 +675,9 @@ class TestArtifactsCollect:
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
-            "      base: ubuntu@24.04\n",
+            "  output:\n  - arch: amd64\n"
+            "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
+            "    base: ubuntu@24.04\n",
         )
 
         dest = tmp_path / "artifacts-generated.yaml"
@@ -703,9 +703,9 @@ class TestArtifactsCollect:
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
-            "      base: ubuntu@24.04\n"
+            "  output:\n  - arch: amd64\n"
+            "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
+            "    base: ubuntu@24.04\n"
             "  resources:\n"
             "    my-rock-image:\n"
             "      type: oci-image\n"
@@ -759,9 +759,9 @@ class TestArtifactsCollect:
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
-            "      base: ubuntu@24.04\n"
+            "  output:\n  - arch: amd64\n"
+            "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
+            "    base: ubuntu@24.04\n"
             "  resources:\n"
             "    missing-rock-image:\n"
             "      type: oci-image\n"
@@ -825,18 +825,18 @@ class TestArtifactsCollect:
             "charm-amd64-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
-            "      base: ubuntu@24.04\n",
+            "  output:\n  - arch: amd64\n"
+            "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
+            "    base: ubuntu@24.04\n",
         )
         charm_arm64 = self._partial(
             tmp_path,
             "charm-arm64-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: arm64\n    files:\n"
-            "    - path: ./my-charm_ubuntu-24.04-arm64.charm\n"
-            "      base: ubuntu@24.04\n",
+            "  output:\n  - arch: arm64\n"
+            "    path: ./my-charm_ubuntu-24.04-arm64.charm\n"
+            "    base: ubuntu@24.04\n",
         )
 
         artifacts_collect(tmp_path, [charm_amd64, charm_arm64])
@@ -943,7 +943,7 @@ class TestArtifactsBuildCIMode:
         gen = load_artifacts_generated(result)
         assert len(gen.charms) == 1
         charm_out = gen.charms[0].output
-        assert charm_out[0].files == []
+        assert charm_out[0].path is None
         assert charm_out[0].artifact == "built-charm-my-charm-amd64"
         assert charm_out[0].run_id == "9876543210"
 
@@ -993,8 +993,8 @@ class TestArtifactsBuildCIMode:
         gen = load_artifacts_generated(result)
         charm_out = gen.charms[0].output
         assert charm_out[0].artifact is None
-        assert len(charm_out[0].files) == 1
-        assert "my-charm_ubuntu-24.04-amd64.charm" in charm_out[0].files[0].path
+        assert len(charm_out) == 1
+        assert "my-charm_ubuntu-24.04-amd64.charm" in charm_out[0].path
 
     def test_ci_missing_env_vars_raises(self, tmp_path: Path) -> None:
         """GITHUB_ACTIONS=true with missing env vars raises ConfigurationError."""
@@ -1120,15 +1120,15 @@ class TestArtifactsLocalize:
 
         assert count == 1
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
-        assert gen.charms[0].output[0].files is not None
-        assert len(gen.charms[0].output[0].files) == 1
-        path = gen.charms[0].output[0].files[0].path
+        assert len(gen.charms[0].output) == 1
+        path = gen.charms[0].output[0].path
+        assert path is not None
         assert path.endswith(".charm")
         assert path.startswith("./"), f"Expected relative path, got: {path}"
         assert "/home/" not in path, f"Expected no absolute home path, got: {path}"
 
     def test_skips_charm_already_with_local_files(self, tmp_path: Path) -> None:
-        """Does not overwrite charms that already have output.files."""
+        """Does not overwrite charms that already have output path."""
 
         generated = (
             "version: 1\n"
@@ -1137,8 +1137,7 @@ class TestArtifactsLocalize:
             "  charmcraft-yaml: charmcraft.yaml\n"
             "  output:\n"
             "  - arch: amd64\n"
-            "    files:\n"
-            "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
+            "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
         )
         _write(tmp_path / "artifacts-generated.yaml", generated)
         charm_file = tmp_path / "my-charm_new.charm"
@@ -1172,8 +1171,7 @@ class TestArtifactsLocalize:
             "  charmcraft-yaml: charmcraft.yaml\n"
             "  output:\n"
             "  - arch: amd64\n"
-            "    files:\n"
-            "    - path: ./my-charm_ubuntu-24.04-amd64.charm\n"
+            "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
         )
         _write(tmp_path / "artifacts-generated.yaml", generated)
         # Create a second charm file — should not be picked up since charm
@@ -1204,11 +1202,11 @@ class TestArtifactsLocalize:
 
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
         charm = gen.charms[0]
-        assert len(charm.output[0].files) == 2  # noqa: PLR2004
-        paths = {f.path for f in charm.output[0].files}
+        assert len(charm.output) == 2  # noqa: PLR2004
+        paths = {o.path for o in charm.output}
         assert any("22.04" in p for p in paths)
         assert any("24.04" in p for p in paths)
-        bases = {f.base for f in charm.output[0].files}
+        bases = {o.base for o in charm.output}
         assert "ubuntu@22.04" in bases
         assert "ubuntu@24.04" in bases
 
@@ -1394,8 +1392,9 @@ class TestArtifactsFetch:
 
         gen = load_artifacts_generated(tmp_path / "artifacts-generated.yaml")
         for charm in gen.charms:
-            assert charm.output[0].files, f"Charm '{charm.name}' was not localised"
-            assert charm.output[0].files[0].path.endswith(".charm")
+            charm_paths = [o.path for o in charm.output if o.path]
+            assert charm_paths, f"Charm '{charm.name}' was not localised"
+            assert charm_paths[0].endswith(".charm")
         for snap in gen.snaps:
             assert snap.output[0].file, f"Snap '{snap.name}' was not localised"
             assert snap.output[0].file.endswith(".snap")

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -17,10 +17,10 @@ from opcli.core.yaml_io import (
 from opcli.models.artifacts import ArtifactsPlan
 from opcli.models.artifacts_generated import (
     ArtifactsGenerated,
-    CharmArchBuild,
+    CharmOutput,
     GeneratedCharm,
     GeneratedRock,
-    RockArchBuild,
+    RockOutput,
 )
 
 
@@ -213,7 +213,7 @@ class TestYamlIO:
                 GeneratedRock(
                     name="r1",
                     rockcraft_yaml="rd/rockcraft.yaml",
-                    output=[RockArchBuild(arch="amd64", file="./r1.rock")],
+                    output=[RockOutput(arch="amd64", file="./r1.rock")],
                 )
             ],
         )
@@ -228,7 +228,7 @@ class TestYamlIO:
                 GeneratedCharm(
                     name="c1",
                     charmcraft_yaml="charmcraft.yaml",
-                    output=[CharmArchBuild(arch="amd64", artifact="a1", run_id="42")],
+                    output=[CharmOutput(arch="amd64", artifact="a1", run_id="42")],
                 )
             ],
         )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -14,13 +14,12 @@ from opcli.models.artifacts import (
 )
 from opcli.models.artifacts_generated import (
     ArtifactsGenerated,
-    CharmArchBuild,
-    CharmFile,
+    CharmOutput,
     GeneratedCharm,
     GeneratedRock,
     GeneratedSnap,
-    RockArchBuild,
-    SnapArchBuild,
+    RockOutput,
+    SnapOutput,
 )
 
 
@@ -147,35 +146,35 @@ class TestArtifactsGenerated:
     """Validation tests for artifacts-generated.yaml models."""
 
     def test_local_output(self) -> None:
-        out = RockArchBuild(arch="amd64", file="./myrock.rock")
+        out = RockOutput(arch="amd64", file="./myrock.rock")
         assert out.file == "./myrock.rock"
         assert out.image is None
 
     def test_ci_output_with_image(self) -> None:
-        out = RockArchBuild(arch="amd64", image="ghcr.io/canonical/indico:abc1234")
+        out = RockOutput(arch="amd64", image="ghcr.io/canonical/indico:abc1234")
         assert out.image is not None
 
     def test_ci_output_artifact_requires_run_id(self) -> None:
         with pytest.raises(ValidationError, match="run-id is required"):
-            CharmArchBuild(arch="amd64", artifact="charm-indico")
+            CharmOutput(arch="amd64", artifact="charm-indico")
 
     def test_ci_output_artifact_with_run_id(self) -> None:
-        out = CharmArchBuild(arch="amd64", artifact="charm-indico", run_id="123456")
+        out = CharmOutput(arch="amd64", artifact="charm-indico", run_id="123456")
         assert out.artifact == "charm-indico"
         assert out.run_id == "123456"
 
     def test_empty_output_rejected(self) -> None:
         with pytest.raises(ValidationError, match="must specify file or image"):
-            RockArchBuild(arch="amd64")
+            RockOutput(arch="amd64")
 
     def test_run_id_alias_from_yaml(self) -> None:
         """YAML uses ``run-id`` (hyphen), Python uses ``run_id``."""
         data = {"arch": "amd64", "artifact": "charm-x", "run-id": "999"}
-        out = CharmArchBuild.model_validate(data)
+        out = CharmOutput.model_validate(data)
         assert out.run_id == "999"
 
     def test_run_id_serialized_with_hyphen(self) -> None:
-        out = CharmArchBuild(arch="amd64", artifact="charm-x", run_id="999")
+        out = CharmOutput(arch="amd64", artifact="charm-x", run_id="999")
         dumped = out.model_dump(by_alias=True, exclude_none=True)
         assert "run-id" in dumped
         assert "run_id" not in dumped
@@ -186,7 +185,7 @@ class TestArtifactsGenerated:
                 GeneratedRock(
                     name="indico",
                     rockcraft_yaml="indico_rock/rockcraft.yaml",
-                    output=[RockArchBuild(arch="amd64", file="./indico.rock")],
+                    output=[RockOutput(arch="amd64", file="./indico.rock")],
                 )
             ],
             charms=[
@@ -194,18 +193,17 @@ class TestArtifactsGenerated:
                     name="indico",
                     charmcraft_yaml="charmcraft.yaml",
                     output=[
-                        CharmArchBuild(
+                        CharmOutput(
                             arch="amd64",
-                            files=[
-                                CharmFile(path="./indico.charm", base="ubuntu@22.04")
-                            ],
+                            path="./indico.charm",
+                            base="ubuntu@22.04",
                         )
                     ],
                 )
             ],
         )
         assert gen.rocks[0].output[0].file == "./indico.rock"
-        assert gen.charms[0].output[0].files[0].path == "./indico.charm"
+        assert gen.charms[0].output[0].path == "./indico.charm"
 
     def test_generated_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError, match="Extra inputs"):
@@ -217,61 +215,63 @@ class TestArtifactsGenerated:
                 GeneratedSnap(
                     name="mysnap",
                     snapcraft_yaml="snap/snapcraft.yaml",
-                    output=[SnapArchBuild(arch="amd64", file="./mysnap.snap")],
+                    output=[SnapOutput(arch="amd64", file="./mysnap.snap")],
                 )
             ],
         )
         assert gen.snaps[0].name == "mysnap"
 
 
-class TestCharmArchBuild:
-    """Validation tests for CharmArchBuild and CharmFile models."""
+class TestCharmOutput:
+    """Validation tests for CharmOutput model."""
 
     def test_local_single_base(self) -> None:
-        out = CharmArchBuild(
+        out = CharmOutput(
             arch="amd64",
-            files=[
-                CharmFile(path="./aproxy_ubuntu-22.04-amd64.charm", base="ubuntu@22.04")
-            ],
+            path="./aproxy_ubuntu-22.04-amd64.charm",
+            base="ubuntu@22.04",
         )
-        assert len(out.files) == 1
-        assert out.files[0].base == "ubuntu@22.04"
+        assert out.path == "./aproxy_ubuntu-22.04-amd64.charm"
+        assert out.base == "ubuntu@22.04"
 
-    def test_local_multi_base(self) -> None:
-        out = CharmArchBuild(
+    def test_local_multi_base_separate_entries(self) -> None:
+        out1 = CharmOutput(
             arch="amd64",
-            files=[
-                CharmFile(path="./a_ubuntu-20.04-amd64.charm", base="ubuntu@20.04"),
-                CharmFile(path="./a_ubuntu-22.04-amd64.charm", base="ubuntu@22.04"),
-            ],
+            path="./a_ubuntu-20.04-amd64.charm",
+            base="ubuntu@20.04",
         )
-        expected_count = 2
-        assert len(out.files) == expected_count
+        out2 = CharmOutput(
+            arch="amd64",
+            path="./a_ubuntu-22.04-amd64.charm",
+            base="ubuntu@22.04",
+        )
+        assert out1.path != out2.path
+        assert out1.base != out2.base
 
     def test_ci_artifact_output(self) -> None:
-        out = CharmArchBuild(arch="amd64", artifact="charm-aproxy", run_id="999")
+        out = CharmOutput(arch="amd64", artifact="charm-aproxy", run_id="999")
         assert out.artifact == "charm-aproxy"
         assert out.run_id == "999"
-        assert out.files == []
+        assert out.path is None
 
     def test_ci_artifact_yaml_alias(self) -> None:
-        out = CharmArchBuild.model_validate(
+        out = CharmOutput.model_validate(
             {"arch": "amd64", "artifact": "charm-x", "run-id": "1"}
         )
         assert out.run_id == "1"
 
     def test_empty_output_rejected(self) -> None:
-        with pytest.raises(ValidationError, match="files or artifact"):
-            CharmArchBuild(arch="amd64")
+        with pytest.raises(ValidationError, match="path or artifact"):
+            CharmOutput(arch="amd64")
 
     def test_artifact_without_run_id_rejected(self) -> None:
         with pytest.raises(ValidationError, match="run-id"):
-            CharmArchBuild(arch="amd64", artifact="charm-x")
+            CharmOutput(arch="amd64", artifact="charm-x")
 
     def test_base_none_allowed(self) -> None:
         """Base can be None when filename does not follow convention."""
-        out = CharmArchBuild(arch="amd64", files=[CharmFile(path="./mycharm.charm")])
-        assert out.files[0].base is None
+        out = CharmOutput(arch="amd64", path="./mycharm.charm")
+        assert out.base is None
 
 
 class TestBuildTarget:
@@ -286,42 +286,42 @@ class TestBuildTarget:
         assert bt.runner == ["ubuntu-latest"]
 
 
-class TestRockArchBuild:
-    """Validation tests for RockArchBuild model."""
+class TestRockOutput:
+    """Validation tests for RockOutput model."""
 
     def test_rock_local_build(self) -> None:
-        build = RockArchBuild(arch="amd64", file="./my.rock")
+        build = RockOutput(arch="amd64", file="./my.rock")
         assert build.arch == "amd64"
         assert build.file == "./my.rock"
         assert build.image is None
 
     def test_rock_ci_build(self) -> None:
-        build = RockArchBuild(arch="amd64", image="ghcr.io/canonical/my-rock:abc123")
+        build = RockOutput(arch="amd64", image="ghcr.io/canonical/my-rock:abc123")
         assert build.image == "ghcr.io/canonical/my-rock:abc123"
         assert build.file is None
 
     def test_rock_empty_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            RockArchBuild(arch="amd64")
+            RockOutput(arch="amd64")
 
     def test_rock_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError, match="Extra inputs"):
-            RockArchBuild.model_validate(
+            RockOutput.model_validate(
                 {"arch": "amd64", "file": "./my.rock", "unknown": "x"}
             )
 
 
-class TestSnapArchBuild:
-    """Validation tests for SnapArchBuild model."""
+class TestSnapOutput:
+    """Validation tests for SnapOutput model."""
 
     def test_snap_local_build(self) -> None:
-        build = SnapArchBuild(arch="amd64", file="./my.snap")
+        build = SnapOutput(arch="amd64", file="./my.snap")
         assert build.arch == "amd64"
         assert build.file == "./my.snap"
         assert build.artifact is None
 
     def test_snap_ci_build(self) -> None:
-        build = SnapArchBuild(
+        build = SnapOutput(
             arch="amd64", artifact="built-snap-my-snap-amd64", run_id="123"
         )
         assert build.artifact == "built-snap-my-snap-amd64"
@@ -329,8 +329,8 @@ class TestSnapArchBuild:
 
     def test_snap_empty_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            SnapArchBuild(arch="amd64")
+            SnapOutput(arch="amd64")
 
     def test_snap_artifact_without_run_id_rejected(self) -> None:
         with pytest.raises(ValidationError, match="run-id"):
-            SnapArchBuild(arch="amd64", artifact="built-snap-my-snap")
+            SnapOutput(arch="amd64", artifact="built-snap-my-snap")

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -36,9 +36,8 @@ charms:
   charmcraft-yaml: charmcraft.yaml
   output:
   - arch: amd64
-    files:
-    - path: ./mycharm_ubuntu-22.04-amd64.charm
-      base: ubuntu@22.04
+    path: ./mycharm_ubuntu-22.04-amd64.charm
+    base: ubuntu@22.04
 """
 
 _GENERATED_WITH_ROCKS_AND_RESOURCES = """\
@@ -59,9 +58,8 @@ charms:
   charmcraft-yaml: charmcraft.yaml
   output:
   - arch: amd64
-    files:
-    - path: ./mycharm_ubuntu-22.04-amd64.charm
-      base: ubuntu@22.04
+    path: ./mycharm_ubuntu-22.04-amd64.charm
+    base: ubuntu@22.04
   resources:
     myrock-image:
       type: oci-image

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -35,9 +35,8 @@ charms:
   charmcraft-yaml: charmcraft.yaml
   output:
   - arch: amd64
-    files:
-    - path: ./mycharm_ubuntu-22.04-amd64.charm
-      base: ubuntu@22.04
+    path: ./mycharm_ubuntu-22.04-amd64.charm
+    base: ubuntu@22.04
   resources:
     myrock-image:
       type: oci-image
@@ -72,9 +71,8 @@ charms:
   charmcraft-yaml: charmcraft.yaml
   output:
   - arch: amd64
-    files:
-    - path: ./simple_ubuntu-22.04-amd64.charm
-      base: ubuntu@22.04
+    path: ./simple_ubuntu-22.04-amd64.charm
+    base: ubuntu@22.04
 """
 
 
@@ -89,8 +87,7 @@ class TestAssemblePytestArgs:
         _write(
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: c\n  source: .\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./c.charm\n      base: ubuntu@22.04\n",
+            "  output:\n  - arch: amd64\n    path: ./c.charm\n",
         )
         with pytest.raises(Exception, match=_V1_ERROR_MATCH):
             assemble_pytest_args(tmp_path)
@@ -139,15 +136,18 @@ class TestAssemblePytestArgs:
     def test_multi_base_charm_emits_multiple_charm_file_flags(
         self, tmp_path: Path
     ) -> None:
-        """Multi-base charm produces one --charm-file per output file."""
+        """Multi-base charm produces one --charm-file per output entry."""
         _write(
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: aproxy\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./aproxy_ubuntu-20.04-amd64.charm\n      base: ubuntu@20.04\n"
-            "    - path: ./aproxy_ubuntu-22.04-amd64.charm\n      base: ubuntu@22.04\n"
-            "    - path: ./aproxy_ubuntu-24.04-amd64.charm\n      base: ubuntu@24.04\n",
+            "  output:\n"
+            "  - arch: amd64\n    path: ./aproxy_ubuntu-20.04-amd64.charm\n"
+            "    base: ubuntu@20.04\n"
+            "  - arch: amd64\n    path: ./aproxy_ubuntu-22.04-amd64.charm\n"
+            "    base: ubuntu@22.04\n"
+            "  - arch: amd64\n    path: ./aproxy_ubuntu-24.04-amd64.charm\n"
+            "    base: ubuntu@24.04\n",
         )
 
         args = assemble_pytest_args(tmp_path)
@@ -168,9 +168,8 @@ class TestAssemblePytestArgs:
         _write(
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./c_ubuntu-22.04-amd64.charm\n"
-            "      base: ubuntu@22.04\n"
+            "  output:\n  - arch: amd64\n    path: ./c_ubuntu-22.04-amd64.charm\n"
+            "    base: ubuntu@22.04\n"
             "  resources:\n    img:\n      type: oci-image\n      rock: myrock\n",
         )
 
@@ -188,9 +187,8 @@ class TestAssemblePytestArgs:
             "  output:\n  - arch: amd64\n    file: ./rock_dir/myrock.rock\n"
             "    image: localhost:32000/myrock:latest\n"
             "charms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./c_ubuntu-22.04-amd64.charm\n"
-            "      base: ubuntu@22.04\n"
+            "  output:\n  - arch: amd64\n    path: ./c_ubuntu-22.04-amd64.charm\n"
+            "    base: ubuntu@22.04\n"
             "  resources:\n    myrock-image:\n      type: oci-image\n"
             "      rock: myrock\n",
         )
@@ -214,9 +212,9 @@ class TestAssemblePytestArgs:
             "  output:\n  - arch: amd64\n    file: ./expressjs-app_1.0_amd64.rock\n"
             "charms:\n- name: expressjs-k8s\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./expressjs-k8s_ubuntu-22.04-amd64.charm\n"
-            "      base: ubuntu@22.04\n"
+            "  output:\n  - arch: amd64\n"
+            "    path: ./expressjs-k8s_ubuntu-22.04-amd64.charm\n"
+            "    base: ubuntu@22.04\n"
             "  resources:\n    app-image:\n      type: oci-image\n"
             "      rock: expressjs-app\n",
         )
@@ -241,9 +239,9 @@ class TestAssemblePytestArgs:
             "- name: fastapi-app\n  rockcraft-yaml: fastapi/rockcraft.yaml\n"
             "  output:\n  - arch: amd64\n    file: ./fastapi-app_1.0_amd64.rock\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./my-charm_ubuntu-22.04-amd64.charm\n"
-            "      base: ubuntu@22.04\n",
+            "  output:\n  - arch: amd64\n"
+            "    path: ./my-charm_ubuntu-22.04-amd64.charm\n"
+            "    base: ubuntu@22.04\n",
         )
 
         args = assemble_pytest_args(tmp_path)
@@ -257,9 +255,9 @@ class TestAssemblePytestArgs:
             tmp_path / "artifacts-generated.yaml",
             "version: 1\ncharms:\n- name: mycharm\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    files:\n"
-            "    - path: ./mycharm_ubuntu-22.04-amd64.charm\n"
-            "      base: ubuntu@22.04\n"
+            "  output:\n  - arch: amd64\n"
+            "    path: ./mycharm_ubuntu-22.04-amd64.charm\n"
+            "    base: ubuntu@22.04\n"
             "  resources:\n    standalone-image:\n      type: oci-image\n",
         )
 


### PR DESCRIPTION
Replaces the arch-grouped charm output format (one entry per arch with nested `files: list[CharmFile]`) with a flat list where each `.charm` file gets its own top-level `CharmOutput` entry.

### Changes

**Models** (`src/opcli/models/artifacts_generated.py`):
- Remove `CharmFile` and `CharmArchBuild`; add `CharmOutput` with `path`, `base`, `artifact`, `run_id` at the same level as `arch`
- Rename `RockArchBuild`→`RockOutput`, `SnapArchBuild`→`SnapOutput`

**Core logic** (`src/opcli/core/artifacts.py`):
- `_build_charm`: creates one `CharmOutput` per produced file (instead of one per arch with nested files)
- `_find_local_charm_files`: returns `list[tuple[str, str | None]]` (path, base)
- Extract `_localize_charm` helper to keep `artifacts_localize` within branch limits
- `_output_key` helper for type-aware duplicate detection in `_merge_artifact_outputs`

**pytest args** (`src/opcli/core/pytest_args.py`):
- Iterates flat charm outputs directly (no inner `files` loop)

**Tests + examples**: updated all YAML fixtures, model imports, and assertions.