### PR TITLE
Grant ubuntu passwordless sudo in CI prepare

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -308,7 +308,7 @@ chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 
 _CI_PREPARE = """\
 loginctl enable-linger ubuntu
-echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
+echo "ubuntu ALL=(ALL) NOPASSWD:ALL" | install -m 0440 /dev/stdin /etc/sudoers.d/ubuntu
 snap install astral-uv --classic || true
 export UV_TOOL_BIN_DIR=/usr/local/bin
 if [ -n "${GITHUB_WORKSPACE:-}" ] && grep -q 'name = "opcli"' "${GITHUB_WORKSPACE}/pyproject.toml" 2>/dev/null; then

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -308,6 +308,7 @@ chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 
 _CI_PREPARE = """\
 loginctl enable-linger ubuntu
+echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
 snap install astral-uv --classic || true
 export UV_TOOL_BIN_DIR=/usr/local/bin
 if [ -n "${GITHUB_WORKSPACE:-}" ] && grep -q 'name = "opcli"' "${GITHUB_WORKSPACE}/pyproject.toml" 2>/dev/null; then


### PR DESCRIPTION
Pytest tests run as the `ubuntu` user (via `runuser -l ubuntu`) and may call `sudo`. GitHub Actions runners don't give the `ubuntu` user passwordless sudo by default.

Fix: add `ubuntu ALL=(ALL) NOPASSWD:ALL` to `/etc/sudoers.d/ubuntu` at the top of `_CI_PREPARE` in `spread.py`.

Also reverts the diagnostic steps in `integration-test.yml` back to `sudo -u ubuntu` (mistakenly changed in the previous commit — Juju is bootstrapped under the ubuntu user's home directory).