### PR TITLE
feat: support explicit arch field on spread.yaml system entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ backends:
     systems:
       - ubuntu-24.04:
           runner: [self-hosted, noble]   # GitHub Actions runner labels (CI only)
+          arch: arm64                    # explicit arch override (CI only, optional)
           cpu: 4                         # LXD VM vCPUs (local only, default 4)
           memory: 8                      # LXD VM RAM in GiB (local only, default 8)
           disk: 20                       # LXD VM disk in GiB (local only, default 20)
@@ -270,6 +271,7 @@ backends:
 | Field | Local backend | CI backend |
 |---|---|---|
 | `runner` | Stripped (not applicable to LXD) | Preserved for GitHub runner selection |
+| `arch` | Stripped (not applicable to LXD) | Used directly in the matrix `arch` field; when absent, arch is derived from the `runner` label |
 | `cpu` / `memory` / `disk` | Used in LXD `lxc launch --vm` arguments, then stripped | Stripped (not applicable to cloud runners) |
 
 Resource values are injected as per-system defaults in the allocate script using `${CPU:-N}` semantics so that an explicit environment variable override (e.g. `CPU=2 opcli spread run`) still takes precedence.

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -384,8 +384,10 @@ _BACKEND_CONFIGS: dict[str, tuple[str, str]] = {
 # passing to spread.  ``runner`` is a GitHub Actions runner-label field only
 # meaningful to the CI backend; resource fields are used by the local allocate
 # script and have no meaning in spread's own backend model.
-_LOCAL_STRIP_KEYS: frozenset[str] = frozenset({"cpu", "memory", "disk", "runner"})
-_CI_STRIP_KEYS: frozenset[str] = frozenset({"cpu", "memory", "disk", "runner"})
+_LOCAL_STRIP_KEYS: frozenset[str] = frozenset(
+    {"cpu", "memory", "disk", "runner", "arch"}
+)
+_CI_STRIP_KEYS: frozenset[str] = frozenset({"cpu", "memory", "disk", "runner", "arch"})
 
 # Names of resource fields and their corresponding shell variable names.
 _RESOURCE_FIELDS: dict[str, str] = {"cpu": "CPU", "memory": "MEM", "disk": "DISK"}
@@ -814,26 +816,30 @@ def _arch_from_runner(runner_json: str) -> str:
 
 def _virtual_runner_map(
     raw: dict[str, object],
-) -> tuple[dict[str, str], list[str]]:
-    """Extract runner labels and CI backend names from virtual backends only.
+) -> tuple[dict[str, str], dict[str, str | None], list[str]]:
+    """Extract runner labels, explicit arches and CI backend names from virtual backends.
 
     Reads only the virtual backend sections (those whose ``type:`` is a
-    recognised virtual type).  The ``runner:`` field is opcli-owned and is
-    stripped before spread ever sees the YAML.
+    recognised virtual type).  The ``runner:`` and ``arch:`` fields are
+    opcli-owned and are stripped before spread ever sees the YAML.
 
     Returns:
         Tuple of:
         - system_runner_map: ``{system_name: runner_json}`` built from virtual
           backend system entries.  The runner value is JSON-encoded so that
           the workflow can use ``fromJSON(matrix.runs-on)``.
+        - system_arch_map: ``{system_name: arch}`` for systems that declare an
+          explicit ``arch:`` field.  Value is ``None`` when no explicit arch is
+          set; callers should fall back to ``_arch_from_runner`` in that case.
         - ci_backend_names: concrete CI names derived from the virtual backend
           names (e.g. ``["integration-test-ci"]``).
     """
     runner_map: dict[str, str] = {}
+    arch_map: dict[str, str | None] = {}
     ci_names: list[str] = []
     raw_backends = raw.get("backends") or {}
     if not isinstance(raw_backends, dict):
-        return runner_map, ci_names
+        return runner_map, arch_map, ci_names
     for backend_name, backend_cfg in raw_backends.items():
         if not isinstance(backend_cfg, dict):
             continue
@@ -845,13 +851,19 @@ def _virtual_runner_map(
         for system_entry in backend_cfg.get("systems") or []:
             if isinstance(system_entry, str):
                 runner_map.setdefault(system_entry, json.dumps(_DEFAULT_RUNNER))
+                arch_map.setdefault(system_entry, None)
             elif isinstance(system_entry, dict):
                 for sys_name, sys_props in system_entry.items():
                     raw_runner: object = _DEFAULT_RUNNER
+                    explicit_arch: str | None = None
                     if isinstance(sys_props, dict):
                         raw_runner = sys_props.get("runner", _DEFAULT_RUNNER)
+                        raw_arch = sys_props.get("arch")
+                        if isinstance(raw_arch, str):
+                            explicit_arch = raw_arch
                     runner_map.setdefault(str(sys_name), json.dumps(raw_runner))
-    return runner_map, ci_names
+                    arch_map.setdefault(str(sys_name), explicit_arch)
+    return runner_map, arch_map, ci_names
 
 
 def spread_tasks(root: Path) -> list[dict[str, str]]:
@@ -868,7 +880,8 @@ def spread_tasks(root: Path) -> list[dict[str, str]]:
     - ``selector``: full spread selector as returned by ``spread -list``.
     - ``runs-on``: GitHub Actions runner label (JSON-encoded, from the
       ``runner:`` field on the system entry, or ``"ubuntu-latest"`` if absent).
-    - ``arch``: architecture string derived from the runner label.
+    - ``arch``: architecture string — taken from the explicit ``arch:`` field
+      on the system entry when present, otherwise derived from the runner label.
 
     Raises:
         ConfigurationError: If ``spread.yaml`` is missing, malformed, or
@@ -876,7 +889,7 @@ def spread_tasks(root: Path) -> list[dict[str, str]]:
         SubprocessError: If ``spread -list`` fails.
     """
     raw = _load_spread_yaml(root)
-    runner_map, ci_backend_names = _virtual_runner_map(raw)
+    runner_map, arch_map, ci_backend_names = _virtual_runner_map(raw)
 
     # _expand_backend raises ConfigurationError when no virtual backends are found.
     expanded = _expand_backend(raw, ci=True)
@@ -906,6 +919,12 @@ def spread_tasks(root: Path) -> list[dict[str, str]]:
                 continue
             system = parts[1]
             runner = runner_map.get(system, json.dumps(_DEFAULT_RUNNER))
+            explicit_arch = arch_map.get(system)
+            arch = (
+                explicit_arch
+                if explicit_arch is not None
+                else _arch_from_runner(runner)
+            )
             name = (
                 parts[-1]
                 if len(parts) >= _VARIANT_PARTS
@@ -916,7 +935,7 @@ def spread_tasks(root: Path) -> list[dict[str, str]]:
                     "name": name,
                     "selector": line,
                     "runs-on": runner,
-                    "arch": _arch_from_runner(runner),
+                    "arch": arch,
                 }
             )
 

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -1206,31 +1206,32 @@ class TestVirtualRunnerMap:
     def test_string_runner_label(self) -> None:
         """Runner string label is JSON-encoded in result."""
         raw = _yaml.load(StringIO(_SPREAD_WITH_RUNNER))
-        runner_map, _ = _virtual_runner_map(raw)
+        runner_map, _, _ = _virtual_runner_map(raw)
         assert runner_map["ubuntu-22.04"] == '"ubuntu-22.04-runner"'
 
     def test_list_runner_label(self) -> None:
         """Runner list is JSON-encoded when system uses a list."""
         raw = _yaml.load(StringIO(_SPREAD_WITH_RUNNER))
-        runner_map, _ = _virtual_runner_map(raw)
+        runner_map, _, _ = _virtual_runner_map(raw)
         assert runner_map["ubuntu-24.04"] == json.dumps(["self-hosted", "ubuntu-24.04"])
 
     def test_no_runner_defaults_to_ubuntu_latest(self) -> None:
         """Systems without runner: default to JSON-encoded ubuntu-latest."""
         raw = _yaml.load(StringIO(_SPREAD_NO_RUNNER))
-        runner_map, _ = _virtual_runner_map(raw)
+        runner_map, _, _ = _virtual_runner_map(raw)
         assert runner_map.get("ubuntu-24.04") == '"ubuntu-latest"'
 
     def test_empty_backends(self) -> None:
         """No backends → empty runner map and no CI names."""
-        runner_map, ci_names = _virtual_runner_map({})
+        runner_map, arch_map, ci_names = _virtual_runner_map({})
         assert runner_map == {}
+        assert arch_map == {}
         assert ci_names == []
 
     def test_ci_backend_names_derived(self) -> None:
         """CI backend names are {virtual_name}-ci for each virtual backend."""
         raw = _yaml.load(StringIO(_SPREAD_WITH_RUNNER))
-        _, ci_names = _virtual_runner_map(raw)
+        _, _, ci_names = _virtual_runner_map(raw)
         assert ci_names == ["integration-test-ci"]
 
     def test_non_virtual_backend_ignored(self) -> None:
@@ -1248,10 +1249,61 @@ backends:
           runner: some-runner
 """)
         )
-        runner_map, ci_names = _virtual_runner_map(raw)
+        runner_map, _, ci_names = _virtual_runner_map(raw)
         assert "ubuntu-24.04" in runner_map
         assert "ubuntu-22.04" not in runner_map
         assert ci_names == ["integration-test-ci"]
+
+    def test_explicit_arch_returned(self) -> None:
+        """Explicit arch: field on a system entry is captured in arch_map."""
+        raw = _yaml.load(
+            StringIO("""\
+backends:
+  integration-test:
+    type: integration-test
+    systems:
+      - ubuntu-24.04-arm64:
+          runner: ["ubuntu-24.04-arm"]
+          arch: arm64
+""")
+        )
+        _, arch_map, _ = _virtual_runner_map(raw)
+        assert arch_map.get("ubuntu-24.04-arm64") == "arm64"
+
+    def test_no_arch_field_returns_none(self) -> None:
+        """Systems without an arch: field have None in arch_map."""
+        raw = _yaml.load(StringIO(_SPREAD_NO_RUNNER))
+        _, arch_map, _ = _virtual_runner_map(raw)
+        assert arch_map.get("ubuntu-24.04") is None
+
+    def test_non_string_arch_falls_back_to_none(self) -> None:
+        """Non-string arch values (e.g. integers) are ignored; arch_map gets None."""
+        raw = _yaml.load(
+            StringIO("""\
+backends:
+  integration-test:
+    type: integration-test
+    systems:
+      - ubuntu-24.04:
+          arch: 123
+""")
+        )
+        _, arch_map, _ = _virtual_runner_map(raw)
+        assert arch_map.get("ubuntu-24.04") is None
+
+    def test_string_system_entry_arch_map_is_none(self) -> None:
+        """String-format system entries (no props) get None in arch_map."""
+        raw = _yaml.load(
+            StringIO("""\
+backends:
+  integration-test:
+    type: integration-test
+    systems:
+      - ubuntu-24.04
+""")
+        )
+        _, arch_map, _ = _virtual_runner_map(raw)
+        assert arch_map.get("ubuntu-24.04") is None
 
 
 class TestArchFromRunner:
@@ -1430,7 +1482,68 @@ suites:
                     if isinstance(sys_props, dict):
                         assert "runner" not in sys_props
 
-    def test_arch_field_amd64_default(self, tmp_path: Path) -> None:
+    def test_ci_backend_strips_arch_field(self, tmp_path: Path) -> None:
+        """Expanded CI backend does not contain arch: key in systems."""
+        spread_with_arch = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    type: integration-test
+    systems:
+      - ubuntu-24.04-arm64:
+          runner: ["ubuntu-24.04-arm"]
+          arch: arm64
+suites:
+  tests/integration/:
+    summary: integration tests
+    backends:
+      - integration-test
+"""
+        _write(tmp_path / "spread.yaml", spread_with_arch)
+
+        result = spread_expand(tmp_path, ci=True)
+        parsed = _yaml.load(StringIO(result))
+
+        ci_backend = parsed["backends"].get("integration-test-ci")
+        assert ci_backend is not None
+        for system_entry in ci_backend.get("systems", []):
+            if isinstance(system_entry, dict):
+                for _sys_name, sys_props in system_entry.items():
+                    if isinstance(sys_props, dict):
+                        assert "arch" not in sys_props
+
+    def test_arch_field_explicit_overrides_runner_label(self, tmp_path: Path) -> None:
+        """An explicit arch: field takes precedence over deriving arch from runner."""
+        spread_arm = """\
+project: test-project
+path: /home/ubuntu/proj
+backends:
+  integration-test:
+    type: integration-test
+    systems:
+      - ubuntu-24.04-arm64:
+          runner: ["ubuntu-24.04-arm"]
+          arch: arm64
+suites:
+  tests/integration/:
+    summary: integration tests
+    backends:
+      - integration-test
+"""
+        _write(tmp_path / "spread.yaml", spread_arm)
+
+        with patch(
+            "opcli.core.spread.run_command",
+            return_value=self._mock_list(
+                "integration-test-ci:ubuntu-24.04-arm64:tests/integration/run:test_charm\n"
+            ),
+        ):
+            entries = spread_tasks(tmp_path)
+
+        assert len(entries) == 1
+        assert entries[0]["arch"] == "arm64"
+
         """Entries without arm64 runner label get arch=amd64."""
         _write(tmp_path / "spread.yaml", _SPREAD_NO_RUNNER)
 


### PR DESCRIPTION
Fixes #113

## What

Adds `arch:` as a first-class opcli-owned field in virtual backend system entries. When present, its value is used directly as the matrix `arch` instead of deriving it from the runner label.

## Why

GitHub-hosted arm64 runners use the label `ubuntu-24.04-arm` (no `arm64` substring), causing `_arch_from_runner` to incorrectly return `amd64`.

## Changes

- Add `arch` to `_CI_STRIP_KEYS` and `_LOCAL_STRIP_KEYS` so spread never sees it
- `_virtual_runner_map` now returns a 3-tuple including an `arch_map` populated from the explicit `arch:` field
- `spread_tasks()` uses the explicit arch when set, falls back to `_arch_from_runner()` otherwise
- Tests: update existing unpack calls; add tests for arch capture, stripping, and the ubuntu-24.04-arm scenario
- README: document `arch:` alongside `runner`, `cpu`, `memory`, `disk`

## Usage

```yaml
backends:
  integration-test:
    systems:
      - ubuntu-24.04-arm64:
          runner: ["ubuntu-24.04-arm"]
          arch: arm64
```
