### PR TITLE
Fail fast when Collect artifacts job is skipped or failed

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -1145,6 +1145,58 @@ _AUTH_ERROR_KEYWORDS = (
 # Keywords that indicate the destination file already exists; we delete it and retry.
 _FILE_EXISTS_KEYWORDS = ("file exists",)
 
+# Job name (or substring) that uploads the merged artifacts-generated artifact.
+# In reusable-workflow runs the API prefixes this with the caller job name
+# (e.g. "build / Collect artifacts"), so we use a substring match.
+_COLLECT_JOB_NAME = "Collect artifacts"
+
+# Conclusions that mean the artifact will never arrive — bail immediately.
+_BAIL_CONCLUSIONS: frozenset[str] = frozenset({"skipped", "failure", "cancelled"})
+
+
+def _check_collect_job_conclusion(run_id: str, repo: str) -> str | None:
+    """Return the conclusion of the ``Collect artifacts`` job, or ``None``.
+
+    Queries ``gh run view --json jobs`` and searches for any job whose name
+    contains :data:`_COLLECT_JOB_NAME` (a substring match handles the
+    ``"build / Collect artifacts"`` prefix that GitHub prepends in
+    reusable-workflow runs).
+
+    Returns the conclusion string (e.g. ``"success"``, ``"skipped"``,
+    ``"failure"``, ``"cancelled"``) when found and the job has finished, or
+    ``None`` when the job is still running (``conclusion`` is ``null``), the
+    job is not yet listed, or the API call fails for any reason.  The caller
+    should treat ``None`` as "don't know yet — keep retrying".
+    """
+    try:
+        result = run_command(
+            ["gh", "run", "view", run_id, "--repo", repo, "--json", "jobs"],
+            stream=False,
+        )
+    except Exception:
+        return None
+
+    try:
+        data: object = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(data, dict):
+        return None
+    jobs = data.get("jobs")
+    if not isinstance(jobs, list):
+        return None
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        name = job.get("name")
+        if not isinstance(name, str):
+            continue
+        if _COLLECT_JOB_NAME in name:
+            conclusion = job.get("conclusion")
+            return conclusion if isinstance(conclusion, str) else None
+    return None
+
 
 def _gh_download(cmd: list[str], cwd: str, dest: Path | None = None) -> None:
     """Run ``gh run download``, raising :class:`SubprocessError` on failure.
@@ -1166,26 +1218,31 @@ def _gh_download(cmd: list[str], cwd: str, dest: Path | None = None) -> None:
 
 
 def _gh_download_with_wait(
-    cmd: list[str], cwd: str, run_id: str, dest: Path | None = None
+    cmd: list[str], cwd: str, run_id: str, repo: str, dest: Path | None = None
 ) -> None:
     """Run ``gh run download``, retrying until the artifact appears.
 
     Retries up to :data:`_WAIT_MAX_ATTEMPTS` times with
     :data:`_WAIT_SLEEP_SECONDS` between each attempt.  Fails immediately if
-    the error looks like an authentication/permission problem or a
-    deterministic failure (e.g. "file exists", handled via delete-and-retry).
+    the error looks like an authentication/permission problem, a deterministic
+    failure (e.g. "file exists", handled via delete-and-retry), or if the
+    ``Collect artifacts`` job is known to have been skipped, failed, or
+    cancelled (meaning the artifact will never arrive).
 
     Args:
         cmd: Full ``gh run download ...`` command list.
         cwd: Working directory for the subprocess.
-        run_id: Run ID used only for log messages.
+        run_id: GitHub Actions run ID.
+        repo: GitHub repository in ``owner/name`` format, used to query job
+            status on each retry.
         dest: Path of the expected output file.  When provided and ``gh``
             reports "file exists", the file is deleted and the download is
             retried once before giving up.
 
     Raises:
-        ConfigurationError: On auth/permission errors or when the timeout
-            is exceeded (includes the last error message).
+        ConfigurationError: On auth/permission errors, when the
+            ``Collect artifacts`` job has a terminal failure conclusion, or
+            when the timeout is exceeded (includes the last error message).
         SubprocessError: Propagated for unexpected non-retryable failures.
     """
     last_exc: SubprocessError | None = None
@@ -1209,6 +1266,14 @@ def _gh_download_with_wait(
                 run_command(cmd, cwd=cwd)
                 return
             last_exc = exc
+            conclusion = _check_collect_job_conclusion(run_id, repo)
+            if conclusion in _BAIL_CONCLUSIONS:
+                msg = (
+                    f"Build artifacts were not collected — the "
+                    f"'{_COLLECT_JOB_NAME}' job {conclusion}. "
+                    f"Check the build job logs."
+                )
+                raise ConfigurationError(msg) from exc
             logger.info(
                 "Artifact not yet available (attempt %d/%d): %s — retrying in %ds...",
                 attempt,
@@ -1284,7 +1349,7 @@ def artifacts_fetch(
     ]
     gen_path = root / _ARTIFACTS_GENERATED_YAML
     if wait:
-        _gh_download_with_wait(generated_cmd, str(root), run_id, dest=gen_path)
+        _gh_download_with_wait(generated_cmd, str(root), run_id, repo, dest=gen_path)
     else:
         _gh_download(generated_cmd, str(root), dest=gen_path)
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -1664,6 +1664,9 @@ class TestArtifactsFetch:
         results = [not_ready, gh, gh, gh, gh]
         with (
             patch("opcli.core.artifacts.run_command", side_effect=results),
+            patch(
+                "opcli.core.artifacts._check_collect_job_conclusion", return_value=None
+            ),
             patch("opcli.core.artifacts.time.sleep"),
         ):
             artifacts_fetch(
@@ -1782,6 +1785,10 @@ class TestArtifactsFetch:
             _artifacts_mod._WAIT_MAX_ATTEMPTS = 2  # speed up the test
             with (
                 patch("opcli.core.artifacts.run_command", side_effect=not_ready),
+                patch(
+                    "opcli.core.artifacts._check_collect_job_conclusion",
+                    return_value=None,
+                ),
                 patch("opcli.core.artifacts.time.sleep"),
                 pytest.raises(ConfigurationError, match="Timed out"),
             ):
@@ -1790,3 +1797,122 @@ class TestArtifactsFetch:
                 )
         finally:
             _artifacts_mod._WAIT_MAX_ATTEMPTS = _orig
+
+    @pytest.mark.parametrize("conclusion", ["skipped", "failure", "cancelled"])
+    def test_wait_fails_fast_on_terminal_collect_conclusion(
+        self, tmp_path: Path, conclusion: str
+    ) -> None:
+        """With wait=True, bails immediately on a terminal collect job conclusion."""
+        not_ready = SubprocessError(["gh"], 1, "artifact not found")
+        with (
+            patch("opcli.core.artifacts.run_command", side_effect=not_ready),
+            patch(
+                "opcli.core.artifacts._check_collect_job_conclusion",
+                return_value=conclusion,
+            ),
+            patch("opcli.core.artifacts.time.sleep") as mock_sleep,
+            pytest.raises(ConfigurationError, match=conclusion),
+        ):
+            artifacts_fetch(
+                tmp_path, run_id="99887766", repo="owner/my-repo", wait=True
+            )
+
+        mock_sleep.assert_not_called()
+
+    def test_wait_continues_when_collect_job_still_running(
+        self, tmp_path: Path
+    ) -> None:
+        """With wait=True, keeps retrying when collect job conclusion is None."""
+        _write(tmp_path / "artifacts-generated.yaml", self._GENERATED_CI)
+        self._make_charm_files(tmp_path)
+        self._make_snap_files(tmp_path)
+
+        not_ready = SubprocessError(["gh"], 1, "artifact not found")
+        gh = self._GH_RESULT
+        with (
+            patch(
+                "opcli.core.artifacts.run_command",
+                side_effect=[not_ready, gh, gh, gh, gh],
+            ),
+            patch(
+                "opcli.core.artifacts._check_collect_job_conclusion",
+                return_value=None,
+            ),
+            patch("opcli.core.artifacts.time.sleep"),
+        ):
+            artifacts_fetch(
+                tmp_path, run_id="99887766", repo="owner/my-repo", wait=True
+            )
+
+
+class TestCheckCollectJobConclusion:
+    """Unit tests for _check_collect_job_conclusion."""
+
+    _GH_JOBS_RESPONSE = json.dumps(
+        {
+            "jobs": [
+                {"name": "Build charm my-charm (amd64)", "conclusion": "success"},
+                {"name": "Collect artifacts", "conclusion": "skipped"},
+            ]
+        }
+    )
+
+    def _gh_result(self, stdout: str) -> SubprocessResult:
+        return SubprocessResult(stdout=stdout, stderr="", returncode=0)
+
+    def test_returns_conclusion_when_job_found(self) -> None:
+        result = SubprocessResult(
+            stdout=self._GH_JOBS_RESPONSE, stderr="", returncode=0
+        )
+        with patch("opcli.core.artifacts.run_command", return_value=result):
+            conclusion = _artifacts_mod._check_collect_job_conclusion(
+                "123", "owner/repo"
+            )
+        assert conclusion == "skipped"
+
+    def test_matches_with_reusable_workflow_prefix(self) -> None:
+        """Job name 'build / Collect artifacts' is matched as a substring."""
+        data = json.dumps(
+            {"jobs": [{"name": "build / Collect artifacts", "conclusion": "failure"}]}
+        )
+        result = SubprocessResult(stdout=data, stderr="", returncode=0)
+        with patch("opcli.core.artifacts.run_command", return_value=result):
+            conclusion = _artifacts_mod._check_collect_job_conclusion(
+                "123", "owner/repo"
+            )
+        assert conclusion == "failure"
+
+    def test_returns_none_when_job_not_found(self) -> None:
+        data = json.dumps({"jobs": [{"name": "Build charm", "conclusion": "success"}]})
+        result = SubprocessResult(stdout=data, stderr="", returncode=0)
+        with patch("opcli.core.artifacts.run_command", return_value=result):
+            conclusion = _artifacts_mod._check_collect_job_conclusion(
+                "123", "owner/repo"
+            )
+        assert conclusion is None
+
+    def test_returns_none_when_conclusion_is_null(self) -> None:
+        """Job still running — conclusion is null in JSON."""
+        data = json.dumps({"jobs": [{"name": "Collect artifacts", "conclusion": None}]})
+        result = SubprocessResult(stdout=data, stderr="", returncode=0)
+        with patch("opcli.core.artifacts.run_command", return_value=result):
+            conclusion = _artifacts_mod._check_collect_job_conclusion(
+                "123", "owner/repo"
+            )
+        assert conclusion is None
+
+    def test_returns_none_when_gh_command_fails(self) -> None:
+        error = SubprocessError(["gh"], 1, "API error")
+        with patch("opcli.core.artifacts.run_command", side_effect=error):
+            conclusion = _artifacts_mod._check_collect_job_conclusion(
+                "123", "owner/repo"
+            )
+        assert conclusion is None
+
+    def test_returns_none_on_invalid_json(self) -> None:
+        result = SubprocessResult(stdout="not-json", stderr="", returncode=0)
+        with patch("opcli.core.artifacts.run_command", return_value=result):
+            conclusion = _artifacts_mod._check_collect_job_conclusion(
+                "123", "owner/repo"
+            )
+        assert conclusion is None


### PR DESCRIPTION
Fixes #111.

## Changes

On each retry in `_gh_download_with_wait`, after a failed `gh run download`, the conclusion of the **'Collect artifacts'** job is now checked via `gh run view --json jobs`. If the conclusion is `skipped`, `failure`, or `cancelled`, the wait loop bails immediately with a clear message:

> Build artifacts were not collected — the 'Collect artifacts' job skipped. Check the build job logs.

Previously the loop would spin for the full ~30 min timeout before surfacing the real cause.

## Implementation notes

- `_check_collect_job_conclusion(run_id, repo)` is a fault-tolerant helper: any API or JSON parse error returns `None` so the retry loop continues uninterrupted.
- Job name matching is a substring check (`_COLLECT_JOB_NAME in name`) to handle the `build / Collect artifacts` prefix GitHub adds in reusable-workflow runs.
- `cancelled` is included alongside `skipped` and `failure` as a terminal conclusion.
- `repo` is now threaded into `_gh_download_with_wait` (required for the API call).