### PR TITLE
Add juju status and debug-log steps on integration test failure

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -143,3 +143,11 @@ jobs:
           # _CI_PREPARE script uses it to authenticate `gh run download`.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: opcli spread run -- -vv ${{ matrix.selector }}
+
+      - name: Juju status (on failure)
+        if: failure()
+        run: sudo -u ubuntu juju status --relations --storage
+
+      - name: Juju debug-log (on failure)
+        if: failure()
+        run: sudo -u ubuntu juju debug-log --replay


### PR DESCRIPTION
When the spread integration test job fails, run two additional diagnostic steps:

- `juju status --relations --storage` — shows the current model state
- `juju debug-log --replay` — replays Juju logs for post-mortem inspection

Both steps run as the `ubuntu` user (where Juju is bootstrapped by concierge) and are gated with `if: failure()`.