### PR TITLE
docs: slim down README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,82 +1,56 @@
 # AGENTS.md
 
-Developer guide for AI coding agents working on this repository.
+Instructions for AI coding agents working on this repository.
 
 ---
 
-## What this project is
+## Project overview
 
-`opcli` is a **local-first CLI tool** that helps Canonical operator developers build charms, rocks, and snaps; manage test environments; and run integration tests — identically on a developer laptop and inside a CI job.
+`opcli` — local-first CLI for Canonical operator developers to build charms/rocks/snaps, manage test environments, and run integration tests.
 
-The authoritative functional specification is [`docs/ISD277-redesign.md`](docs/ISD277-redesign.md). Always read it before implementing a new feature. Known divergences between the spec and the implementation are documented in [`docs/divergences.md`](docs/divergences.md).
-
-**`opcli` owns:** file-based contracts, local artifact discovery, subprocess execution (charmcraft/rockcraft/snapcraft/spread/tox/concierge), and YAML transforms.
-
-**`opcli` does NOT own:** GitHub workflow orchestration, matrix job coordination, artifact upload/download between jobs, runner selection, or any GitHub API calls. Those concerns belong to the GitHub workflow YAML that calls opcli commands.
+- **Spec:** [`docs/ISD277-redesign.md`](docs/ISD277-redesign.md) — read before implementing new features.
+- **Divergences:** [`docs/divergences.md`](docs/divergences.md) — where implementation differs from spec.
+- **opcli owns:** file-based contracts, artifact discovery, subprocess execution, YAML transforms.
+- **opcli does NOT own:** GitHub workflow orchestration, artifact upload/download, runner selection, GitHub API calls.
 
 ---
 
 ## Quick-start
 
 ```bash
-# Install dependencies (uses uv lockfile)
-uv sync
-
-# Run the tool
-uv run opcli --help
-
-# Run all checks (lint → format → types → tests)
-uv run ruff check src/ tests/
-uv run ruff format --check src/ tests/
-uv run mypy src/
-uv run pytest tests/unit/
-
-# Auto-fix formatting
-uv run ruff format src/ tests/
+uv sync                                    # install deps
+uv run opcli --help                        # run the tool
+uv run ruff check src/ tests/              # lint
+uv run ruff format --check src/ tests/     # format check
+uv run mypy src/                           # type check
+uv run pytest tests/unit/                  # unit tests
 ```
 
 Never use `pip install`. All dependency management goes through `uv` and `pyproject.toml`.
 
 ---
 
-## Repository layout
+## Architecture rules
+
+### Repository layout
 
 ```
-pyproject.toml                  # single config: project, ruff, mypy, pytest
 src/opcli/
-  app.py                        # top-level Typer app, registers sub-commands
-  commands/                     # Typer CLI layer only — no business logic here
-    artifacts.py
-    provision.py
-    spread.py
-    pytest_cmd.py               # "pytest" is a reserved Python name
-    tutorial_cmd.py
-  core/                         # all business logic
-    artifacts.py                # build, fetch, localize, collect
-    discovery.py                # walk repo tree to find charmcraft/rockcraft/snapcraft yamls
-    exceptions.py               # OpcliError hierarchy
-    provision.py                # concierge wrapper + CI patching
-    pytest_args.py              # assemble tox/pytest flags from artifacts-generated.yaml
-    spread.py                   # virtual backend expansion + matrix generation
-    subprocess.py               # central subprocess wrapper (mock boundary in tests)
-    tutorial.py
-    yaml_io.py                  # YAML load/dump helpers (ruamel.yaml)
-  models/
-    artifacts.py                # Pydantic V2 model for artifacts.yaml
-    artifacts_generated.py      # Pydantic V2 model for artifacts-generated.yaml
-  data/                         # bundled static files (templates, etc.)
+  commands/    # CLI layer ONLY — parses args, calls core/. No business logic.
+  core/        # All business logic lives here.
+  models/      # Pydantic V2 models (artifacts.yaml, artifacts-generated.yaml)
 tests/
-  unit/                         # fast unit tests — no external processes
-  integration/                  # integration tests (require LXD, spread, etc.)
-  conftest.py
-docs/
-  ISD277-redesign.md            # authoritative spec
-  divergences.md                # where implementation differs from spec
+  unit/        # Fast tests — mock external processes
+  integration/ # Requires LXD/spread — not in standard test suite
+docs/          # Spec + divergences
 ```
 
-### Strict architecture rule
+### Key constraints
 
-`commands/` is **presentation only**. It parses CLI arguments and calls `core/`. Never put business logic directly in a Typer command callback. Tests validate `core/` functions directly — they do not go through the CLI layer.
+1. **`commands/` is presentation only.** Never put logic in Typer callbacks. Tests validate `core/` directly.
+2. **Subprocess rule.** All external binary calls go through `core/subprocess.py:run_command`. This is the mock boundary in tests.
+3. **Never overwrite `spread.yaml`.** Always produce a transformed copy in a temp file.
+4. **No `Any` type.** All signatures fully annotated. `mypy --strict` must pass.
 
 ---
 
@@ -84,169 +58,49 @@ docs/
 
 | Concern | Choice |
 |---|---|
-| Language | Python 3.12+ with strict typing (`mypy --strict`) |
+| Language | Python 3.12+, strict typing |
 | Packaging | `uv` |
-| CLI | `Typer` |
-| Data validation | `Pydantic V2` |
-| Lint / format | `Ruff` (rules: `E F W I UP B SIM PL RUF`) |
-| YAML (user files) | `ruamel.yaml` — preserves comments and round-trips |
-| Testing | `pytest` + `pytest-mock` + `syrupy` (snapshot testing) |
+| CLI | `Typer` (with `typing.Annotated` for params) |
+| Data models | `Pydantic V2` |
+| Lint/format | `Ruff` (rules: `E F W I UP B SIM PL RUF`) |
+| YAML (user files) | `ruamel.yaml` (preserves comments) |
+| Testing | `pytest` + `pytest-mock` + `syrupy` |
 
 ---
 
 ## CI detection
 
-Two environment variables gate CI behaviour — they are set independently by different subsystems:
-
-| Variable | Checked by | Meaning when set |
+| Variable | Controls | Where checked |
 |---|---|---|
-| `CI` | `spread.py` (`_is_ci()`) | Expand virtual backends to `{name}-ci` instead of `{name}-local` |
-| `GITHUB_ACTIONS=true` | `artifacts.py` (`_get_ci_context()`) | Produce CI-format artifact references (GitHub artifact names + run-id) instead of local file paths |
-
-In practice both are set inside a GitHub Actions job, so they agree. On a developer machine neither is set.
-
-Every `artifacts build`, `spread run`, `spread expand`, and `provision run` must respect their respective variable.
+| `CI` | Spread backend expansion (`-local` vs `-ci`) | `core/spread.py` |
+| `GITHUB_ACTIONS=true` | CI-format artifact output (GHCR + artifact refs) | `core/artifacts.py` |
 
 ---
 
-## Data model overview
+## Data model: Pydantic vs ruamel.yaml
 
-### Which files use Pydantic vs ruamel.yaml
+| File | Approach |
+|---|---|
+| `artifacts.yaml`, `artifacts-generated.yaml` | **Pydantic V2** — validated at load |
+| `spread.yaml`, `concierge.yaml`, `task.yaml` | **ruamel.yaml dict** — preserve comments/unknown keys |
 
-| File | Ownership | Approach | Notes |
-|---|---|---|---|
-| `artifacts.yaml` | opcli-generated, user-editable | **Pydantic V2 model** | Strongly validated at load time |
-| `artifacts-generated.yaml` | opcli-generated, machine-consumed | **Pydantic V2 model** | Strongly validated at load time |
-| `spread.yaml` | User-owned, opcli-expanded | **ruamel.yaml dict** | Preserve unknown keys, comments, custom backends; opcli only transforms virtual backends |
-| `concierge.yaml` | User-owned, opcli-patched in CI | **ruamel.yaml dict** | Additive merge for CI patches — preserve everything else |
-| `tests/integration/run/task.yaml` | opcli-generated, user-editable | **ruamel.yaml dict** | Simple template, not worth a model |
-
-**Critical:** when transforming `spread.yaml`, never rewrite the original file. Always produce a transformed copy in a temp file.
-
-### `artifacts.yaml` (user-edited, Pydantic-validated)
-
-Declares what to build. Each artifact points to its craft YAML file:
-
-```yaml
-version: 1
-charms:
-  - name: my-charm              # opcli alias (may differ from internal charmcraft name)
-    charmcraft-yaml: charmcraft-my-charm.yaml
-    pack-dir: .                 # optional: cwd for charmcraft pack
-    resources:
-      my-image:
-        type: oci-image
-        rock: my-rock
-    builds:
-      - arch: amd64
-        runner: ["ubuntu-22.04"]
-      - arch: arm64
-        runner: ["ubuntu-24.04-arm"]
-rocks:
-  - name: my-rock
-    rockcraft-yaml: my_rock/rockcraft.yaml
-snaps:
-  - name: my-snap
-    snapcraft-yaml: snap/snapcraft.yaml
-```
-
-### `artifacts-generated.yaml` (machine-generated, Pydantic-validated)
-
-Produced by `opcli artifacts build` (local paths) or `opcli artifacts fetch`/`localize` (CI references → local paths). The `output` field is a **flat list** — one entry per produced file:
-
-```yaml
-# Local build
-charms:
-  - name: my-charm
-    charmcraft-yaml: charmcraft-my-charm.yaml
-    output:
-      - arch: amd64
-        path: ./my-charm_ubuntu-22.04-amd64.charm
-        base: ubuntu@22.04
-      - arch: amd64
-        path: ./my-charm_ubuntu-24.04-amd64.charm
-        base: ubuntu@24.04
-
-# CI build (before localize)
-charms:
-  - name: my-charm
-    charmcraft-yaml: charmcraft-my-charm.yaml
-    output:
-      - arch: amd64
-        artifact: built-charm-my-charm-amd64
-        run-id: "1234567890"
-```
-
-### `spread.yaml` — virtual backends
-
-`opcli spread` recognises a `type:` field in backend entries. Known virtual types: `integration-test`, `tutorial`. The backend **name** is user-defined. `opcli` expands each virtual backend to `{name}-local` (LXD VM) or `{name}-ci` (current runner) depending on `CI`. All other spread-native backends and keys are preserved unchanged — never rewrite the original file; always work from a temp copy.
+Pydantic conventions:
+- YAML-facing models: lax mode. Internal-only: `strict=True`.
+- Field aliases: `alias=` + `populate_by_name=True` (e.g. `charmcraft-yaml` → `charmcraft_yaml`).
 
 ---
 
-## Command-family invariants
+## Build tool invariants
 
-### `opcli artifacts init`
+These encode hard-won correctness lessons — do not violate.
 
-- Walks directories recursively from the repository root.
-- Discovery markers: `charmcraft.yaml` → charm, `rockcraft.yaml` → rock, `snapcraft.yaml` → snap.
-- Inspects `charmcraft.yaml` to extract resource declarations and link them to discovered rocks.
-- **Non-destructive:** refuses to overwrite an existing `artifacts.yaml` unless `--force` is passed.
+1. **Symlinks for non-standard filenames.** When `artifacts.yaml` points to e.g. `charmcraft-my-charm.yaml`, a temp symlink is created in `pack_dir`. If a real file with *different* content exists at that path → `ConfigurationError`. Cleanup checks `.is_symlink()` not `.exists()`.
 
-### `opcli artifacts build`
+2. **Output attribution.** `attributed: set[str]` tracks claimed output paths across builds. Prevents two artifacts in a shared pack-dir from claiming the same file.
 
-- Reads `artifacts.yaml`; for each artifact runs the appropriate pack tool in `pack-dir` (or the directory containing the craft YAML if `pack-dir` is omitted).
-- Extracts the produced file paths from build tool output; writes `artifacts-generated.yaml` with `output` entries populated.
-- Supports `--charm <name>` and `--rock <name>` flags (repeatable) to build a subset.
+3. **`after - before` for output detection.** Never use `sorted(after)` alone. The set difference identifies files produced by *this* specific build invocation.
 
-### `opcli provision run`
-
-- Runs `sudo concierge prepare -c concierge.yaml`.
-- In CI (`CI` env var set): additively patches `concierge.yaml` with CI-specific overrides (Docker/GHCR mirror credentials, registry config) before running concierge.
-
-### `opcli provision load`
-
-- Loads OCI image artifacts (rocks) into a local image registry.
-- Default registry: `localhost:32000`. Override with `-r <registry>`.
-
-### `opcli spread init`
-
-- Discovers integration test modules and generates `spread.yaml` + `tests/integration/run/task.yaml`.
-- **Non-destructive:** refuses to overwrite existing files unless `--force` is passed.
-
-### `opcli spread run`
-
-- Reads `spread.yaml`, expands all virtual backends, writes to a **temp file** (never overwrites the original), invokes `spread` with the temp file.
-- All tokens after `--` are forwarded **verbatim and in order** to spread — opcli must not reinterpret or swallow spread selectors or flags.
-  ```bash
-  opcli spread run -- -list
-  opcli spread run -- integration-test-local:ubuntu-24.04:tests/integration/run:test_charm
-  ```
-
-### `opcli spread expand`
-
-- Same expansion logic as `spread run`, but prints the fully expanded `spread.yaml` to stdout without running spread. Useful for debugging.
-
-### `opcli spread tasks`
-
-- Generates the GitHub Actions CI matrix by calling `spread -list <backend-ci>:` on the expanded (CI-mode) `spread.yaml`.
-- Selectors are taken **verbatim** from `spread -list` output — opcli never constructs them by parsing suite environments or task directories.
-- The **only** fields read from `spread.yaml` are opcli-owned ones inside virtual backend sections: `type:` (to identify virtual backends) and `runner:` on system entries (to populate `runs-on` and `arch`). Nothing else in `spread.yaml` or any `task.yaml` is read.
-- Like `spread run`, expands to a temp dir with `reroot: ..` before invoking spread.
-- The workflow that calls `opcli spread tasks` must have `spread` installed.
-
-### `opcli pytest expand`
-
-- Reads `artifacts-generated.yaml` and prints the full assembled tox command to stdout (does not run it).
-- For each charm: `--charm-file <path-or-artifact-ref>`; for each OCI resource: `--<resource-name> <image-or-path>`.
-- Extra arguments after `--` are appended to the printed command.
-
----
-
-## Subprocess rule
-
-All calls to external binaries (`charmcraft`, `rockcraft`, `snapcraft`, `spread`, `concierge`, `juju`, `tox`) **must** go through `core/subprocess.py:run_command`. Never call `subprocess.run` or `subprocess.Popen` directly outside that module. This is the mock boundary in unit tests.
-
-When a command's stdout is consumed programmatically (e.g. the result is captured by a shell `$(...)` substitution or parsed by the caller), use `stream=False`. In this mode `_log_command` writes to **stderr** so the diagnostic lines do not pollute stdout.
+4. **CI artifact download.** `artifacts_fetch` downloads to `root/{artifact-name}/` subdirectories to prevent filename collisions.
 
 ---
 
@@ -254,128 +108,41 @@ When a command's stdout is consumed programmatically (e.g. the result is capture
 
 ```
 OpcliError (base)
-├── SubprocessError    — external command failed (exit code + stderr)
+├── SubprocessError    — external command failed
 ├── ValidationError    — YAML schema validation failed
-├── DiscoveryError     — artifact discovery found nothing / conflicting markers
-└── ConfigurationError — missing or invalid config file
+├── DiscoveryError     — discovery found nothing / conflicts
+└── ConfigurationError — missing or invalid config
 ```
 
-All Typer command callbacks catch `OpcliError` and emit a user-friendly message. Raw tracebacks must not appear in normal usage.
-
----
-
-## Build tool invariants
-
-These invariants must be maintained; they encode hard-won correctness lessons.
-
-### 1. `charmcraft-yaml` / `rockcraft-yaml` symlinks
-
-Charmcraft and Rockcraft always look for `charmcraft.yaml` / `rockcraft.yaml` by that exact filename in the working directory. When `artifacts.yaml` points to a non-standard filename (e.g. `charmcraft-my-charm.yaml`), `_with_charm_symlink` / `_with_rock_symlink` creates a **temporary relative symlink** in `pack_dir` before the build and removes it in a `finally` block.
-
-Rules:
-- If `pack_dir/charmcraft.yaml` is already the right file (resolved path matches): no-op.
-- If `pack_dir/charmcraft.yaml` is a real file with **identical byte content**: no-op (accepted as a valid copy).
-- If `pack_dir/charmcraft.yaml` is a real file with **different content**: raise `ConfigurationError` — prevents silently building the wrong charm.
-- Cleanup uses `.is_symlink()`, not `.exists()`, so a real file accidentally at that path is never deleted.
-
-### 2. Output attribution — `attributed` set
-
-`artifacts_build` maintains a shared `attributed: set[str]` of absolute output paths already claimed by previous builds in the same session. Each `_build_rock`, `_build_charm`, and `_build_snap` call adds its outputs to `attributed` and passes it to `_pick_new_output` / `_pick_new_charm_outputs`.
-
-The overwrite-in-place fallback (when `after - before` is empty) raises `OpcliError` if the candidate path is already in `attributed`. This catches the case where two artifacts share a pack-dir and produce identically-named output files.
-
-### 3. `after - before` for output detection
-
-`_pick_new_output` (rocks, snaps) and `_pick_new_charm_outputs` (charms) both use `after - before` to identify the file(s) produced by this specific build invocation. Never use `sorted(after)` alone — this was the root cause of a cross-attribution bug where the second charm in a shared pack-dir inherited all charm files.
-
-The overwrite-in-place fallback (`after == before`, i.e. `after - before` is empty) only applies when a rebuild produces the same filenames.
-
-### 4. CI artifact download — per-artifact subdirectories
-
-`artifacts_fetch` downloads each charm/snap artifact to `root/{artifact-name}/` (e.g. `root/built-charm-my-charm-amd64/`) rather than a flat `root/`. This prevents filename collisions when two charms have the same internal charmcraft name (and thus the same packed filename).
-
-`_localize_charm` and the snap localize path search the artifact's own subdirectory for any `.charm`/`.snap` file by extension (not by opcli alias), because the packed filename reflects the internal craft name — which may differ from the opcli alias.
-
----
-
-## Git workflow
-
-**Never push directly to `main`.** Always:
-
-1. Create a feature branch
-2. Open a PR
-3. **Wait for CI to pass** (both `CI` and `Test Integration` workflows) — **NEVER merge a PR before CI is green. No exceptions.**
-4. Run a code review with a sub-agent when making non-trivial changes
-5. Squash-merge
-
-```bash
-git checkout -b fix/my-fix
-# ... make changes ...
-git push --set-upstream origin fix/my-fix
-gh pr create --title "..." --body "..."
-# Wait for CI — check with: gh pr checks <number> --watch
-# Do NOT proceed to merge until all checks pass
-gh pr merge <number> --squash
-git checkout main && git pull
-```
-
-> **CI must be green before merging.** Use `gh pr checks <number> --watch` to
-> monitor. If checks are still running, wait. If they fail, fix the issue and
-> push again. Merging with failing or pending CI is not acceptable under any
-> circumstances.
-
-When creating git commits, always include the trailer:
-
-```
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
-```
+All Typer callbacks catch `OpcliError` and emit user-friendly messages. No raw tracebacks.
 
 ---
 
 ## Testing conventions
 
-- **TDD order**: write unit tests before implementation for non-trivial features.
-- **Mock boundary**: unit tests mock at `opcli.core.artifacts.run_command` (or `opcli.core.subprocess.run_command`). Never execute real `charmcraft`, `rockcraft`, `snapcraft`, `spread`, `concierge`, or `juju` in unit tests.
-- **Snapshot testing**: use `syrupy` for CLI output assertions to catch unintended format changes.
-- **Integration tests** (`@pytest.mark.integration`) require real LXD and are not run in the standard unit test suite.
-- The `pre_existing_before / after` pattern: when testing build output detection, simulate charmcraft's behaviour by writing files inside the `fake_run` side-effect, not before it.
+- **TDD:** write unit tests before implementation for non-trivial features.
+- **Mock boundary:** mock at `run_command`. Never run real charmcraft/rockcraft/spread in unit tests.
+- **Snapshot testing:** `syrupy` for CLI output assertions.
+- **`pre_existing_before/after` pattern:** simulate build tool output by writing files inside the `fake_run` side-effect, not before it.
 
 ---
 
-## Pydantic conventions
+## Git workflow
 
-- **YAML-facing models** (`artifacts.yaml`, `artifacts-generated.yaml`): use default lax mode (`ConfigDict()`). YAML's native int/str coercion works.
-- **Internal-only models**: use `ConfigDict(strict=True)`.
-- No `Any` type anywhere. Use specific types or `object` if truly dynamic.
-- Field aliases use `alias=` (hyphenated YAML keys map to underscore Python names, e.g. `charmcraft-yaml` → `charmcraft_yaml`). Use `populate_by_name=True` so both forms work.
+**Never push to `main`.** Always: branch → PR → CI green → squash merge.
 
----
+```bash
+git checkout -b fix/my-fix
+# make changes
+git push --set-upstream origin fix/my-fix
+gh pr create --title "..." --body "..."
+gh pr checks <number> --watch   # WAIT for green
+gh pr merge <number> --squash
+```
 
-## Type safety
+**CI must be green before merging. No exceptions.**
 
-- No `Any` anywhere in the codebase. Use specific types or `object` if truly dynamic.
-- All function signatures have full type annotations.
-- Use `typing.Annotated` for all Typer CLI parameters.
-- `mypy --strict` must pass with zero errors before merging.
-
----
-
-## YAML handling
-
-- `ruamel.yaml` is used for all user-owned files (`spread.yaml`, `concierge.yaml`, `task.yaml`) to preserve comments and unknown keys.
-- Pydantic models are used for `artifacts.yaml` and `artifacts-generated.yaml` only.
-- When transforming `spread.yaml` (spread expand / run), **never overwrite the original file**. Always write to a temp file and pass that to the spread subprocess.
-
----
-
-## Reusable GitHub workflows
-
-Three workflows in `.github/workflows/` are designed to be called from operator repositories:
-
-| Workflow | Purpose |
-|---|---|
-| `build-artifacts.yml` | Generates build matrix, builds all artifacts in parallel, merges into a single `artifacts-generated.yaml` artifact |
-| `integration-test.yml` | Downloads built artifacts, generates spread task matrix, runs integration tests |
-| `test-integration.yml` | Lighter integration test runner (no spread) |
-
-These workflows install `opcli` at the exact commit SHA they were called with (via `canonical/get-workflow-version-action`), so downstream repos automatically get the version of opcli pinned to the workflow ref they reference.
+All commits must include:
+```
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,9 +39,10 @@ src/opcli/
   commands/    # CLI layer ONLY — parses args, calls core/. No business logic.
   core/        # All business logic lives here.
   models/      # Pydantic V2 models (artifacts.yaml, artifacts-generated.yaml)
+  data/        # Bundled static files (e.g. registry.yaml manifest)
 tests/
   unit/        # Fast tests — mock external processes
-  integration/ # Requires LXD/spread — not in standard test suite
+  integration/ # Requires LXD/spread — skip-guarded with @pytest.mark.integration
 docs/          # Spec + divergences
 ```
 
@@ -50,7 +51,7 @@ docs/          # Spec + divergences
 1. **`commands/` is presentation only.** Never put logic in Typer callbacks. Tests validate `core/` directly.
 2. **Subprocess rule.** All external binary calls go through `core/subprocess.py:run_command`. This is the mock boundary in tests.
 3. **Never overwrite `spread.yaml`.** Always produce a transformed copy in a temp file.
-4. **No `Any` type.** All signatures fully annotated. `mypy --strict` must pass.
+4. **Avoid `Any`.** Prefer specific types; `mypy --strict` must pass. Legacy `Any` in YAML-handling helpers is tolerated but should not spread.
 
 ---
 
@@ -60,7 +61,7 @@ docs/          # Spec + divergences
 |---|---|
 | Language | Python 3.12+, strict typing |
 | Packaging | `uv` |
-| CLI | `Typer` (with `typing.Annotated` for params) |
+| CLI | `Typer` |
 | Data models | `Pydantic V2` |
 | Lint/format | `Ruff` (rules: `E F W I UP B SIM PL RUF`) |
 | YAML (user files) | `ruamel.yaml` (preserves comments) |
@@ -136,7 +137,7 @@ git checkout -b fix/my-fix
 # make changes
 git push --set-upstream origin fix/my-fix
 gh pr create --title "..." --body "..."
-gh pr checks <number> --watch   # WAIT for green
+gh pr checks <number> --watch   # WAIT for green (CI + Test Integration workflows)
 gh pr merge <number> --squash
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,46 +1,28 @@
 # opcli
 
-CLI tool for operator development workflows — build, test, and provision Charms, Rocks, and Snaps.
+A **local-first CLI tool** for Canonical operator developers to build charms, rocks, and snaps; manage test environments; and run integration tests — identically on a developer laptop and inside a CI job.
 
-`opcli` replaces the monolithic `operator-workflows` approach with a modular, local-first model based on explicit build plans (`artifacts.yaml`), stable build output (`artifacts-generated.yaml`), and spread-based test execution.
+`opcli` replaces the monolithic [`operator-workflows`](https://github.com/canonical/operator-workflows) approach with a modular pipeline based on explicit build plans (`artifacts.yaml`), stable build output (`artifacts-generated.yaml`), and [spread](https://github.com/canonical/spread)-based test execution.
 
-See [docs/ISD277-redesign.md](docs/ISD277-redesign.md) for the full specification.
+## Documentation
+
+| Document | Purpose |
+|---|---|
+| [docs/ISD277-redesign.md](docs/ISD277-redesign.md) | Authoritative functional specification |
+| [docs/divergences.md](docs/divergences.md) | Where implementation differs from the spec |
+| [AGENTS.md](AGENTS.md) | Developer guide for AI coding agents |
 
 ## Installation
 
-`opcli` is installed directly from this repository (not published to PyPI).
-
-### With uv (recommended)
-
 ```bash
+# With uv (recommended)
 uv tool install git+https://github.com/javierdelapuente/operator-ci-poc.git
-```
 
-Or from a local clone:
-
-```bash
+# Or from a local clone
 git clone https://github.com/javierdelapuente/operator-ci-poc.git
-cd operator-ci-poc
-uv tool install .
-```
+cd operator-ci-poc && uv tool install .
 
-### With pip
-
-```bash
-pip install git+https://github.com/javierdelapuente/operator-ci-poc.git
-```
-
-Or from a local clone:
-
-```bash
-git clone https://github.com/javierdelapuente/operator-ci-poc.git
-cd operator-ci-poc
-pip install .
-```
-
-### Verify
-
-```bash
+# Verify
 opcli --help
 ```
 
@@ -49,21 +31,13 @@ opcli --help
 ### Local testing with spread
 
 ```bash
-# Discover charms/rocks/snaps and generate artifacts.yaml
-opcli artifacts init
+opcli artifacts init     # discover charms/rocks/snaps → artifacts.yaml
+opcli artifacts build    # build all → artifacts-generated.yaml
+opcli spread init        # generate spread.yaml + task.yaml
+opcli spread expand      # preview expanded spread config
+opcli spread run         # run integration tests (LXD backend)
 
-# Build all declared artifacts → produces artifacts-generated.yaml
-opcli artifacts build
-
-# Generate spread.yaml and tests/integration/run/task.yaml
-opcli spread init
-
-# Preview the expanded spread configuration
-opcli spread expand
-
-# Run integration tests via spread (local LXD backend)
-opcli spread run
-# Or target a specific test:
+# Target a specific test:
 opcli spread run -- integration-test-local:ubuntu-24.04:tests/integration/run:test_charm
 ```
 
@@ -72,29 +46,10 @@ opcli spread run -- integration-test-local:ubuntu-24.04:tests/integration/run:te
 ```bash
 opcli artifacts init
 opcli artifacts build
-
-# Provision the environment with concierge
-opcli provision run
-
-# Deploy a local OCI registry (if k8s or MicroK8s is enabled in concierge.yaml)
-opcli provision registry
-
-# Load rock images into the local registry
-opcli provision load
-
-# Run integration tests via tox (opcli pytest expand prints the full command)
-eval "$(opcli pytest expand -- -k test_charm)"
-```
-
-### Inspect the assembled tox command
-
-```bash
-# Print the full tox command that would run the integration tests
-opcli pytest expand
-# Example output: tox -e integration -- --charm-file=./mycharm.charm --myrock-image=./myrock.rock
-
-# With extra pytest arguments forwarded:
-opcli pytest expand -- -k test_charm
+opcli provision run          # provision with concierge
+opcli provision registry     # deploy local OCI registry (if k8s enabled)
+opcli provision load         # push rocks to registry
+eval "$(opcli pytest expand -- -k test_charm)"   # run tests via tox
 ```
 
 ## Commands
@@ -103,75 +58,43 @@ opcli pytest expand -- -k test_charm
 
 | Command | Description |
 |---|---|
-| `opcli artifacts init` | Discover charms/rocks/snaps and generate `artifacts.yaml`. Use `--force` to overwrite. |
-| `opcli artifacts build` | Build all artifacts and produce `artifacts-generated.yaml`. Filter with `--charm <name>`, `--rock <name>`, `--snap <name>`. |
-| `opcli artifacts matrix` | Read `artifacts.yaml` and print a JSON build matrix for GitHub Actions (one entry per artifact/arch build target pair). |
-| `opcli artifacts collect <partial>...` | Merge partial `artifacts-generated.yaml` files from parallel build jobs into a single output file. |
-| `opcli artifacts fetch` | Download `artifacts-generated.yaml` and all charm/snap archives from a CI run, then rewrite paths to local files so `opcli pytest expand` and `opcli spread run` work without a local build. Rock artifacts are GHCR images and need no download. Use `--run-id`, `--repo`, and `--wait` (retries until the artifact appears). |
-| `opcli artifacts localize` | Rewrite `artifacts-generated.yaml` to replace CI artifact references with local `.charm`/`.snap` file paths after charm and snap archives have been manually downloaded. (Prefer `opcli artifacts fetch` for the full workflow.) |
+| `init` | Discover charms/rocks/snaps and generate `artifacts.yaml`. `--force` to overwrite. |
+| `build` | Build artifacts → `artifacts-generated.yaml`. Filter: `--charm`, `--rock`, `--snap`. |
+| `matrix` | Print JSON build matrix for GitHub Actions. |
+| `collect <partial>...` | Merge partial `artifacts-generated.yaml` from parallel jobs. |
+| `fetch` | Download CI artifacts and rewrite to local paths. `--run-id`, `--repo`, `--wait`. |
+| `localize` | Rewrite CI artifact refs to local paths (after manual download). |
 
 ### `opcli provision`
 
 | Command | Description |
 |---|---|
-| `opcli provision run` | Run `concierge prepare` to provision the test environment. |
-| `opcli provision load` | Push locally-built rock images to a container registry and update each arch build entry's `image` field in `artifacts-generated.yaml`. Use `-r` to set registry (default: `localhost:32000`). Images are tagged `{registry}/{name}:{arch}` (e.g. `localhost:32000/my-rock:amd64`). |
-| `opcli provision registry` | Deploy a local OCI registry at `localhost:32000`. Reads `concierge.yaml` to detect whether MicroK8s or canonical k8s is enabled and applies the same embedded `registry:2` manifest via the provider's own `kubectl`. No-op if the registry is already running, if no k8s provider is configured, or if there are no rocks to push. Raises an error if both providers are enabled simultaneously. Use `-c` to specify a custom concierge file path. |
+| `run` | Run `concierge prepare` to provision the test environment. |
+| `load` | Push rock images to registry, update `artifacts-generated.yaml`. `-r` for registry. |
+| `registry` | Deploy local OCI registry at `localhost:32000`. `-c` for concierge path. |
 
 ### `opcli spread`
 
 | Command | Description |
 |---|---|
-| `opcli spread init` | Discover integration tests and generate `spread.yaml` + `tests/integration/run/task.yaml`. Use `--force` to overwrite. |
-| `opcli spread expand` | Print the fully expanded `spread.yaml` to stdout. |
-| `opcli spread run` | Expand the virtual backend and run spread. Extra args after `--` are forwarded verbatim to spread (e.g. `opcli spread run -- -list`). |
-| `opcli spread tasks` | Generate the GitHub Actions CI matrix as JSON. Calls `spread -list` on the CI-mode expanded `spread.yaml` and emits one entry per spread task with `name`, `selector`, `runs-on`, and `arch` fields. |
+| `init` | Generate `spread.yaml` + `tests/integration/run/task.yaml`. `--force` to overwrite. |
+| `expand` | Print fully expanded `spread.yaml` to stdout. |
+| `run` | Expand virtual backend and run spread. Args after `--` forwarded verbatim. |
+| `tasks` | Print CI matrix JSON (one entry per spread task). |
 
 ### `opcli pytest`
 
 | Command | Description |
 |---|---|
-| `opcli pytest expand` | Print the full `tox -e integration -- <flags>` command assembled from `artifacts-generated.yaml`. Use `-e` to change the tox environment. Extra args after `--` are forwarded into the printed command. Pipe to `eval` to execute. |
-
-The tox environment defaults to `integration`. To use a different environment, either pass `-e` directly:
-
-```bash
-opcli pytest expand -e charms-integration -- -k test_charm
-```
-
-Or, when using spread, set `TOX_ENV` in the suite environment of `spread.yaml` (generated by `opcli spread init`):
-
-```yaml
-suites:
-  tests/integration/:
-    environment:
-      TOX_ENV: charms-integration   # overrides the default "integration"
-      MODULE/test_charm: test_charm
-```
-
-Different suites can each declare their own `TOX_ENV` value.
+| `expand` | Print full `tox -e integration -- <flags>` command. `-e` for env, `--` forwards args. |
 
 ### `opcli tutorial`
 
 | Command | Description |
 |---|---|
-| `opcli tutorial expand <file>` | Extract and print shell commands from a tutorial file (`.md`, `.rst`). Output is a shell script suitable for `eval` in a spread task. |
-
-## Key files
-
-| File | Purpose |
-|---|---|
-| `artifacts.yaml` | Declares charms, rocks, snaps and their resource links. Auto-generated or hand-edited. |
-| `artifacts-generated.yaml` | Build output with artifact paths/refs. Generated by `opcli artifacts build`. |
-| `concierge.yaml` | Declarative environment provisioning (Juju, MicroK8s, LXD, etc.). |
-| `spread.yaml` | Spread configuration with a virtual `integration-test` backend expanded by opcli. |
-| `tests/integration/run/task.yaml` | Spread task that runs integration tests via `opcli pytest expand`. |
+| `expand <file>` | Extract shell commands from a tutorial (`.md`/`.rst`) for `eval`. |
 
 ## `artifacts.yaml` schema
-
-Each artifact entry uses an explicit path to its craft YAML file rather than a directory.
-An optional `builds:` list declares which architectures (and runners) to build for — it
-defaults to `[{arch: amd64}]` when omitted:
 
 ```yaml
 version: 1
@@ -192,171 +115,22 @@ charms:
 snaps:
   - name: my-snap
     snapcraft-yaml: snap/snapcraft.yaml
-    pack-dir: .        # run snapcraft pack from the repo root
+    pack-dir: .
 ```
 
-The `runner` field in each `builds:` entry is a YAML list of GitHub Actions runner
-labels (e.g. `[ubuntu-latest]` or `[self-hosted, arm64]`). It is used by
-`opcli artifacts matrix` and the reusable build workflow to select the correct
-runner for each arch. If omitted, it defaults to `[ubuntu-latest]`.
-
-When `opcli artifacts matrix` serialises the matrix for GitHub Actions it
-JSON-encodes the runner list into a string so that
-`${{ fromJSON(matrix.runner) }}` produces the correct runner label array at
-job execution time.
-
-### `pack-dir` (charms, rocks, and snaps)
-
-By default `opcli artifacts build` runs the pack tool from the directory that contains
-the craft YAML file. Set `pack-dir` to run from a different directory. This is required
-for Go monorepos where `go.mod` lives at the repository root but `rockcraft.yaml` lives
-in a subdirectory:
-
-```yaml
-rocks:
-  - name: my-go-rock
-    rockcraft-yaml: rocks/my-go-rock/rockcraft.yaml
-    pack-dir: .    # rockcraft pack runs from the repo root where go.mod lives
-```
-
-When `pack-dir` differs from the directory containing the craft YAML, opcli creates a
-temporary symlink `<pack-dir>/rockcraft.yaml → <rockcraft-yaml>` before running
-`rockcraft pack`, then removes it afterwards. If a real (non-symlink) file already
-exists at that path with **different content**, the build fails with an error. If a
-real file exists with identical byte content it is accepted and no symlink is created.
-
-## `artifacts-generated.yaml` schema — local format
-
-`opcli artifacts build` produces `artifacts-generated.yaml`. The `output:` field
-is a flat list where each entry carries `arch` alongside its file info. Rocks and
-snaps produce one entry per arch. Charms produce **one entry per produced `.charm`
-file** — when `charmcraft pack` builds multiple bases (e.g. ubuntu@22.04 and
-ubuntu@24.04), each file becomes a separate entry in the list:
-
-```yaml
-version: 1
-rocks:
-  - name: my-rock
-    rockcraft-yaml: rocks/my-rock/rockcraft.yaml
-    output:
-      - arch: amd64
-        file: ./rocks/my-rock/my-rock_1.0_amd64.rock
-charms:
-  - name: aproxy
-    charmcraft-yaml: charmcraft.yaml
-    output:
-      - arch: amd64
-        path: ./aproxy_ubuntu-20.04-amd64.charm
-        base: ubuntu@20.04
-      - arch: amd64
-        path: ./aproxy_ubuntu-22.04-amd64.charm
-        base: ubuntu@22.04
-      - arch: amd64
-        path: ./aproxy_ubuntu-24.04-amd64.charm
-        base: ubuntu@24.04
-```
-
-`opcli pytest expand` emits one `--charm-file=<path>` flag per entry matching the current machine's arch.
-
-System entries under the virtual `integration-test` (or `tutorial`) backend accept opcli-specific fields alongside standard spread fields:
-
-```yaml
-backends:
-  integration-test:
-    systems:
-      - ubuntu-24.04:
-          runner: [self-hosted, noble]   # GitHub Actions runner labels (CI only)
-          arch: arm64                    # explicit arch override (CI only, optional)
-          cpu: 4                         # LXD VM vCPUs (local only, default 4)
-          memory: 8                      # LXD VM RAM in GiB (local only, default 8)
-          disk: 20                       # LXD VM disk in GiB (local only, default 20)
-```
-
-**How they are handled:**
-
-| Field | Local backend | CI backend |
-|---|---|---|
-| `runner` | Stripped | Read by `opcli spread tasks` to populate `runs-on` in the matrix, then stripped |
-| `arch` | Stripped | Read by `opcli spread tasks` to populate `arch` in the matrix (derived from runner labels when absent), then stripped |
-| `cpu` / `memory` / `disk` | Used in LXD `lxc launch --vm` arguments, then stripped | Stripped (not applicable to cloud runners) |
-
-Resource values are injected as per-system defaults in the allocate script using `${CPU:-N}` semantics so that an explicit environment variable override (e.g. `CPU=2 opcli spread run`) still takes precedence.
+Key fields:
+- **`*-yaml`**: explicit path to the craft YAML file (not a directory).
+- **`pack-dir`**: working directory for the build tool (defaults to the YAML's parent dir).
+- **`builds[].runner`**: GitHub Actions runner labels; defaults to `[ubuntu-latest]`.
 
 ## CI vs local
 
-Two environment variables govern how opcli behaves in different environments:
-
 | Env var | Controls | Local | CI |
 |---|---|---|---|
-| `CI` | Spread backend expansion | `integration-test-local:` (LXD VM) | `integration-test-ci:` (current machine) |
-| `GITHUB_ACTIONS` | Artifact build output format | Local file paths (`output.file`) | GHCR images + GitHub artifact refs |
-
-When `GITHUB_ACTIONS=true` (set automatically by GitHub Actions runners),
-`opcli artifacts build` switches to CI format:
-
-- **Rocks**: pushed to GHCR via skopeo; each arch build entry gets `output[*].image: ghcr.io/<owner>/<repo>/<rock>:<sha7>-<arch>`
-- **Charms / Snaps**: each arch build entry gets `output[*].artifact: built-<type>-<name>-<arch>` + `output[*].run-id: <GITHUB_RUN_ID>`
-
-## `artifacts-generated.yaml` — CI vs local format
-
-### Local format
-
-```yaml
-version: 1
-rocks:
-  - name: my-rock
-    rockcraft-yaml: rocks/my-rock/rockcraft.yaml
-    output:
-      - arch: amd64
-        file: ./rocks/my-rock/my-rock_1.0_amd64.rock
-charms:
-  - name: my-charm
-    charmcraft-yaml: charmcraft.yaml
-    output:
-      - arch: amd64
-        path: ./my-charm_ubuntu-24.04-amd64.charm
-        base: ubuntu@24.04
-    resources:
-      my-rock-image:
-        type: oci-image
-        rock: my-rock
-```
-
-### CI format (after `opcli artifacts collect`)
-
-```yaml
-version: 1
-rocks:
-  - name: my-rock
-    rockcraft-yaml: rocks/my-rock/rockcraft.yaml
-    output:
-      - arch: amd64
-        image: ghcr.io/myorg/my-repo/my-rock:abc1234-amd64
-charms:
-  - name: my-charm
-    charmcraft-yaml: charmcraft.yaml
-    output:
-      - arch: amd64
-        artifact: built-charm-my-charm-amd64
-        run-id: "1234567890"
-    resources:
-      my-rock-image:
-        type: oci-image
-        rock: my-rock
-```
-
-Rock images live exclusively under `rocks[].output.image`. Charm resources
-carry only a `rock:` link — the image ref is never duplicated onto the resource.
-`opcli pytest expand` resolves rock flags by iterating `rocks`, not by reading
-resource fields.
+| `CI` | Spread backend expansion | `*-local` (LXD VM) | `*-ci` (current runner) |
+| `GITHUB_ACTIONS` | Artifact output format | Local file paths | GHCR images + artifact refs |
 
 ## GitHub Actions reusable workflow
-
-The repository ships a reusable workflow that builds all charms, rocks, and
-snaps in parallel and publishes a merged `artifacts-generated.yaml` as a
-GitHub artifact.
-
-### Calling from an operator repository
 
 ```yaml
 jobs:
@@ -364,58 +138,25 @@ jobs:
     uses: javierdelapuente/operator-ci-poc/.github/workflows/build-artifacts.yml@main
     permissions:
       contents: read
-      packages: write   # required for GHCR rock pushes
-      actions: read     # required for get-workflow-version-action
+      packages: write
+      actions: read
     with:
-      working-directory: .  # directory containing artifacts.yaml (default: .)
+      working-directory: .
 ```
 
-Pinning to a SHA or tag (e.g. `@abc1234`, `@v1.2`) automatically installs the
-matching `opcli` version — the SHA is resolved via
-`canonical/get-workflow-version-action`, so no separate version input is needed.
-
-### Workflow jobs
-
-| Job | What it does |
-|---|---|
-| **build-matrix** | Runs `opcli artifacts matrix` to generate the GitHub Actions matrix |
-| **build** (parallel) | Builds each artifact; pushes rocks to GHCR; uploads partial `artifacts-generated.yaml` |
-| **collect** | Merges all partials via `opcli artifacts collect`; uploads final `artifacts-generated` artifact |
-
-## Local OCI registry
-
-When running integration tests locally with k8s or MicroK8s, rock images need to be available in a registry that the cluster can pull from.
-
-`opcli provision registry` deploys a local OCI registry at `localhost:32000` by inspecting `concierge.yaml`:
-
-- **MicroK8s or canonical k8s**: applies an embedded `registry:2` Deployment + NodePort 32000 Service manifest via the provider's own `kubectl` (`microk8s kubectl` or `k8s kubectl`). The same manifest is used for both providers.
-- **Neither enabled**: logs a message and skips — no action taken.
-- **Already running**: detects an existing listener on port 32000 and skips without modifying anything.
-- **No rocks in `artifacts-generated.yaml`**: skips — the registry is only needed to serve locally-built rock images.
-- **Both providers enabled simultaneously**: raises an error.
-
-When using `opcli spread run`, the local prepare script automatically calls `opcli provision registry -c "$CONCIERGE"` after `concierge prepare`, so no manual step is needed in the spread workflow.
-
-> **Note (canonical k8s):** For workloads to pull images from `localhost:32000`, containerd must treat it as an insecure registry. This may require additional manual configuration for canonical k8s.
+Pinning to a SHA or tag automatically installs the matching `opcli` version via `canonical/get-workflow-version-action`.
 
 ## Development
 
 Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/).
 
 ```bash
-git clone https://github.com/javierdelapuente/operator-ci-poc.git
-cd operator-ci-poc
-uv sync
-
-# Lint
-uv run ruff check src/ tests/
-uv run ruff format --check src/ tests/
-
-# Type check
-uv run mypy src/
-
-# Test
-uv run pytest tests/ -v
+uv sync                                    # install deps
+uv run opcli --help                        # run the tool
+uv run ruff check src/ tests/              # lint
+uv run ruff format --check src/ tests/     # format check
+uv run mypy src/                           # type check
+uv run pytest tests/unit/                  # unit tests
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ snaps:
 Key fields:
 - **`*-yaml`**: explicit path to the craft YAML file (not a directory).
 - **`pack-dir`**: working directory for the build tool (defaults to the YAML's parent dir).
-- **`builds[].runner`**: GitHub Actions runner labels; defaults to `[ubuntu-latest]`.
+- **`builds[].runner`**: GitHub Actions runner labels (used by `opcli artifacts matrix`; defaults to `["ubuntu-latest"]` at matrix generation time when omitted).
 
 ## CI vs local
 
@@ -130,7 +130,16 @@ Key fields:
 | `CI` | Spread backend expansion | `*-local` (LXD VM) | `*-ci` (current runner) |
 | `GITHUB_ACTIONS` | Artifact output format | Local file paths | GHCR images + artifact refs |
 
-## GitHub Actions reusable workflow
+## GitHub Actions reusable workflows
+
+Two reusable workflows are available for operator repositories:
+
+| Workflow | Purpose |
+|---|---|
+| `build-artifacts.yml` | Build matrix generation, parallel artifact builds, merged `artifacts-generated.yaml` |
+| `integration-test.yml` | Download artifacts, generate spread task matrix, run integration tests |
+
+Example usage:
 
 ```yaml
 jobs:


### PR DESCRIPTION
## Changes

**README.md** — reduced from ~420 lines to ~160:
- Added intro paragraph (what/why/who)
- Added documentation links table (spec, divergences, AGENTS.md)
- Condensed command tables to scannable one-liners
- Removed duplicated content that belongs in the spec (CI vs local format examples, system field handling table, OCI registry internals, pack-dir symlink explanation)
- Kept: quick-start, command reference, schema example, CI env var table, workflow usage

**AGENTS.md** — reduced from ~382 lines to ~150:
- Removed command-family invariants section (agents can read the spec)
- Removed data model YAML examples (agents can read models/ directly)
- Removed spread.yaml virtual backend explanation (in spec)
- Kept only what agents need to avoid mistakes: architecture rules, build tool invariants, subprocess rule, error hierarchy, testing conventions, git workflow
- Aligned with AGENTS.md best practices: concise, actionable, constraint-focused