### PR TITLE
refactor: replace inline shell with opcli install/concierge commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ eval "$(opcli pytest expand -- -k test_charm)"   # run tests via tox
 | `fetch` | Download CI artifacts and rewrite to local paths. `--run-id`, `--repo`, `--wait`. |
 | `localize` | Rewrite CI artifact refs to local paths (after manual download). |
 
+### `opcli install`
+
+| Command | Description |
+|---|---|
+| `spread` | Install the spread test runner (no-op if already present). |
+| `tox` | Install tox with tox-uv for running integration tests. |
+
+### `opcli concierge`
+
+| Command | Description |
+|---|---|
+| `prepare` | Install concierge snap and run `concierge prepare`. No-op if no config file. `-c` for path. |
+
 ### `opcli provision`
 
 | Command | Description |

--- a/src/opcli/app.py
+++ b/src/opcli/app.py
@@ -2,7 +2,15 @@
 
 import typer
 
-from opcli.commands import artifacts, provision, pytest_cmd, spread, tutorial_cmd
+from opcli.commands import (
+    artifacts,
+    concierge,
+    install,
+    provision,
+    pytest_cmd,
+    spread,
+    tutorial_cmd,
+)
 
 app = typer.Typer(
     name="opcli",
@@ -11,6 +19,8 @@ app = typer.Typer(
 )
 
 app.add_typer(artifacts.app, name="artifacts")
+app.add_typer(concierge.app, name="concierge")
+app.add_typer(install.app, name="install")
 app.add_typer(provision.app, name="provision")
 app.add_typer(spread.app, name="spread")
 app.add_typer(pytest_cmd.app, name="pytest")

--- a/src/opcli/commands/concierge.py
+++ b/src/opcli/commands/concierge.py
@@ -1,0 +1,35 @@
+"""CLI commands for concierge operations."""
+
+from pathlib import Path
+
+import typer
+
+from opcli.core.concierge import concierge_prepare as _concierge_prepare
+
+app = typer.Typer(
+    help="Manage concierge-based test environment provisioning.",
+    no_args_is_help=True,
+)
+
+_CONCIERGE_YAML = "concierge.yaml"
+
+
+@app.command()
+def prepare(
+    *,
+    concierge_file: str = typer.Option(
+        _CONCIERGE_YAML,
+        "-c",
+        "--concierge",
+        help="Path to concierge.yaml (relative to the project root).",
+    ),
+) -> None:
+    """Install concierge and provision the test environment.
+
+    No-op if concierge.yaml does not exist.
+    """
+    ran = _concierge_prepare(Path.cwd(), concierge_file=concierge_file)
+    if ran:
+        typer.echo("Concierge provisioning complete.")
+    else:
+        typer.echo("No concierge.yaml found — skipped.")

--- a/src/opcli/commands/install.py
+++ b/src/opcli/commands/install.py
@@ -1,0 +1,24 @@
+"""CLI commands for installing tool dependencies."""
+
+import typer
+
+from opcli.core.install import install_spread, install_tox
+
+app = typer.Typer(
+    help="Install tool dependencies for spread test environments.",
+    no_args_is_help=True,
+)
+
+
+@app.command()
+def spread() -> None:
+    """Install the spread test runner (no-op if already present)."""
+    install_spread()
+    typer.echo("spread is available.")
+
+
+@app.command()
+def tox() -> None:
+    """Install tox with tox-uv for running integration tests."""
+    install_tox()
+    typer.echo("tox is available.")

--- a/src/opcli/core/concierge.py
+++ b/src/opcli/core/concierge.py
@@ -1,0 +1,39 @@
+"""Core logic for ``opcli concierge prepare``.
+
+Installs the concierge snap and runs ``concierge prepare`` to provision
+the test environment.  No-op if no ``concierge.yaml`` is found.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from opcli.core.subprocess import run_command
+
+logger = logging.getLogger(__name__)
+
+_CONCIERGE_YAML = "concierge.yaml"
+
+
+def concierge_prepare(
+    root: Path,
+    *,
+    concierge_file: str = _CONCIERGE_YAML,
+) -> bool:
+    """Install concierge and run ``concierge prepare``.
+
+    Returns True if concierge was run, False if skipped (no config file).
+    """
+    concierge_path = root / concierge_file
+    if not concierge_path.exists():
+        logger.info("No %s found — skipping concierge.", concierge_file)
+        return False
+
+    run_command(["snap", "install", "concierge", "--classic"], check=False)
+    run_command(
+        ["concierge", "prepare", "-c", str(concierge_path)],
+        cwd=str(root),
+    )
+    logger.info("Concierge provisioning complete via %s", concierge_file)
+    return True

--- a/src/opcli/core/install.py
+++ b/src/opcli/core/install.py
@@ -1,0 +1,41 @@
+"""Core logic for ``opcli install spread`` and ``opcli install tox``.
+
+These commands install tool dependencies needed by the spread test
+environment.  They are designed to be called from the spread ``prepare:``
+script after opcli itself has been bootstrapped.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+from opcli.core.subprocess import run_command
+
+
+def install_spread() -> None:
+    """Install spread if not already on PATH.
+
+    Installs Go via snap and builds spread from source.
+    """
+    if shutil.which("spread"):
+        return
+    run_command(["snap", "install", "go", "--classic"])
+    run_command(
+        ["go", "install", "github.com/canonical/spread/cmd/spread@latest"],
+    )
+    run_command(["ln", "-sf", "/root/go/bin/spread", "/usr/local/bin/spread"])
+
+
+def install_tox() -> None:
+    """Install tox with tox-uv via uv tool.
+
+    Uses /usr/local/bin as the tool bin directory so that tox is
+    available system-wide.
+    """
+    run_command(
+        ["uv", "tool", "install", "tox", "--with", "tox-uv", "--quiet"],
+        env={
+            "UV_TOOL_BIN_DIR": "/usr/local/bin",
+            "UV_TOOL_DIR": "/usr/local/share/uv-tools",
+        },
+    )

--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -85,10 +85,15 @@ def provision_load(
     """
     gen_path = root / _ARTIFACTS_GENERATED_YAML
     if not gen_path.exists():
-        msg = (
-            f"{_ARTIFACTS_GENERATED_YAML} not found. Run 'opcli artifacts build' first."
+        logger.info("No %s found — nothing to load.", _ARTIFACTS_GENERATED_YAML)
+        return []
+
+    if not _is_port_open("localhost", _REGISTRY_PORT):
+        logger.info(
+            "Registry not reachable at localhost:%d — skipping load.",
+            _REGISTRY_PORT,
         )
-        raise ConfigurationError(msg)
+        return []
 
     generated = load_artifacts_build(gen_path)
     pushed: list[str] = []

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -280,22 +280,12 @@ else
       "git+https://github.com/javierdelapuente/operator-ci-poc@${OPCLI_GIT_REF:-main}" \
       --quiet
 fi
-if ! command -v spread >/dev/null 2>&1; then
-  snap install go --classic
-  go install github.com/canonical/spread/cmd/spread@latest
-  ln -sf ~/go/bin/spread /usr/local/bin/spread
-fi
-UV_TOOL_BIN_DIR=/usr/local/bin UV_TOOL_DIR=/usr/local/share/uv-tools uv tool install tox --with tox-uv --quiet
-if [ -f "$CONCIERGE" ]; then
-  snap install concierge --classic || true
-  concierge prepare -c "$CONCIERGE"
-  runuser -l ubuntu -c \
-    "cd \\"${SPREAD_PATH}\\" && opcli provision registry -c \\"$CONCIERGE\\""
-fi
-if [ -f "${SPREAD_PATH}/artifacts.build.yaml" ] && \
-    curl -sf --max-time 5 http://localhost:32000/v2/ > /dev/null 2>&1; then
-  opcli provision load
-fi
+opcli install spread
+opcli install tox
+opcli concierge prepare -c "$CONCIERGE"
+runuser -l ubuntu -c \
+  "cd \\"${SPREAD_PATH}\\" && opcli provision registry -c \\"$CONCIERGE\\""
+opcli provision load
 """
 
 _LOCAL_PREPARE_AFTER_USER = """\
@@ -314,16 +304,9 @@ else
       "git+https://github.com/javierdelapuente/operator-ci-poc@${OPCLI_GIT_REF:-main}" \
       --quiet
 fi
-if ! command -v spread >/dev/null 2>&1; then
-  snap install go --classic
-  go install github.com/canonical/spread/cmd/spread@latest
-  ln -sf ~/go/bin/spread /usr/local/bin/spread
-fi
-runuser -l ubuntu -c "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox --with tox-uv --quiet"
-if [ -f "$CONCIERGE" ]; then
-  snap install concierge --classic || true
-  concierge prepare -c "$CONCIERGE"
-fi
+opcli install spread
+opcli install tox
+opcli concierge prepare -c "$CONCIERGE"
 """
 
 _CI_PREPARE_AFTER_USER = """\
@@ -333,8 +316,8 @@ if [ -n "${GITHUB_RUN_ID:-}" ]; then
     --run-id "${GITHUB_RUN_ID}" \
     --repo "${GITHUB_REPOSITORY}" \
     --wait
-  chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 fi
+chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 """
 
 _CI_ALLOCATE = """\

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -102,14 +102,17 @@ class TestProvisionRun:
 class TestProvisionLoad:
     """Tests for provision_load()."""
 
-    def test_missing_generated_raises(self, tmp_path: Path) -> None:
-        with pytest.raises(ConfigurationError, match="not found"):
-            provision_load(tmp_path)
+    def test_missing_generated_returns_empty(self, tmp_path: Path) -> None:
+        result = provision_load(tmp_path)
+        assert result == []
 
     def test_pushes_local_rocks(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts.build.yaml", _GENERATED_WITH_ROCKS)
 
-        with patch("opcli.core.provision.run_command") as mock_run:
+        with (
+            patch("opcli.core.provision.run_command") as mock_run,
+            patch("opcli.core.provision._is_port_open", return_value=True),
+        ):
             pushed = provision_load(tmp_path)
 
         # Only myrock has a file output; otherrock has image (CI) → skipped
@@ -122,7 +125,10 @@ class TestProvisionLoad:
     def test_custom_registry(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts.build.yaml", _GENERATED_WITH_ROCKS)
 
-        with patch("opcli.core.provision.run_command") as mock_run:
+        with (
+            patch("opcli.core.provision.run_command") as mock_run,
+            patch("opcli.core.provision._is_port_open", return_value=True),
+        ):
             pushed = provision_load(tmp_path, registry="myregistry:5000")
 
         assert "myregistry:5000" in pushed[0]
@@ -138,7 +144,10 @@ class TestProvisionLoad:
             "  output:\n  - arch: amd64\n    image: ghcr.io/r1:v1\n",
         )
 
-        with patch("opcli.core.provision.run_command") as mock_run:
+        with (
+            patch("opcli.core.provision.run_command") as mock_run,
+            patch("opcli.core.provision._is_port_open", return_value=True),
+        ):
             pushed = provision_load(tmp_path)
 
         assert pushed == []
@@ -147,7 +156,10 @@ class TestProvisionLoad:
     def test_empty_generated_returns_empty(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts.build.yaml", "version: 1\n")
 
-        with patch("opcli.core.provision.run_command") as mock_run:
+        with (
+            patch("opcli.core.provision.run_command") as mock_run,
+            patch("opcli.core.provision._is_port_open", return_value=True),
+        ):
             pushed = provision_load(tmp_path)
 
         assert pushed == []
@@ -156,7 +168,10 @@ class TestProvisionLoad:
     def test_skopeo_commands_correct(self, tmp_path: Path) -> None:
         _write(tmp_path / "artifacts.build.yaml", _GENERATED_WITH_ROCKS)
 
-        with patch("opcli.core.provision.run_command") as mock_run:
+        with (
+            patch("opcli.core.provision.run_command") as mock_run,
+            patch("opcli.core.provision._is_port_open", return_value=True),
+        ):
             provision_load(tmp_path)
 
         # Single call: direct oci-archive → registry (no docker-daemon step)
@@ -172,7 +187,10 @@ class TestProvisionLoad:
         """After pushing, rock.output.image is set and file is preserved."""
         _write(tmp_path / "artifacts.build.yaml", _GENERATED_WITH_ROCKS)
 
-        with patch("opcli.core.provision.run_command"):
+        with (
+            patch("opcli.core.provision.run_command"),
+            patch("opcli.core.provision._is_port_open", return_value=True),
+        ):
             provision_load(tmp_path)
 
         updated = load_artifacts_build(tmp_path / "artifacts.build.yaml")
@@ -187,7 +205,10 @@ class TestProvisionLoad:
             _GENERATED_WITH_ROCKS_AND_RESOURCES,
         )
 
-        with patch("opcli.core.provision.run_command"):
+        with (
+            patch("opcli.core.provision.run_command"),
+            patch("opcli.core.provision._is_port_open", return_value=True),
+        ):
             provision_load(tmp_path)
 
         updated = load_artifacts_build(tmp_path / "artifacts.build.yaml")

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -176,10 +176,11 @@ class TestSpreadExpand:
         assert "SPREAD_PASSWORD" in local["allocate"]
         assert "lxc delete --force" in local["discard"]
         prepare = local["prepare"]
-        assert "concierge prepare" in prepare
+        assert "opcli concierge prepare" in prepare
         assert "opcli provision registry" in prepare
-        assert '[ -f "$CONCIERGE" ]' in prepare
         assert "opcli provision load" in prepare
+        assert "opcli install spread" in prepare
+        assert "opcli install tox" in prepare
         # Local uses uv (not pipx) with dev-mode detection, same as CI
         assert "pipx" not in prepare
         assert "uv tool install" in prepare
@@ -187,11 +188,7 @@ class TestSpreadExpand:
         assert "UV_TOOL_DIR=/usr/local/share/uv-tools" in prepare
         assert "pyproject.toml" in prepare
         assert "SPREAD_PATH" in prepare
-        # spread installed if not already present
-        assert "command -v spread" in prepare
         assert "loginctl enable-linger ubuntu" in prepare
-        # artifacts-build check uses SPREAD_PATH
-        assert "${SPREAD_PATH}/artifacts.build.yaml" in prepare
 
         # Systems should have username: ubuntu injected
         systems = local["systems"]
@@ -216,15 +213,12 @@ class TestSpreadExpand:
         # concierge runs as root but loginctl enable-linger ubuntu ensures
         # ubuntu's systemd session is active so snap cgroups work correctly
         assert 'runuser -l ubuntu -c "concierge prepare' not in ci["prepare"]
-        assert "tox" in ci["prepare"]
+        assert "opcli install tox" in ci["prepare"]
+        assert "opcli install spread" in ci["prepare"]
         assert "opcli" in ci["prepare"]
         assert "SPREAD_PATH" in ci["prepare"]
         assert "GITHUB_WORKSPACE" in ci["prepare"]
         assert "chown" in ci["prepare"]
-        # tox is installed for the ubuntu user via runuser with explicit bin dir
-        assert "runuser" in ci["prepare"]
-        assert "runuser -l ubuntu" in ci["prepare"]
-        assert "UV_TOOL_BIN_DIR=/usr/local/bin uv tool install tox" in ci["prepare"]
         assert "loginctl enable-linger ubuntu" in ci["prepare"]
         assert "UV_TOOL_BIN_DIR=/usr/local/bin" in ci["prepare"]
         # CI prepare downloads build artifacts via opcli artifacts fetch
@@ -249,8 +243,8 @@ class TestSpreadExpand:
         assert "pipx install" not in ci["prepare"]
         # uv installed in CI prepare (idempotent: already on runner but re-ensures)
         assert "astral-uv" in ci["prepare"]
-        # spread installed if not already present
-        assert "command -v spread" in ci["prepare"]
+        # spread installed via opcli install spread
+        assert "opcli install spread" in ci["prepare"]
         assert "discard" not in ci
         # CI injects username: root per-system for SSH access
         systems = ci["systems"]
@@ -448,26 +442,27 @@ suites:
         assert "PasswordAuthentication yes" in allocate
 
     def test_local_prepare_conditional(self, tmp_path: Path) -> None:
-        """Prepare script gates concierge and provision load on file existence."""
+        """Prepare script delegates conditionals to opcli subcommands."""
         _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
 
         result = spread_expand(tmp_path, ci=False)
         parsed = _yaml.load(StringIO(result))
         prepare = parsed["backends"]["integration-test-local"]["prepare"]
 
-        assert '[ -f "$CONCIERGE" ]' in prepare
-        assert '[ -f "${SPREAD_PATH}/artifacts.build.yaml" ]' in prepare
+        # Conditionals are now internal to the opcli commands
+        assert "opcli concierge prepare" in prepare
+        assert "opcli provision load" in prepare
 
     def test_ci_prepare_conditional(self, tmp_path: Path) -> None:
-        """CI prepare gates concierge on file existence."""
+        """CI prepare delegates concierge to opcli subcommand."""
         _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
 
         result = spread_expand(tmp_path, ci=True)
         parsed = _yaml.load(StringIO(result))
         prepare = parsed["backends"]["integration-test-ci"]["prepare"]
 
-        assert '[ -f "$CONCIERGE" ]' in prepare
-        assert "tox" in prepare
+        assert "opcli concierge prepare" in prepare
+        assert "opcli install tox" in prepare
         assert "SPREAD_PATH" in prepare
         assert "pipx install" not in prepare
 


### PR DESCRIPTION
Extract spread/tox installation and concierge preparation logic from embedded shell scripts into proper opcli subcommands:

- `opcli install spread` — installs spread (no-op if already present)
- `opcli install tox` — installs tox+tox-uv via uv tool
- `opcli concierge prepare -c $CONCIERGE` — installs concierge snap + runs prepare (no-op if no config file)

Also makes `provision_load` a safe no-op when `artifacts-generated.yaml` is missing or the registry is unreachable.

The prepare scripts now read as explicit step-by-step recipes rather than duplicated shell logic with inline conditionals.