### PR TITLE
Move chown of SPREAD_PATH to top of _CI_PREPARE

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -310,6 +310,9 @@ _CI_PREPARE = """\
 loginctl enable-linger ubuntu
 echo "ubuntu ALL=(ALL) NOPASSWD:ALL" | install -m 0440 /dev/stdin /etc/sudoers.d/ubuntu
 echo "DEBUG: SPREAD_PATH=${SPREAD_PATH}"
+echo "DEBUG: SPREAD_PATH owner: $(stat -c '%U:%G' "${SPREAD_PATH}" 2>&1)"
+echo "DEBUG: ls -la $(dirname "${SPREAD_PATH}")"
+ls -la "$(dirname "${SPREAD_PATH}")" 2>&1 || true
 snap install astral-uv --classic || true
 export UV_TOOL_BIN_DIR=/usr/local/bin
 if [ -n "${GITHUB_WORKSPACE:-}" ] && grep -q 'name = "opcli"' "${GITHUB_WORKSPACE}/pyproject.toml" 2>/dev/null; then
@@ -339,6 +342,7 @@ if [ -n "${GITHUB_RUN_ID:-}" ]; then
     --wait
 fi
 chown -R ubuntu:ubuntu "${SPREAD_PATH}"
+echo "DEBUG: SPREAD_PATH owner after chown: $(stat -c '%U:%G' "${SPREAD_PATH}" 2>&1)"
 """
 
 _CI_ALLOCATE = """\

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -309,6 +309,7 @@ chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 _CI_PREPARE = """\
 loginctl enable-linger ubuntu
 echo "ubuntu ALL=(ALL) NOPASSWD:ALL" | install -m 0440 /dev/stdin /etc/sudoers.d/ubuntu
+echo "DEBUG: SPREAD_PATH=${SPREAD_PATH}"
 snap install astral-uv --classic || true
 export UV_TOOL_BIN_DIR=/usr/local/bin
 if [ -n "${GITHUB_WORKSPACE:-}" ] && grep -q 'name = "opcli"' "${GITHUB_WORKSPACE}/pyproject.toml" 2>/dev/null; then

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -309,10 +309,7 @@ chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 _CI_PREPARE = """\
 loginctl enable-linger ubuntu
 echo "ubuntu ALL=(ALL) NOPASSWD:ALL" | install -m 0440 /dev/stdin /etc/sudoers.d/ubuntu
-echo "DEBUG: SPREAD_PATH=${SPREAD_PATH}"
-echo "DEBUG: SPREAD_PATH owner: $(stat -c '%U:%G' "${SPREAD_PATH}" 2>&1)"
-echo "DEBUG: ls -la $(dirname "${SPREAD_PATH}")"
-ls -la "$(dirname "${SPREAD_PATH}")" 2>&1 || true
+chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 snap install astral-uv --classic || true
 export UV_TOOL_BIN_DIR=/usr/local/bin
 if [ -n "${GITHUB_WORKSPACE:-}" ] && grep -q 'name = "opcli"' "${GITHUB_WORKSPACE}/pyproject.toml" 2>/dev/null; then
@@ -340,9 +337,8 @@ if [ -n "${GITHUB_RUN_ID:-}" ]; then
     --run-id "${GITHUB_RUN_ID}" \
     --repo "${GITHUB_REPOSITORY}" \
     --wait
+  chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 fi
-chown -R ubuntu:ubuntu "${SPREAD_PATH}"
-echo "DEBUG: SPREAD_PATH owner after chown: $(stat -c '%U:%G' "${SPREAD_PATH}" 2>&1)"
 """
 
 _CI_ALLOCATE = """\


### PR DESCRIPTION
Spread's `SendTar` creates `SPREAD_PATH` owned by root before backend prepare runs. The `chown` was at the bottom of `_CI_PREPARE`, so any failure under `set -eu` would leave the directory root-owned.

Changes:
- Move `chown -R ubuntu:ubuntu "${SPREAD_PATH}"` to right after the sudoers line, before anything can fail
- Add a second `chown` after `opcli artifacts fetch`, since downloaded artifacts are written as root