### PR TITLE
Support user-defined prepare scripts in virtual backends

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -268,7 +268,7 @@ if [ -n "$instance_name" ]; then
 fi
 """
 
-_LOCAL_PREPARE = """\
+_LOCAL_PREPARE_BEFORE_USER = """\
 loginctl enable-linger ubuntu
 snap install astral-uv --classic
 export UV_TOOL_BIN_DIR=/usr/local/bin
@@ -296,10 +296,13 @@ if [ -f "${SPREAD_PATH}/artifacts.build.yaml" ] && \
     curl -sf --max-time 5 http://localhost:32000/v2/ > /dev/null 2>&1; then
   opcli provision load
 fi
+"""
+
+_LOCAL_PREPARE_AFTER_USER = """\
 chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 """
 
-_CI_PREPARE = """\
+_CI_PREPARE_BEFORE_USER = """\
 loginctl enable-linger ubuntu
 chown -R ubuntu:ubuntu "${SPREAD_PATH}"
 snap install astral-uv --classic
@@ -321,6 +324,9 @@ if [ -f "$CONCIERGE" ]; then
   snap install concierge --classic || true
   concierge prepare -c "$CONCIERGE"
 fi
+"""
+
+_CI_PREPARE_AFTER_USER = """\
 if [ -n "${GITHUB_RUN_ID:-}" ]; then
   export GH_TOKEN="${GITHUB_TOKEN}"
   cd "${SPREAD_PATH}" && opcli artifacts fetch \
@@ -362,16 +368,21 @@ fi
 
 
 # Map each virtual backend type value to:
-#   (local_prepare, ci_prepare)
+#   (local_prepare_before, local_prepare_after, ci_prepare_before, ci_prepare_after)
 # Backends in spread.yaml declare their virtual type via the ``type:`` field
 # (e.g. ``type: integration-test``).  Concrete names are derived as
 # ``"{backend_name}-local"`` / ``"{backend_name}-ci"`` from the user-defined
 # backend name.
 # The CI prepare for tutorial is empty — workflows are expected to
 # install opcli before invoking spread.
-_BACKEND_CONFIGS: dict[str, tuple[str, str]] = {
-    _VIRTUAL_BACKEND: (_LOCAL_PREPARE, _CI_PREPARE),
-    _TUTORIAL_BACKEND: (_TUTORIAL_LOCAL_PREPARE, ""),
+_BACKEND_CONFIGS: dict[str, tuple[str, str, str, str]] = {
+    _VIRTUAL_BACKEND: (
+        _LOCAL_PREPARE_BEFORE_USER,
+        _LOCAL_PREPARE_AFTER_USER,
+        _CI_PREPARE_BEFORE_USER,
+        _CI_PREPARE_AFTER_USER,
+    ),
+    _TUTORIAL_BACKEND: (_TUTORIAL_LOCAL_PREPARE, "", "", ""),
 }
 
 # Keys in system entries that are opcli-specific and must be stripped before
@@ -515,21 +526,34 @@ def _build_concrete_backend(
     virtual: object,
     *,
     use_ci: bool,
-    local_prepare: str,
-    ci_prepare: str,
+    prepare_parts: tuple[str, str, str, str],
 ) -> dict[str, object]:
-    """Return a concrete adhoc backend dict built from a virtual backend entry."""
+    """Return a concrete adhoc backend dict built from a virtual backend entry.
+
+    *prepare_parts* is ``(local_before, local_after, ci_before, ci_after)``.
+    If the user's virtual backend contains a ``prepare`` key its content is
+    spliced between the *before* and *after* sections of the appropriate mode.
+    """
     backend_def: dict[str, object] = (
         deepcopy(virtual) if isinstance(virtual, dict) else {}
     )
     backend_def["type"] = "adhoc"
 
+    # Extract user-defined prepare before we overwrite it.
+    user_prepare = backend_def.pop("prepare", None)
+    user_prepare_str = str(user_prepare).rstrip("\n") + "\n" if user_prepare else ""
+
+    local_prepare_before, local_prepare_after, ci_prepare_before, ci_prepare_after = (
+        prepare_parts
+    )
+
     systems = backend_def.get("systems")
 
     if use_ci:
         backend_def["allocate"] = _CI_ALLOCATE
-        if ci_prepare:
-            backend_def["prepare"] = ci_prepare
+        prepare = ci_prepare_before + user_prepare_str + ci_prepare_after
+        if prepare:
+            backend_def["prepare"] = prepare
         # GitHub Actions vars are only needed for the CI backend so that
         # _CI_PREPARE can authenticate and download build artifacts via gh.
         # Scoping them here keeps the root spread.yaml clean for local runs.
@@ -568,8 +592,9 @@ def _build_concrete_backend(
             "SUDO_USER": "ubuntu",
             **existing_env,
         }
-        if local_prepare:
-            backend_def["prepare"] = local_prepare
+        prepare = local_prepare_before + user_prepare_str + local_prepare_after
+        if prepare:
+            backend_def["prepare"] = prepare
 
         if isinstance(systems, list):
             backend_def["systems"] = _transform_systems(
@@ -653,7 +678,7 @@ def _expand_backend(
             continue
         found_any = True
 
-        local_prepare, ci_prepare = _BACKEND_CONFIGS[backend_type]
+        prepare_parts = _BACKEND_CONFIGS[backend_type]
         # Strip the virtual type field; _build_concrete_backend sets type: adhoc
         virtual = {k: v for k, v in backend_entry.items() if k != "type"}
         del backends[backend_name]
@@ -669,8 +694,7 @@ def _expand_backend(
         backends[concrete_name] = _build_concrete_backend(
             virtual,
             use_ci=use_ci,
-            local_prepare=local_prepare,
-            ci_prepare=ci_prepare,
+            prepare_parts=prepare_parts,
         )
         _replace_suite_backend_name(data, backend_name, concrete_name)
 

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -306,6 +306,82 @@ suites:
         assert local["type"] == "adhoc"
         assert "lxc launch --vm" in local["allocate"]
 
+    def test_user_prepare_spliced_into_local(self, tmp_path: Path) -> None:
+        """User prepare is inserted after provisioning, before final chown."""
+        spread_with_prepare = """\
+project: test-project
+backends:
+  integration-test:
+    type: integration-test
+    systems:
+      - ubuntu-24.04
+    prepare: |
+      echo "user setup step"
+      apt-get install -y custom-pkg
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/integration/: {}
+"""
+        _write(tmp_path / "spread.yaml", spread_with_prepare)
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        local = parsed["backends"]["integration-test-local"]
+        prepare = local["prepare"]
+
+        # User prepare is present
+        assert 'echo "user setup step"' in prepare
+        assert "apt-get install -y custom-pkg" in prepare
+        # User prepare comes after concierge/provisioning
+        assert prepare.index("concierge prepare") < prepare.index("user setup step")
+        # User prepare comes before final chown
+        assert prepare.index("user setup step") < prepare.index(
+            'chown -R ubuntu:ubuntu "${SPREAD_PATH}"'
+        )
+
+    def test_user_prepare_spliced_into_ci(self, tmp_path: Path) -> None:
+        """User prepare is inserted after concierge, before artifact fetch."""
+        spread_with_prepare = """\
+project: test-project
+backends:
+  integration-test:
+    type: integration-test
+    systems:
+      - ubuntu-24.04
+    prepare: |
+      echo "user ci setup"
+environment:
+  MODULE/test_charm: test_charm
+suites:
+  tests/integration/: {}
+"""
+        _write(tmp_path / "spread.yaml", spread_with_prepare)
+        result = spread_expand(tmp_path, ci=True)
+        parsed = _yaml.load(StringIO(result))
+        ci = parsed["backends"]["integration-test-ci"]
+        prepare = ci["prepare"]
+
+        # User prepare is present
+        assert 'echo "user ci setup"' in prepare
+        # User prepare comes after concierge provisioning
+        assert prepare.index("concierge prepare") < prepare.index("user ci setup")
+        # User prepare comes before artifact fetch
+        assert prepare.index("user ci setup") < prepare.index("opcli artifacts fetch")
+
+    def test_no_user_prepare_unchanged(self, tmp_path: Path) -> None:
+        """Without a user prepare key, generated prepare is unchanged."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+        result = spread_expand(tmp_path, ci=False)
+        parsed = _yaml.load(StringIO(result))
+        local = parsed["backends"]["integration-test-local"]
+        prepare = local["prepare"]
+
+        # Standard parts are present
+        assert "concierge prepare" in prepare
+        assert 'chown -R ubuntu:ubuntu "${SPREAD_PATH}"' in prepare
+        # No doubled newlines from empty user prepare
+        assert "\n\n\n" not in prepare
+
     def test_local_allocate_has_cleanup_trap(self, tmp_path: Path) -> None:
         """The local allocate script must clean up the VM on failure."""
         _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)


### PR DESCRIPTION
## Summary

Split `_LOCAL_PREPARE` and `_CI_PREPARE` into before/after parts so that a user-defined `prepare` key on a virtual backend is spliced at the correct insertion point:

- **CI**: after concierge provisioning, before artifact fetch (runs in parallel with build jobs for a performance win)
- **Local**: after provisioning and OCI image loading, before final chown

If no user prepare is specified, behavior is unchanged.

## Changes

- `src/opcli/core/spread.py`: Split prepare templates into `_*_PREPARE_BEFORE_USER` / `_*_PREPARE_AFTER_USER` pairs. Updated `_BACKEND_CONFIGS` to store 4-tuples. Updated `_build_concrete_backend` to extract and splice user prepare.
- `tests/unit/test_spread.py`: Added tests for user prepare splicing in both local and CI modes, and a test verifying no-op when no user prepare is defined.

Closes #136