### PR TITLE
fix: add --verbose flag to charmcraft pack

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -49,7 +49,7 @@ _ARTIFACTS_YAML = "artifacts.yaml"
 _ARTIFACTS_GENERATED_YAML = "artifacts-generated.yaml"
 
 _PACK_COMMANDS: dict[str, list[str]] = {
-    "charm": ["charmcraft", "pack"],
+    "charm": ["charmcraft", "pack", "--verbose"],
     "rock": ["rockcraft", "pack"],
     "snap": ["snapcraft", "pack"],
 }


### PR DESCRIPTION
Adds `--verbose` to the `charmcraft pack` invocation so build output is visible in CI logs. `rockcraft` and `snapcraft` are unchanged.