### PR TITLE
fix: spread tasks uses spread -list instead of parsing MODULE env vars

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -75,6 +75,12 @@ jobs:
             uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ steps.workflow-version.outputs.sha }}"
           fi
 
+      - name: Install spread
+        run: |
+          sudo snap install go --classic
+          go install github.com/canonical/spread/cmd/spread@latest
+          sudo ln -sf ~/go/bin/spread /usr/local/bin/spread
+
       - name: Generate spread task matrix
         id: tasks
         run: |

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -812,153 +812,112 @@ def _arch_from_runner(runner_json: str) -> str:
     return "amd64"
 
 
-def _runner_by_system(raw: dict[str, object]) -> dict[str, str]:
-    """Extract {system_name: runner_label_json} from the raw spread.yaml.
+def _virtual_runner_map(
+    raw: dict[str, object],
+) -> tuple[dict[str, str], list[str]]:
+    """Extract runner labels and CI backend names from virtual backends only.
 
-    The runner value is always JSON-encoded so that the workflow can use
-    ``fromJSON(matrix.runs-on)`` for both plain strings and runner arrays.
+    Reads only the virtual backend sections (those whose ``type:`` is a
+    recognised virtual type).  The ``runner:`` field is opcli-owned and is
+    stripped before spread ever sees the YAML.
+
+    Returns:
+        Tuple of:
+        - system_runner_map: ``{system_name: runner_json}`` built from virtual
+          backend system entries.  The runner value is JSON-encoded so that
+          the workflow can use ``fromJSON(matrix.runs-on)``.
+        - ci_backend_names: concrete CI names derived from the virtual backend
+          names (e.g. ``["integration-test-ci"]``).
     """
-    result: dict[str, str] = {}
+    runner_map: dict[str, str] = {}
+    ci_names: list[str] = []
     raw_backends = raw.get("backends") or {}
     if not isinstance(raw_backends, dict):
-        return result
-    for backend_cfg in raw_backends.values():
+        return runner_map, ci_names
+    for backend_name, backend_cfg in raw_backends.items():
         if not isinstance(backend_cfg, dict):
             continue
+        raw_type = backend_cfg.get("type")
+        backend_type = raw_type if isinstance(raw_type, str) else backend_name
+        if backend_type not in _BACKEND_CONFIGS:
+            continue
+        ci_names.append(f"{backend_name}-ci")
         for system_entry in backend_cfg.get("systems") or []:
             if isinstance(system_entry, str):
-                result.setdefault(system_entry, json.dumps(_DEFAULT_RUNNER))
+                runner_map.setdefault(system_entry, json.dumps(_DEFAULT_RUNNER))
             elif isinstance(system_entry, dict):
                 for sys_name, sys_props in system_entry.items():
                     raw_runner: object = _DEFAULT_RUNNER
                     if isinstance(sys_props, dict):
                         raw_runner = sys_props.get("runner", _DEFAULT_RUNNER)
-                    result.setdefault(sys_name, json.dumps(raw_runner))
-    return result
-
-
-def _task_dirs(root: Path, suite_dir: str) -> list[str]:
-    """Return sorted task directory names (dirs with task.yaml) inside *suite_dir*."""
-    suite_abs = root / suite_dir
-    if not suite_abs.is_dir():
-        return []
-    return sorted(
-        d.name for d in suite_abs.iterdir() if d.is_dir() and (d / "task.yaml").exists()
-    )
-
-
-def _system_entry_name(entry: object) -> str | None:
-    """Extract the system name from a spread systems-list entry."""
-    if isinstance(entry, str):
-        return entry
-    if isinstance(entry, dict):
-        key = next(iter(entry))
-        return str(key)
-    return None
+                    runner_map.setdefault(str(sys_name), json.dumps(raw_runner))
+    return runner_map, ci_names
 
 
 def spread_tasks(root: Path) -> list[dict[str, str]]:
     """Return all CI spread task selectors as a list of GitHub Actions matrix entries.
 
-    Reads the raw ``spread.yaml`` to extract per-system ``runner`` labels
-    (GitHub Actions runner selectors), then expands with CI mode to derive
-    the concrete backend name and system names.
+    Calls ``spread -list`` on the expanded (CI-mode) ``spread.yaml``, restricted
+    to virtual backends (``integration-test``, ``tutorial``).  Non-virtual
+    spread-native backends are excluded.
 
     Each entry has:
-    - ``name``: display name (variant name, or task directory if no variant)
-    - ``selector``: full spread selector (``backend:system:task/path:variant``)
-    - ``runs-on``: GitHub Actions runner label (from ``runner:`` system field,
-      or ``ubuntu-latest`` if absent)
 
-    Only enumerates ``MODULE/*`` variants.  For non-standard suite structures
-    use ``spread -list`` directly.
+    - ``name``: display name — the variant component of the selector if present,
+      otherwise the last path component of the task path.
+    - ``selector``: full spread selector as returned by ``spread -list``.
+    - ``runs-on``: GitHub Actions runner label (JSON-encoded, from the
+      ``runner:`` field on the system entry, or ``"ubuntu-latest"`` if absent).
+    - ``arch``: architecture string derived from the runner label.
 
     Raises:
-        ConfigurationError: If ``spread.yaml`` is missing or malformed.
+        ConfigurationError: If ``spread.yaml`` is missing, malformed, or
+            contains no virtual backend.
+        SubprocessError: If ``spread -list`` fails.
     """
     raw = _load_spread_yaml(root)
-    expanded = _expand_backend(raw, ci=True)
+    runner_map, ci_backend_names = _virtual_runner_map(raw)
 
-    runner_map = _runner_by_system(raw)
-    raw_suites = expanded.get("suites") or {}
-    raw_all_backends = expanded.get("backends") or {}
-    suites: dict[str, object] = raw_suites if isinstance(raw_suites, dict) else {}
-    all_backends: dict[str, object] = (
-        raw_all_backends if isinstance(raw_all_backends, dict) else {}
-    )
+    # _expand_backend raises ConfigurationError when no virtual backends are found.
+    expanded = _expand_backend(raw, ci=True)
+    expanded["reroot"] = _compose_reroot(expanded.get("reroot"))
 
     entries: list[dict[str, str]] = []
-    for suite_path, suite_cfg in suites.items():
-        if not isinstance(suite_cfg, dict):
-            continue
-        suite_dir = suite_path.rstrip("/")
+    with tempfile.TemporaryDirectory(prefix=".spread-tasks-", dir=root) as tmp_dir:
+        tmp_yaml = Path(tmp_dir) / _SPREAD_YAML
+        with tmp_yaml.open("w") as fh:
+            _yaml.dump(_literalize(expanded), fh)
 
-        suite_backend_names: list[str] = []
-        raw_suite_backends = suite_cfg.get("backends")
-        if isinstance(raw_suite_backends, list):
-            suite_backend_names = [str(b) for b in raw_suite_backends]
-        else:
-            suite_backend_names = list(all_backends.keys())
-
-        env = suite_cfg.get("environment") or {}
-        variants: list[str | None] = [
-            str(v) for k, v in env.items() if str(k).startswith("MODULE/")
-        ]
-        if not variants:
-            variants = [None]
-
-        dirs = _task_dirs(root, suite_dir)
-        if not dirs:
-            continue
-
-        entries.extend(
-            _collect_suite_entries(
-                suite_dir,
-                dirs,
-                variants,
-                suite_backend_names,
-                all_backends,
-                runner_map,
-            )
+        selectors = [f"{name}:" for name in ci_backend_names]
+        result = run_command(
+            ["spread", "-list", *selectors],
+            cwd=tmp_dir,
+            stream=False,
         )
 
-    return entries
-
-
-def _collect_suite_entries(  # noqa: PLR0913
-    suite_dir: str,
-    dirs: list[str],
-    variants: list[str | None],
-    backend_names: list[str],
-    all_backends: dict[str, object],
-    runner_map: dict[str, str],
-) -> list[dict[str, str]]:
-    """Return matrix entries for one suite."""
-    entries: list[dict[str, str]] = []
-    for backend_name in backend_names:
-        backend_cfg = all_backends.get(backend_name)
-        if not isinstance(backend_cfg, dict):
-            continue
-        for system_entry in backend_cfg.get("systems") or []:
-            system_name = _system_entry_name(system_entry)
-            if system_name is None:
+        for raw_line in result.stdout.splitlines():
+            line = raw_line.strip()
+            if not line:
                 continue
-            runner = runner_map.get(system_name, json.dumps(_DEFAULT_RUNNER))
-            for task_dir in dirs:
-                task_path = f"{suite_dir}/{task_dir}"
-                for variant in variants:
-                    if variant:
-                        selector = f"{backend_name}:{system_name}:{task_path}:{variant}"
-                        name = variant
-                    else:
-                        selector = f"{backend_name}:{system_name}:{task_path}"
-                        name = task_dir
-                    entries.append(
-                        {
-                            "name": name,
-                            "selector": selector,
-                            "runs-on": runner,
-                            "arch": _arch_from_runner(runner),
-                        }
-                    )
+            parts = line.split(":")
+            _MIN_PARTS = 3
+            _VARIANT_PARTS = 4
+            if len(parts) < _MIN_PARTS:
+                continue
+            system = parts[1]
+            runner = runner_map.get(system, json.dumps(_DEFAULT_RUNNER))
+            name = (
+                parts[-1]
+                if len(parts) >= _VARIANT_PARTS
+                else parts[2].rsplit("/", 1)[-1]
+            )
+            entries.append(
+                {
+                    "name": name,
+                    "selector": line,
+                    "runs-on": runner,
+                    "arch": _arch_from_runner(runner),
+                }
+            )
+
     return entries

--- a/src/opcli/core/subprocess.py
+++ b/src/opcli/core/subprocess.py
@@ -116,11 +116,11 @@ def run_command(  # noqa: PLR0913
     )
 
 
-def _log_command(cmd: list[str], cwd: str | None) -> None:
+def _log_command(cmd: list[str], cwd: str | None, *, err: bool = False) -> None:
     """Print the command and working directory for reproducibility."""
-    typer.echo(f"$ {shlex.join(cmd)}")
+    typer.echo(f"$ {shlex.join(cmd)}", err=err)
     if cwd:
-        typer.echo(f"  cwd: {cwd}")
+        typer.echo(f"  cwd: {cwd}", err=err)
 
 
 def _run_interactive(
@@ -258,7 +258,7 @@ def _run_captured(  # noqa: PLR0913
     env: dict[str, str] | None = None,
 ) -> SubprocessResult:
     """Run *cmd* with fully buffered output (no terminal echo)."""
-    _log_command(cmd, cwd)
+    _log_command(cmd, cwd, err=True)
     try:
         proc = subprocess.run(
             cmd,

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -183,9 +183,11 @@ class TestSubprocessWrapper:
 
             run_command(["echo", "hello"], stream=False)
 
-        captured = capsys.readouterr().out
-        assert "$ echo hello" in captured
-        assert "cwd:" not in captured
+        captured = capsys.readouterr()
+        # Captured mode logs to stderr so stdout stays clean for programmatic use
+        assert "$ echo hello" in captured.err
+        assert "$ echo hello" not in captured.out
+        assert "cwd:" not in captured.err
 
     # --- Interactive mode ---
 

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -13,12 +13,13 @@ from ruamel.yaml import YAML
 from opcli.core.exceptions import ConfigurationError, SubprocessError, ValidationError
 from opcli.core.spread import (
     _arch_from_runner,
-    _runner_by_system,
+    _virtual_runner_map,
     spread_expand,
     spread_init,
     spread_run,
     spread_tasks,
 )
+from opcli.core.subprocess import SubprocessResult
 
 _yaml = YAML()
 
@@ -1199,31 +1200,58 @@ suites:
 """
 
 
-class TestRunnerBySystem:
-    """Tests for _runner_by_system()."""
+class TestVirtualRunnerMap:
+    """Tests for _virtual_runner_map()."""
 
     def test_string_runner_label(self) -> None:
         """Runner string label is JSON-encoded in result."""
         raw = _yaml.load(StringIO(_SPREAD_WITH_RUNNER))
-        result = _runner_by_system(raw)
-        assert result["ubuntu-22.04"] == '"ubuntu-22.04-runner"'
+        runner_map, _ = _virtual_runner_map(raw)
+        assert runner_map["ubuntu-22.04"] == '"ubuntu-22.04-runner"'
 
     def test_list_runner_label(self) -> None:
         """Runner list is JSON-encoded when system uses a list."""
         raw = _yaml.load(StringIO(_SPREAD_WITH_RUNNER))
-        result = _runner_by_system(raw)
-        assert result["ubuntu-24.04"] == json.dumps(["self-hosted", "ubuntu-24.04"])
+        runner_map, _ = _virtual_runner_map(raw)
+        assert runner_map["ubuntu-24.04"] == json.dumps(["self-hosted", "ubuntu-24.04"])
 
     def test_no_runner_defaults_to_ubuntu_latest(self) -> None:
         """Systems without runner: default to JSON-encoded ubuntu-latest."""
         raw = _yaml.load(StringIO(_SPREAD_NO_RUNNER))
-        result = _runner_by_system(raw)
-        assert result.get("ubuntu-24.04") == '"ubuntu-latest"'
+        runner_map, _ = _virtual_runner_map(raw)
+        assert runner_map.get("ubuntu-24.04") == '"ubuntu-latest"'
 
     def test_empty_backends(self) -> None:
-        """No backends → empty result."""
-        result = _runner_by_system({})
-        assert result == {}
+        """No backends → empty runner map and no CI names."""
+        runner_map, ci_names = _virtual_runner_map({})
+        assert runner_map == {}
+        assert ci_names == []
+
+    def test_ci_backend_names_derived(self) -> None:
+        """CI backend names are {virtual_name}-ci for each virtual backend."""
+        raw = _yaml.load(StringIO(_SPREAD_WITH_RUNNER))
+        _, ci_names = _virtual_runner_map(raw)
+        assert ci_names == ["integration-test-ci"]
+
+    def test_non_virtual_backend_ignored(self) -> None:
+        """Backends without a recognised virtual type are excluded."""
+        raw = _yaml.load(
+            StringIO("""\
+backends:
+  integration-test:
+    type: integration-test
+    systems:
+      - ubuntu-24.04
+  lxd:
+    systems:
+      - ubuntu-22.04:
+          runner: some-runner
+""")
+        )
+        runner_map, ci_names = _virtual_runner_map(raw)
+        assert "ubuntu-24.04" in runner_map
+        assert "ubuntu-22.04" not in runner_map
+        assert ci_names == ["integration-test-ci"]
 
 
 class TestArchFromRunner:
@@ -1248,67 +1276,72 @@ class TestArchFromRunner:
 class TestSpreadTasks:
     """Tests for spread_tasks()."""
 
-    def _make_task_dir(self, root: Path, path: str) -> None:
-        task_path = root / path / "task.yaml"
-        task_path.parent.mkdir(parents=True, exist_ok=True)
-        task_path.write_text("summary: test task\n")
+    _SPREAD_LIST_TWO_VARIANTS = (
+        "integration-test-ci:ubuntu-22.04:tests/integration/run:test_charm\n"
+        "integration-test-ci:ubuntu-22.04:tests/integration/run:test_other\n"
+        "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm\n"
+        "integration-test-ci:ubuntu-24.04:tests/integration/run:test_other\n"
+    )
+    _SPREAD_LIST_ONE_VARIANT = (
+        "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm\n"
+    )
+    _SPREAD_LIST_NO_VARIANT = "integration-test-ci:ubuntu-24.04:tests/integration/run\n"
+
+    def _mock_list(self, stdout: str) -> SubprocessResult:
+        return SubprocessResult(stdout=stdout, stderr="", returncode=0)
 
     def test_returns_selectors_for_each_variant(self, tmp_path: Path) -> None:
         """Returns one entry per (system, task_dir, variant) combination."""
         _write(tmp_path / "spread.yaml", _SPREAD_WITH_RUNNER)
-        self._make_task_dir(tmp_path, "tests/integration/run")
 
-        entries = spread_tasks(tmp_path)
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(self._SPREAD_LIST_TWO_VARIANTS),
+        ):
+            entries = spread_tasks(tmp_path)
 
         names = [e["name"] for e in entries]
         assert "test_charm" in names
         assert "test_other" in names
 
     def test_selector_format(self, tmp_path: Path) -> None:
-        """Selector includes backend:system:suite/task:variant."""
+        """Selector is taken verbatim from spread -list output."""
         _write(tmp_path / "spread.yaml", _SPREAD_NO_RUNNER)
-        self._make_task_dir(tmp_path, "tests/integration/run")
+        raw_selector = (
+            "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm"
+        )
 
-        entries = spread_tasks(tmp_path)
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(raw_selector + "\n"),
+        ):
+            entries = spread_tasks(tmp_path)
 
         assert len(entries) == 1
-        entry = entries[0]
-        assert entry["selector"].startswith("integration-test-ci:")
-        assert "ubuntu-24.04" in entry["selector"]
-        assert ":test_charm" in entry["selector"]
+        assert entries[0]["selector"] == raw_selector
 
     def test_runs_on_from_runner_field(self, tmp_path: Path) -> None:
         """runs-on matches the system's runner: label (JSON-encoded)."""
         _write(tmp_path / "spread.yaml", _SPREAD_WITH_RUNNER)
-        self._make_task_dir(tmp_path, "tests/integration/run")
 
-        entries = spread_tasks(tmp_path)
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(self._SPREAD_LIST_TWO_VARIANTS),
+        ):
+            entries = spread_tasks(tmp_path)
 
         ubuntu_22_entries = [e for e in entries if "ubuntu-22.04" in e["selector"]]
         assert all(e["runs-on"] == '"ubuntu-22.04-runner"' for e in ubuntu_22_entries)
 
-    def test_no_variants_uses_task_dir_name(self, tmp_path: Path) -> None:
-        """When no MODULE/ variants, name is the task directory name."""
-        spread_no_variants = """\
-project: test-project
-path: /home/ubuntu/proj
-backends:
-  integration-test:
-    type: integration-test
-    systems:
-      - ubuntu-24.04
-environment:
-  CONCIERGE: concierge.yaml
-suites:
-  tests/integration/:
-    summary: integration tests
-    backends:
-      - integration-test
-"""
-        _write(tmp_path / "spread.yaml", spread_no_variants)
-        self._make_task_dir(tmp_path, "tests/integration/run")
+    def test_no_variants_uses_last_path_component(self, tmp_path: Path) -> None:
+        """When spread -list returns no variant, name is the last path component."""
+        _write(tmp_path / "spread.yaml", _SPREAD_NO_RUNNER)
 
-        entries = spread_tasks(tmp_path)
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(self._SPREAD_LIST_NO_VARIANT),
+        ):
+            entries = spread_tasks(tmp_path)
 
         assert len(entries) == 1
         assert entries[0]["name"] == "run"
@@ -1317,6 +1350,52 @@ suites:
         """Raises ConfigurationError when spread.yaml is missing."""
         with pytest.raises(ConfigurationError):
             spread_tasks(tmp_path)
+
+    def test_spread_list_called_with_ci_backend_selectors(self, tmp_path: Path) -> None:
+        """spread -list is invoked with one selector per virtual backend."""
+        _write(tmp_path / "spread.yaml", _SPREAD_NO_RUNNER)
+
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(self._SPREAD_LIST_ONE_VARIANT),
+        ) as mock_run:
+            spread_tasks(tmp_path)
+
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "spread"
+        assert cmd[1] == "-list"
+        assert "integration-test-ci:" in cmd
+
+    def test_spread_list_excludes_non_virtual_backends(self, tmp_path: Path) -> None:
+        """Non-virtual backends are not passed as selectors to spread -list."""
+        spread_mixed = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    type: integration-test
+    systems:
+      - ubuntu-24.04
+  lxd:
+    systems:
+      - ubuntu-22.04
+suites:
+  tests/integration/:
+    summary: integration tests
+    backends:
+      - integration-test
+"""
+        _write(tmp_path / "spread.yaml", spread_mixed)
+
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(self._SPREAD_LIST_ONE_VARIANT),
+        ) as mock_run:
+            spread_tasks(tmp_path)
+
+        cmd = mock_run.call_args[0][0]
+        assert "integration-test-ci:" in cmd
+        assert not any("lxd" in arg for arg in cmd)
 
     def test_ci_backend_has_username_root(self, tmp_path: Path) -> None:
         """Expanded CI backend sets username: root per system for SSH."""
@@ -1354,9 +1433,12 @@ suites:
     def test_arch_field_amd64_default(self, tmp_path: Path) -> None:
         """Entries without arm64 runner label get arch=amd64."""
         _write(tmp_path / "spread.yaml", _SPREAD_NO_RUNNER)
-        self._make_task_dir(tmp_path, "tests/integration/run")
 
-        entries = spread_tasks(tmp_path)
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(self._SPREAD_LIST_ONE_VARIANT),
+        ):
+            entries = spread_tasks(tmp_path)
 
         assert all(e["arch"] == "amd64" for e in entries)
 
@@ -1376,12 +1458,50 @@ suites:
     summary: integration tests
     backends:
       - integration-test
-    environment:
-      MODULE/test_charm: test_charm
 """
         _write(tmp_path / "spread.yaml", spread_arm)
-        self._make_task_dir(tmp_path, "tests/integration/run")
 
-        entries = spread_tasks(tmp_path)
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(
+                "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm\n"
+            ),
+        ):
+            entries = spread_tasks(tmp_path)
 
         assert all(e["arch"] == "arm64" for e in entries)
+
+    def test_duplicate_variant_keys_produce_distinct_selectors(
+        self, tmp_path: Path
+    ) -> None:
+        """Key != value in MODULE/* produces distinct selectors (the original bug)."""
+        _write(tmp_path / "spread.yaml", _SPREAD_NO_RUNNER)
+        list_output = (
+            "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm\n"
+            "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm_k8s\n"
+        )
+
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(list_output),
+        ):
+            entries = spread_tasks(tmp_path)
+
+        selectors = [e["selector"] for e in entries]
+        names = [e["name"] for e in entries]
+        assert len(set(selectors)) == len(entries)
+        assert "test_charm" in names
+        assert "test_charm_k8s" in names
+
+    def test_temp_dir_cleaned_up_after_tasks(self, tmp_path: Path) -> None:
+        """Temporary spread.yaml directory is removed after spread_tasks returns."""
+        _write(tmp_path / "spread.yaml", _SPREAD_NO_RUNNER)
+
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(self._SPREAD_LIST_ONE_VARIANT),
+        ):
+            spread_tasks(tmp_path)
+
+        leftover = list(tmp_path.glob(".spread-tasks-*"))
+        assert leftover == []


### PR DESCRIPTION
Fixes #109.

## Problem
`spread_tasks()` was parsing `MODULE/*` **values** from `spread.yaml` suites to build CI matrix selectors. Since spread resolves variants by **key** name (the part after `MODULE/`), any config where key ≠ value (e.g. two variants pointing to the same test module) produced duplicate or wrong selectors.

## Solution
Replace all suite/env/MODULE parsing with a call to `spread -list`, filtered to virtual backends only. Selectors are taken verbatim from spread's own output.

## Changes
- `_runner_by_system()` → `_virtual_runner_map()`: reads only virtual backend sections and also returns the concrete CI backend names
- Removed `_task_dirs()`, `_system_entry_name()`, `_collect_suite_entries()`
- `spread_tasks()` now writes expanded YAML to a temp dir (same pattern as `spread_run`) and calls `spread -list <backend>:` for each virtual backend
- Tests updated to mock `run_command` with realistic `spread -list` output; added regression test for the key ≠ value case