### PR TITLE
fix: always send _log_command output to stderr

### DIFF
--- a/src/opcli/core/subprocess.py
+++ b/src/opcli/core/subprocess.py
@@ -131,7 +131,7 @@ def _run_interactive(
     env: dict[str, str] | None = None,
 ) -> SubprocessResult:
     """Run *cmd* with inherited stdin/stdout/stderr for full TTY access."""
-    _log_command(cmd, cwd)
+    _log_command(cmd, cwd, err=True)
     try:
         proc = subprocess.run(cmd, cwd=cwd, check=False, env=env)
     except OSError as exc:
@@ -163,7 +163,7 @@ def _run_streaming(  # noqa: PLR0913
     env: dict[str, str] | None = None,
 ) -> SubprocessResult:
     """Run *cmd* with real-time output to the terminal."""
-    _log_command(cmd, cwd)
+    _log_command(cmd, cwd, err=True)
     try:
         proc = subprocess.Popen(
             cmd,

--- a/tests/unit/test_scaffold.py
+++ b/tests/unit/test_scaffold.py
@@ -171,9 +171,10 @@ class TestSubprocessWrapper:
 
             run_command(["charmcraft", "pack"], cwd="/some/dir")
 
-        captured = capsys.readouterr().out
-        assert "$ charmcraft pack" in captured
-        assert "cwd: /some/dir" in captured
+        captured = capsys.readouterr()
+        assert "$ charmcraft pack" in captured.err
+        assert "cwd: /some/dir" in captured.err
+        assert "$ charmcraft pack" not in captured.out
 
     def test_logs_command_without_cwd(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch("opcli.core.subprocess.subprocess.run") as mock_run:


### PR DESCRIPTION
## Problem

Diagnostic lines (`$ <cmd>` and `cwd: ...`) printed by `_log_command` were going to **stdout** in `_run_streaming` and `_run_interactive`. Only `_run_captured` correctly used `err=True`.

This meant piping or redirecting stdout (e.g. `opcli spread run -list 2>/dev/null`) would still include the diagnostic header lines, polluting programmatic consumers.

## Fix

Pass `err=True` to `_log_command` in both `_run_streaming` and `_run_interactive` so all diagnostic output consistently goes to stderr.

## Test

Updated `test_logs_command_and_cwd` to assert the log lines appear on stderr (not stdout), consistent with the existing `test_logs_command_without_cwd` test for captured mode.