### PR TITLE
fix: allow real charmcraft.yaml when content matches charmcraft-yaml

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -450,6 +450,11 @@ def _with_charm_symlink(
         return None, False
 
     if target.exists() and not target.is_symlink():
+        if target.read_bytes() == yaml_path.read_bytes():
+            # A real charmcraft.yaml already exists with identical content
+            # (e.g. a copy kept alongside a non-standard filename).
+            # Charmcraft will use it and produce the correct charm — no action.
+            return None, False
         msg = (
             f"A regular file already exists at {target} and it differs from "
             f"{yaml_path}. Remove it or set pack-dir to a directory without a "

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -254,9 +254,17 @@ def _snapshot_outputs(pack_dir: Path, kind: str) -> set[str]:
 
 
 def _pick_new_output(
-    before: set[str], after: set[str], kind: str, pack_dir: Path
+    before: set[str],
+    after: set[str],
+    kind: str,
+    pack_dir: Path,
+    attributed: set[str] | None = None,
 ) -> str:
     """Return the new output file produced by pack, relative to repo root.
+
+    *attributed* is the set of paths already claimed by previous artifact builds
+    in this session.  If the overwrite-in-place fallback would return a path that
+    is already attributed, a collision is detected and an error is raised.
 
     Three cases:
     1. New files appeared (``after - before`` non-empty) — use those.
@@ -283,7 +291,16 @@ def _pick_new_output(
 
     if len(after) == 1:
         # Exactly one pre-existing file; the build overwrote it in place.
-        return next(iter(after))
+        path = next(iter(after))
+        if attributed and path in attributed:
+            msg = (
+                f"Output file {path} was already produced by another artifact. "
+                "Two artifacts cannot share the same output filename in the same "
+                "pack-dir. Use separate pack-dirs or ensure each artifact produces "
+                "a unique filename."
+            )
+            raise OpcliError(msg)
+        return path
 
     # Multiple pre-existing files, none added — cannot determine which was built.
     msg = (
@@ -355,21 +372,21 @@ def _parse_arch_from_snap_path(path: str) -> str | None:
 
 
 def _pick_new_charm_outputs(
-    before: set[str], after: set[str], pack_dir: Path
+    before: set[str],
+    after: set[str],
+    pack_dir: Path,
+    attributed: set[str] | None = None,
 ) -> list[str]:
     """Return the charm files produced by this pack invocation.
 
-    ``charmcraft pack`` always rebuilds **all** declared bases in a single
-    invocation.  When multiple charms share the same pack_dir, files from a
-    previous charm build are already present in ``before``.  Using
-    ``after - before`` ensures we only attribute newly-produced files to this
-    charm rather than accumulating all charm files in the directory.
+    *attributed* is the set of paths already claimed by previous charm builds
+    in this session.  If the overwrite-in-place fallback would return paths that
+    are all already attributed, a collision is detected and an error is raised.
 
     Cases:
     1. New files appeared (``after - before`` non-empty) — return those.
-    2. No change (overwrite-in-place rebuild) — return all files in ``after``.
-       This handles the case where a charm is rebuilt and the same filenames
-       are overwritten.
+    2. No change (overwrite-in-place rebuild) — return all files in ``after``,
+       unless they are all already attributed to a previous artifact (collision).
     3. No files at all after pack — raise error.
     """
     if not after:
@@ -381,6 +398,14 @@ def _pick_new_charm_outputs(
         return sorted(new)
 
     # Overwrite-in-place: charmcraft rebuilt the same files (before == after).
+    if attributed and after.issubset(attributed):
+        msg = (
+            f"Output files {sorted(after)} were already produced by another "
+            "artifact. Two artifacts cannot share the same output filenames in "
+            "the same pack-dir. Use separate pack-dirs or ensure each charm "
+            "produces unique filenames."
+        )
+        raise OpcliError(msg)
     return sorted(after)
 
 
@@ -411,18 +436,22 @@ def _with_rock_symlink(
     call created the symlink (and the caller must remove it afterwards).
 
     Raises:
-        ConfigurationError: If a real (non-symlink) file already exists at the
-            target location.
+        ConfigurationError: If a real (non-symlink) ``rockcraft.yaml`` already
+            exists in *pack_dir* and its content differs from *yaml_path*.
     """
-    target = pack_dir / "rockcraft.yaml"  # always the standard name
-    if target == yaml_path:
-        # Already named rockcraft.yaml and already in pack_dir — no symlink needed.
+    target = pack_dir / "rockcraft.yaml"
+    if target.resolve() == yaml_path.resolve():
+        # Already the right file — no symlink needed.
         return None, False
 
     if target.exists() and not target.is_symlink():
+        if target.read_bytes() == yaml_path.read_bytes():
+            # Identical content — rockcraft will use it correctly.
+            return None, False
         msg = (
-            f"A regular file already exists at {target}. "
-            "Remove it or set pack-dir to a directory without a rockcraft.yaml."
+            f"A regular file already exists at {target} and it differs from "
+            f"{yaml_path}. Remove it or set pack-dir to a directory without a "
+            "rockcraft.yaml."
         )
         raise ConfigurationError(msg)
     if target.is_symlink():
@@ -476,7 +505,7 @@ def _with_charm_symlink(
     return target, True
 
 
-def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
+def _build_rock(rock: RockArtifact, root: Path, attributed: set[str]) -> GeneratedRock:
     yaml_path = (root / rock.rockcraft_yaml).resolve()
     if not yaml_path.is_file():
         msg = f"rockcraft-yaml not found: {rock.rockcraft_yaml}"
@@ -492,12 +521,13 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
     try:
         run_command([*_PACK_COMMANDS["rock"]], cwd=str(pack_dir), env=_ROCKCRAFT_ENV)
     finally:
-        if symlink_created and symlink_path and symlink_path.exists():
+        if symlink_created and symlink_path and symlink_path.is_symlink():
             symlink_path.unlink()
 
     after = _snapshot_outputs(pack_dir, "rock")
-    new_output = _pick_new_output(before, after, "rock", pack_dir)
+    new_output = _pick_new_output(before, after, "rock", pack_dir, attributed)
     output_file = _relative_to_root(new_output, root)
+    attributed.add(new_output)
     return GeneratedRock(
         name=rock.name,
         **{"rockcraft-yaml": rock.rockcraft_yaml},
@@ -508,6 +538,7 @@ def _build_rock(rock: RockArtifact, root: Path) -> GeneratedRock:
 def _build_charm(
     charm: CharmArtifact,
     root: Path,
+    attributed: set[str],
 ) -> GeneratedCharm:
     yaml_path = (root / charm.charmcraft_yaml).resolve()
     if not yaml_path.is_file():
@@ -523,10 +554,11 @@ def _build_charm(
     try:
         run_command([*_PACK_COMMANDS["charm"]], cwd=str(pack_dir))
     finally:
-        if symlink_created and symlink_path and symlink_path.exists():
+        if symlink_created and symlink_path and symlink_path.is_symlink():
             symlink_path.unlink()
     after = _snapshot_outputs(pack_dir, "charm")
-    new_outputs = _pick_new_charm_outputs(before, after, pack_dir)
+    new_outputs = _pick_new_charm_outputs(before, after, pack_dir, attributed)
+    attributed.update(new_outputs)
     arch = _current_arch()
     charm_outputs = [
         CharmOutput(
@@ -552,7 +584,7 @@ def _build_charm(
     )
 
 
-def _build_snap(snap: SnapArtifact, root: Path) -> GeneratedSnap:
+def _build_snap(snap: SnapArtifact, root: Path, attributed: set[str]) -> GeneratedSnap:
     yaml_path = (root / snap.snapcraft_yaml).resolve()
     if not yaml_path.is_file():
         msg = f"snapcraft-yaml not found: {snap.snapcraft_yaml}"
@@ -565,8 +597,9 @@ def _build_snap(snap: SnapArtifact, root: Path) -> GeneratedSnap:
     before = _snapshot_outputs(pack_dir, "snap")
     run_command([*_PACK_COMMANDS["snap"]], cwd=str(pack_dir))
     after = _snapshot_outputs(pack_dir, "snap")
-    new_output = _pick_new_output(before, after, "snap", pack_dir)
+    new_output = _pick_new_output(before, after, "snap", pack_dir, attributed)
     output_file = _relative_to_root(new_output, root)
+    attributed.add(new_output)
     return GeneratedSnap(
         name=snap.name,
         **{"snapcraft-yaml": snap.snapcraft_yaml},
@@ -614,9 +647,12 @@ def artifacts_build(
     charms_to_build = _filter_by_name(plan.charms, charm_names, "charm")
     snaps_to_build = _filter_by_name(plan.snaps, snap_names, "snap")
 
-    gen_rocks = [_build_rock(r, root) for r in rocks_to_build]
-    gen_charms = [_build_charm(c, root) for c in charms_to_build]
-    gen_snaps = [_build_snap(s, root) for s in snaps_to_build]
+    # Track absolute output paths attributed to each artifact so far, to detect
+    # collisions when multiple artifacts share a pack-dir.
+    attributed: set[str] = set()
+    gen_rocks = [_build_rock(r, root, attributed) for r in rocks_to_build]
+    gen_charms = [_build_charm(c, root, attributed) for c in charms_to_build]
+    gen_snaps = [_build_snap(s, root, attributed) for s in snaps_to_build]
 
     # In GitHub Actions, rewrite outputs to CI-format references.
     ci = _get_ci_context()

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -357,21 +357,30 @@ def _parse_arch_from_snap_path(path: str) -> str | None:
 def _pick_new_charm_outputs(
     before: set[str], after: set[str], pack_dir: Path
 ) -> list[str]:
-    """Return all charm files produced by pack, relative paths TBD by caller.
+    """Return the charm files produced by this pack invocation.
 
     ``charmcraft pack`` always rebuilds **all** declared bases in a single
-    invocation, so the complete set of output files is always ``after``.
-    The ``before`` snapshot is only used to detect the error case where the
-    pack produced nothing.
+    invocation.  When multiple charms share the same pack_dir, files from a
+    previous charm build are already present in ``before``.  Using
+    ``after - before`` ensures we only attribute newly-produced files to this
+    charm rather than accumulating all charm files in the directory.
 
     Cases:
-    1. Files present after pack — return all of them (sorted for determinism).
-    2. No files at all — raise error.
+    1. New files appeared (``after - before`` non-empty) — return those.
+    2. No change (overwrite-in-place rebuild) — return all files in ``after``.
+       This handles the case where a charm is rebuilt and the same filenames
+       are overwritten.
+    3. No files at all after pack — raise error.
     """
     if not after:
         msg = f"No *.charm found in {pack_dir} after pack"
         raise OpcliError(msg)
 
+    new = after - before
+    if new:
+        return sorted(new)
+
+    # Overwrite-in-place: charmcraft rebuilt the same files (before == after).
     return sorted(after)
 
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -389,11 +389,11 @@ class TestArtifactsBuild:
         assert gen.rocks[0].output[0].file is not None
 
     def test_build_rock_pack_dir_real_file_raises(self, tmp_path: Path) -> None:
-        """A real rockcraft.yaml at pack-dir raises ConfigurationError."""
+        """A real rockcraft.yaml with different content at pack-dir raises."""
         rock_subdir = tmp_path / "rocks" / "myrock"
         rock_subdir.mkdir(parents=True)
         _write(rock_subdir / "rockcraft.yaml", "name: myrock\n")
-        # Real file at the pack-dir location (not a symlink)
+        # Real file at the pack-dir location with DIFFERENT content
         _write(tmp_path / "rockcraft.yaml", "name: other\n")
 
         _write(
@@ -409,6 +409,36 @@ class TestArtifactsBuild:
             pytest.raises(ConfigurationError, match="regular file already exists"),
         ):
             artifacts_build(tmp_path)
+
+    def test_build_rock_pack_dir_identical_real_file_ok(self, tmp_path: Path) -> None:
+        """A real rockcraft.yaml with identical content at pack-dir is allowed."""
+        content = "name: myrock\n"
+        rock_subdir = tmp_path / "rocks" / "myrock"
+        rock_subdir.mkdir(parents=True)
+        _write(rock_subdir / "rockcraft.yaml", content)
+        # Real file at the pack-dir location with identical content
+        _write(tmp_path / "rockcraft.yaml", content)
+        _write(tmp_path / "myrock_1.0_amd64.rock", "fake rock")
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "rocks:\n- name: myrock\n"
+            "  rockcraft-yaml: rocks/myrock/rockcraft.yaml\n"
+            "  pack-dir: .\n",
+        )
+
+        symlink_created: list[bool] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> None:
+            symlink_created.append((tmp_path / "rockcraft.yaml").is_symlink())
+
+        with patch("opcli.core.artifacts.run_command", side_effect=fake_run):
+            result = artifacts_build(tmp_path)
+
+        assert symlink_created == [False], "no symlink when content is identical"
+        gen = load_artifacts_generated(result)
+        assert gen.rocks[0].output[0].file is not None
 
     def test_build_rock_pack_dir_existing_symlink_replaced(
         self, tmp_path: Path
@@ -727,6 +757,67 @@ class TestArtifactsBuild:
         paths = {o.path for o in outputs}
         assert "./mycharm_ubuntu-22.04-amd64.charm" in paths
         assert "./mycharm_ubuntu-24.04-amd64.charm" in paths
+
+    def test_two_charms_same_output_filename_raises(self, tmp_path: Path) -> None:
+        """Two charms that produce the same output filename raise an error.
+
+        If both charmcraft yamls declare the same internal name (e.g. 'any-charm'),
+        charmcraft produces identically-named .charm files. The second build
+        overwrites the first and the attribution would be silently wrong.
+        opcli must detect this and raise rather than silently recording stale data.
+        """
+        _write(tmp_path / "charmcraft-a.yaml", "name: same-charm\n")
+        _write(tmp_path / "charmcraft-b.yaml", "name: same-charm\n")
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n"
+            "- name: charm-a\n  charmcraft-yaml: charmcraft-a.yaml\n"
+            "- name: charm-b\n  charmcraft-yaml: charmcraft-b.yaml\n",
+        )
+
+        call_count = [0]
+
+        def fake_run(cmd: list[str], **kwargs: object) -> None:
+            call_count[0] += 1
+            # Both builds produce the same filename (overwrite-in-place for #2)
+            _write(tmp_path / "same-charm_ubuntu-22.04-amd64.charm", "charm")
+
+        with (
+            patch("opcli.core.artifacts.run_command", side_effect=fake_run),
+            pytest.raises(OpcliError, match="already produced by another artifact"),
+        ):
+            artifacts_build(tmp_path)
+
+    def test_symlink_not_removed_if_replaced_by_real_file(self, tmp_path: Path) -> None:
+        """If pack replaces the symlink with a real file, cleanup does not delete it.
+
+        A crafting tool could theoretically create a real charmcraft.yaml during
+        the build (unlikely but possible). The cleanup must only remove symlinks,
+        not real files.
+        """
+        _write(tmp_path / "charmcraft-mycharm.yaml", "name: mycharm\n")
+        _write(tmp_path / "mycharm_ubuntu-22.04-amd64.charm", "fake charm")
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n- name: mycharm\n"
+            "  charmcraft-yaml: charmcraft-mycharm.yaml\n",
+        )
+
+        def fake_run(cmd: list[str], **kwargs: object) -> None:
+            # Simulate pack replacing the symlink with a real file
+            symlink = tmp_path / "charmcraft.yaml"
+            if symlink.is_symlink():
+                symlink.unlink()
+            _write(symlink, "name: mycharm\n")  # real file now
+
+        with patch("opcli.core.artifacts.run_command", side_effect=fake_run):
+            artifacts_build(tmp_path)
+
+        # Real file must still be there — cleanup must not have deleted it
+        assert (tmp_path / "charmcraft.yaml").exists()
+        assert not (tmp_path / "charmcraft.yaml").is_symlink()
 
 
 class TestArtifactsMatrix:

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -567,6 +567,36 @@ class TestArtifactsBuild:
             "symlink removed after build"
         )
 
+    def test_build_charm_real_charmcraft_yaml_same_content_ok(
+        self, tmp_path: Path
+    ) -> None:
+        """A real charmcraft.yaml with identical content to charmcraft-yaml is allowed.
+
+        This handles repos that keep both charmcraft.yaml and charmcraft-mycharm.yaml
+        as duplicate files.  Charmcraft will use the existing charmcraft.yaml and
+        produce the correct charm — no symlink is needed, no error raised.
+        """
+        content = "name: mycharm\n"
+        _write(tmp_path / "charmcraft-mycharm.yaml", content)
+        _write(tmp_path / "charmcraft.yaml", content)  # identical content
+        _write(tmp_path / "mycharm_ubuntu-22.04-amd64.charm", "fake charm")
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n- name: mycharm\n"
+            "  charmcraft-yaml: charmcraft-mycharm.yaml\n",
+        )
+
+        symlink_created: list[bool] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> None:
+            symlink_created.append((tmp_path / "charmcraft.yaml").is_symlink())
+
+        with patch("opcli.core.artifacts.run_command", side_effect=fake_run):
+            artifacts_build(tmp_path)
+
+        assert symlink_created == [False], "no symlink when content is identical"
+
     def test_build_charm_real_charmcraft_yaml_blocks_build(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -646,6 +646,58 @@ class TestArtifactsBuild:
             "no symlink should be created for standard name"
         )
 
+    def test_two_charms_same_pack_dir_no_cross_attribution(
+        self, tmp_path: Path
+    ) -> None:
+        """Two charms in the same pack-dir only claim their own output files.
+
+        When charms share pack-dir (e.g. both yamls are in the repo root), the
+        second charm's build must not inherit the first charm's .charm files.
+        """
+        charm1_content = "name: charm-a\n"
+        charm2_content = "name: charm-b\n"
+        _write(tmp_path / "charmcraft-a.yaml", charm1_content)
+        _write(tmp_path / "charmcraft-b.yaml", charm2_content)
+
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\ncharms:\n"
+            "- name: charm-a\n  charmcraft-yaml: charmcraft-a.yaml\n"
+            "- name: charm-b\n  charmcraft-yaml: charmcraft-b.yaml\n",
+        )
+
+        call_count = [0]
+
+        def fake_run(cmd: list[str], **kwargs: object) -> None:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First charm pack produces charm-a files
+                _write(tmp_path / "charm-a_ubuntu-22.04-amd64.charm", "a1")
+                _write(tmp_path / "charm-a_ubuntu-24.04-amd64.charm", "a2")
+            else:
+                # Second charm pack produces charm-b files
+                _write(tmp_path / "charm-b_ubuntu-22.04-amd64.charm", "b1")
+                _write(tmp_path / "charm-b_ubuntu-24.04-amd64.charm", "b2")
+
+        with patch("opcli.core.artifacts.run_command", side_effect=fake_run):
+            result = artifacts_build(tmp_path)
+
+        gen = load_artifacts_generated(result)
+        charm_a = next(c for c in gen.charms if c.name == "charm-a")
+        charm_b = next(c for c in gen.charms if c.name == "charm-b")
+
+        a_paths = {o.path for o in charm_a.output}
+        b_paths = {o.path for o in charm_b.output}
+
+        assert a_paths == {
+            "./charm-a_ubuntu-22.04-amd64.charm",
+            "./charm-a_ubuntu-24.04-amd64.charm",
+        }, "charm-a must only claim its own output files"
+        assert b_paths == {
+            "./charm-b_ubuntu-22.04-amd64.charm",
+            "./charm-b_ubuntu-24.04-amd64.charm",
+        }, "charm-b must not inherit charm-a files"
+
     def test_pick_new_charm_output_overwrite_in_place_multi(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
When a repo keeps both `charmcraft.yaml` and a non-standard-named yaml (e.g. `charmcraft-any-charm.yaml`) as duplicate files with identical content, the previous check raised `ConfigurationError` by comparing file paths alone.

**Fix:** if a real `charmcraft.yaml` exists in pack-dir and its byte content is identical to the declared `charmcraft-yaml`, skip symlink creation and proceed — charmcraft will use the existing file and produce the right charm.

A real `charmcraft.yaml` with *different* content still raises, preventing silent wrong-charm builds.