### PR TITLE
spread init: add warn-timeout, --model testing, --keep-models

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -49,7 +49,7 @@ _ARTIFACTS_YAML = "artifacts.yaml"
 _ARTIFACTS_GENERATED_YAML = "artifacts-generated.yaml"
 
 _PACK_COMMANDS: dict[str, list[str]] = {
-    "charm": ["charmcraft", "pack"],
+    "charm": ["charmcraft", "pack", "--verbose"],
     "rock": ["rockcraft", "pack"],
     "snap": ["snapcraft", "pack"],
 }

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -106,6 +106,7 @@ def _generate_spread_yaml(
         "project": project_name,
         "path": "/home/ubuntu/proj",
         "kill-timeout": "60m",
+        "warn-timeout": "1m",
         "backends": {
             _VIRTUAL_BACKEND: {
                 "type": _VIRTUAL_BACKEND,
@@ -133,7 +134,7 @@ _TASK_YAML_CONTENT = (
     "execute: |\n"
     '    cd "${SPREAD_PATH}"\n'
     '    PYTEST_CMD=$(opcli pytest expand -e "${TOX_ENV:-integration}"'
-    ' -- -k "$MODULE") || exit 1\n'
+    ' -- --model testing --keep-models -k "$MODULE") || exit 1\n'
     '    runuser -l "${SUDO_USER}" -c'
     ' "cd \\"${SPREAD_PATH}\\" && $PYTEST_CMD"\n'
 )

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -71,6 +71,7 @@ class TestSpreadInit:
         parsed = _yaml.load(StringIO(spread_path.read_text()))
         assert parsed["path"] == "/home/ubuntu/proj"
         assert parsed["kill-timeout"] == "60m"
+        assert parsed["warn-timeout"] == "1m"
         assert "summary" in parsed["suites"]["tests/integration/"]
 
     def test_generates_exclude_list(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Changes

- **`warn-timeout: 1m`** added to the generated `spread.yaml` template. Spread's default is 5 minutes, so slow scripts would only emit progress output every 5 minutes. 1 minute gives much more useful feedback during CI runs.

- **`--model testing`** added to the generated `task.yaml` pytest command. Concierge always creates a model named `testing` after every bootstrap (`juju add-model testing`), so tests should explicitly target it rather than relying on pytest-operator to create a random model.

- **`--keep-models`** added for consistency with `operator-workflows` conventions, allowing post-failure model inspection.