### PR TITLE
build-artifacts: set fail-fast: true on build matrix

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -78,7 +78,7 @@ jobs:
       contents: read
       packages: write
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix: ${{ fromJSON(needs.build-matrix.outputs.matrix) }}
     defaults:
       run:

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -49,7 +49,7 @@ _ARTIFACTS_YAML = "artifacts.yaml"
 _ARTIFACTS_GENERATED_YAML = "artifacts-generated.yaml"
 
 _PACK_COMMANDS: dict[str, list[str]] = {
-    "charm": ["charmcraft", "pack"],
+    "charm": ["charmcraft", "pack", "--verbose"],
     "rock": ["rockcraft", "pack"],
     "snap": ["snapcraft", "pack"],
 }

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -106,6 +106,7 @@ def _generate_spread_yaml(
         "project": project_name,
         "path": "/home/ubuntu/proj",
         "kill-timeout": "60m",
+        "warn-timeout": "1m",
         "backends": {
             _VIRTUAL_BACKEND: {
                 "type": _VIRTUAL_BACKEND,
@@ -133,7 +134,7 @@ _TASK_YAML_CONTENT = (
     "execute: |\n"
     '    cd "${SPREAD_PATH}"\n'
     '    PYTEST_CMD=$(opcli pytest expand -e "${TOX_ENV:-integration}"'
-    ' -- -k "$MODULE") || exit 1\n'
+    ' -- --model testing --keep-models -k "$MODULE") || exit 1\n'
     '    runuser -l "${SUDO_USER}" -c'
     ' "cd \\"${SPREAD_PATH}\\" && $PYTEST_CMD"\n'
 )

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -71,6 +71,7 @@ class TestSpreadInit:
         parsed = _yaml.load(StringIO(spread_path.read_text()))
         assert parsed["path"] == "/home/ubuntu/proj"
         assert parsed["kill-timeout"] == "60m"
+        assert parsed["warn-timeout"] == "1m"
         assert "summary" in parsed["suites"]["tests/integration/"]
 
     def test_generates_exclude_list(self, tmp_path: Path) -> None:


### PR DESCRIPTION
The build matrix had `fail-fast: false`, so when one arch/artifact build failed the others kept running to completion, wasting runner minutes and making it harder to see the failure quickly.

Setting `fail-fast: true` (the GitHub Actions default) cancels all remaining matrix jobs as soon as any one of them fails.