### PR TITLE
fix: use full spread selector as job name in GitHub Actions matrix

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -93,7 +93,7 @@ jobs:
   # Provisioning runs in parallel with the build.  The spread _CI_PREPARE script
   # waits for and downloads the build artifacts before executing tests.
   test:
-    name: "${{ matrix.name }} (${{ matrix.arch }})"
+    name: "${{ matrix.name }}"
     needs: [test-plan]
     runs-on: ${{ fromJSON(matrix.runs-on) }}
     permissions:

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -572,8 +572,8 @@ suitable for use as a GitHub Actions `strategy.matrix`:
 
 ```json
 {"include": [
-  {"name": "test_charm", "selector": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm", "runs-on": ["self-hosted", "noble"]},
-  {"name": "test_actions", "selector": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_actions", "runs-on": ["self-hosted", "noble"]}
+  {"name": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm", "selector": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm", "runs-on": ["self-hosted", "noble"]},
+  {"name": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_actions", "selector": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_actions", "runs-on": ["self-hosted", "noble"]}
 ]}
 ```
 
@@ -682,7 +682,7 @@ opcli spread run -- integration-test-ci:ubuntu-24.04:tests/integration/run:test_
 And `opcli spread tasks` produces entries like:
 
 ```json
-{"name": "test_charm", "selector": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm", "runs-on": ["self-hosted", "noble"]}
+{"name": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm", "selector": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm", "runs-on": ["self-hosted", "noble"]}
 ```
 
 The naming convention makes the origin of each backend immediately visible in selector strings and spread output, and avoids clashing with user-defined backends named `local` or `ci`.

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -875,8 +875,8 @@ def spread_tasks(root: Path) -> list[dict[str, str]]:
 
     Each entry has:
 
-    - ``name``: display name — the variant component of the selector if present,
-      otherwise the last path component of the task path.
+    - ``name``: display name — the full spread selector as returned by
+      ``spread -list``.
     - ``selector``: full spread selector as returned by ``spread -list``.
     - ``runs-on``: GitHub Actions runner label (JSON-encoded, from the
       ``runner:`` field on the system entry, or ``"ubuntu-latest"`` if absent).
@@ -914,7 +914,6 @@ def spread_tasks(root: Path) -> list[dict[str, str]]:
                 continue
             parts = line.split(":")
             _MIN_PARTS = 3
-            _VARIANT_PARTS = 4
             if len(parts) < _MIN_PARTS:
                 continue
             system = parts[1]
@@ -925,14 +924,9 @@ def spread_tasks(root: Path) -> list[dict[str, str]]:
                 if explicit_arch is not None
                 else _arch_from_runner(runner)
             )
-            name = (
-                parts[-1]
-                if len(parts) >= _VARIANT_PARTS
-                else parts[2].rsplit("/", 1)[-1]
-            )
             entries.append(
                 {
-                    "name": name,
+                    "name": line,
                     "selector": line,
                     "runs-on": runner,
                     "arch": arch,

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -1353,8 +1353,12 @@ class TestSpreadTasks:
             entries = spread_tasks(tmp_path)
 
         names = [e["name"] for e in entries]
-        assert "test_charm" in names
-        assert "test_other" in names
+        assert (
+            "integration-test-ci:ubuntu-22.04:tests/integration/run:test_charm" in names
+        )
+        assert (
+            "integration-test-ci:ubuntu-22.04:tests/integration/run:test_other" in names
+        )
 
     def test_selector_format(self, tmp_path: Path) -> None:
         """Selector is taken verbatim from spread -list output."""
@@ -1385,8 +1389,8 @@ class TestSpreadTasks:
         ubuntu_22_entries = [e for e in entries if "ubuntu-22.04" in e["selector"]]
         assert all(e["runs-on"] == '"ubuntu-22.04-runner"' for e in ubuntu_22_entries)
 
-    def test_no_variants_uses_last_path_component(self, tmp_path: Path) -> None:
-        """When spread -list returns no variant, name is the last path component."""
+    def test_no_variants_name_is_full_selector(self, tmp_path: Path) -> None:
+        """When spread -list returns no variant, name is the full selector."""
         _write(tmp_path / "spread.yaml", _SPREAD_NO_RUNNER)
 
         with patch(
@@ -1396,7 +1400,10 @@ class TestSpreadTasks:
             entries = spread_tasks(tmp_path)
 
         assert len(entries) == 1
-        assert entries[0]["name"] == "run"
+        assert (
+            entries[0]["name"]
+            == "integration-test-ci:ubuntu-24.04:tests/integration/run"
+        )
 
     def test_missing_spread_yaml_raises(self, tmp_path: Path) -> None:
         """Raises ConfigurationError when spread.yaml is missing."""
@@ -1603,8 +1610,13 @@ suites:
         selectors = [e["selector"] for e in entries]
         names = [e["name"] for e in entries]
         assert len(set(selectors)) == len(entries)
-        assert "test_charm" in names
-        assert "test_charm_k8s" in names
+        assert (
+            "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm" in names
+        )
+        assert (
+            "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm_k8s"
+            in names
+        )
 
     def test_temp_dir_cleaned_up_after_tasks(self, tmp_path: Path) -> None:
         """Temporary spread.yaml directory is removed after spread_tasks returns."""


### PR DESCRIPTION
## Summary

Previously the `name` field in the spread tasks matrix was set to just the variant component (e.g. `test_charm`) or the last path component (`run`), then displayed as `<name> (<arch>)` in the GitHub Actions job title.

This change sets `name` to the full selector string returned by `spread -list` (e.g. `integration-test-ci:ubuntu-22.04:tests/integration/run:test_charm`), and simplifies the workflow job name to just `${{ matrix.name }}` — the arch suffix is redundant since the system name already appears in the selector.

## Changes

- `src/opcli/core/spread.py`: Set `name = line` (full selector) instead of extracting the last path/variant component. Removed the now-unused `_VARIANT_PARTS` constant. Updated docstring.
- `.github/workflows/integration-test.yml`: Job name simplified to `${{ matrix.name }}`.
- `tests/unit/test_spread.py`: Updated three tests to assert the full selector string as the name.