### PR TITLE
Iterate over all Juju models for status on failure

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -148,7 +148,7 @@ jobs:
         if: failure()
         run: |
           sudo -u ubuntu bash -c '
-            for model in $(juju models --format json | jq -r ".models[].\"short-name\""); do
+            juju models --format json | jq -r ".models[].\"short-name\"" | while IFS= read -r model; do
               echo "=== juju status for model: $model ==="
               juju status -m "$model" --relations --storage || true
             done

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -146,7 +146,13 @@ jobs:
 
       - name: Juju status (on failure)
         if: failure()
-        run: sudo -u ubuntu juju status --relations --storage
+        run: |
+          sudo -u ubuntu bash -c '
+            for model in $(juju models --format json | jq -r ".models[].\"short-name\""); do
+              echo "=== juju status for model: $model ==="
+              juju status -m "$model" --relations --storage || true
+            done
+          '
 
       - name: Juju debug-log (on failure)
         if: failure()


### PR DESCRIPTION
Replace the single `juju status` call with a loop over all models, so every model's status is printed when the integration test job fails.

```bash
for model in $(juju models --format json | jq -r '.models[]."short-name"'); do
  echo "=== juju status for model: $model ==="
  juju status -m "$model" --relations --storage || true
done
```

Uses `|| true` so a failing status on one model doesn't abort the loop.