### PR TITLE
feat: add .secrets.env support for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,6 +27,27 @@ on:
         description: "Directory containing artifacts.yaml and spread.yaml (relative to workspace root)"
         type: string
         default: "."
+      test-secret-1-name:
+        description: "Name of secret #1 to pass to integration tests"
+        type: string
+        default: ""
+      test-secret-2-name:
+        description: "Name of secret #2 to pass to integration tests"
+        type: string
+        default: ""
+      test-secret-3-name:
+        description: "Name of secret #3 to pass to integration tests"
+        type: string
+        default: ""
+      test-secret-4-name:
+        description: "Name of secret #4 to pass to integration tests"
+        type: string
+        default: ""
+      test-secret-5-name:
+        description: "Name of secret #5 to pass to integration tests"
+        type: string
+        default: ""
+    secrets: inherit
 
 jobs:
   # ── Job 1: build all artifacts ──────────────────────────────────────────────
@@ -132,6 +153,33 @@ jobs:
           sudo snap install go --classic
           go install github.com/canonical/spread/cmd/spread@latest
           sudo ln -sf ~/go/bin/spread /usr/local/bin/spread
+
+      # ── Export test secrets ─────────────────────────────────────────────
+      - name: Export test secrets
+        if: >-
+          inputs.test-secret-1-name != '' ||
+          inputs.test-secret-2-name != '' ||
+          inputs.test-secret-3-name != '' ||
+          inputs.test-secret-4-name != '' ||
+          inputs.test-secret-5-name != ''
+        env:
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+        run: |
+          for name in \
+            "${{ inputs.test-secret-1-name }}" \
+            "${{ inputs.test-secret-2-name }}" \
+            "${{ inputs.test-secret-3-name }}" \
+            "${{ inputs.test-secret-4-name }}" \
+            "${{ inputs.test-secret-5-name }}"; do
+            if [ -z "$name" ]; then continue; fi
+            value=$(echo "$ALL_SECRETS" | jq -r --arg k "$name" '.[$k] // empty')
+            if [ -z "$value" ]; then
+              echo "::warning::Secret '$name' not found or empty"
+              continue
+            fi
+            echo "::add-mask::$value"
+            echo "$name=$value" >> "$GITHUB_ENV"
+          done
 
       # ── Run the spread task ───────────────────────────────────────────────
       # Artifact download happens inside spread _CI_PREPARE (after provisioning).

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -794,6 +794,51 @@ def spread_expand(
 # ---------------------------------------------------------------------------
 
 
+_SECRETS_ENV_FILE = ".secrets.env"
+
+
+def _load_secrets_env(root: Path) -> dict[str, str]:
+    """Load secrets from ``.secrets.env`` in the project root.
+
+    The file uses plain ``KEY=VALUE`` format (one per line).  Blank lines and
+    lines starting with ``#`` are ignored.  Values may be optionally quoted
+    with single or double quotes.
+
+    Returns an empty dict if the file does not exist.
+    """
+    secrets_path = root / _SECRETS_ENV_FILE
+    if not secrets_path.is_file():
+        return {}
+
+    env: dict[str, str] = {}
+    for lineno, raw_line in enumerate(secrets_path.read_text().splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            logger.warning(
+                "%s:%d: skipping malformed line (no '=' found)",
+                _SECRETS_ENV_FILE,
+                lineno,
+            )
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        # Strip optional surrounding quotes
+        if (
+            len(value) >= 2  # noqa: PLR2004
+            and value[0] == value[-1]
+            and value[0] in ("'", '"')
+        ):
+            value = value[1:-1]
+        env[key] = value
+
+    if env:
+        logger.info("Loaded %d secret(s) from %s", len(env), _SECRETS_ENV_FILE)
+    return env
+
+
 def spread_run(
     root: Path,
     *,
@@ -807,12 +852,24 @@ def spread_run(
     parent directory.  Spread is invoked from that subdirectory; the original
     ``spread.yaml`` is never modified.
 
+    In local mode, secrets from ``.secrets.env`` (if present) are loaded and
+    passed as environment variables to the spread subprocess.  In CI mode the
+    variables are expected to already be in the environment.
+
     Raises:
         ConfigurationError: If ``spread.yaml`` is missing or malformed.
         SubprocessError: If spread exits non-zero.
     """
+    is_ci = ci if ci is not None else _is_ci()
     expanded = _expand(root, ci=ci)
     expanded["reroot"] = _compose_reroot(expanded.get("reroot"))
+
+    # Load secrets env overlay for local runs only
+    secrets_env: dict[str, str] | None = None
+    if not is_ci:
+        loaded = _load_secrets_env(root)
+        if loaded:
+            secrets_env = loaded
 
     with tempfile.TemporaryDirectory(prefix=".spread-run-", dir=root) as tmp_dir:
         tmp_yaml = Path(tmp_dir) / _SPREAD_YAML
@@ -822,7 +879,7 @@ def spread_run(
         cmd = ["spread"]
         if extra_args:
             cmd.extend(extra_args)
-        run_command(cmd, cwd=tmp_dir, interactive=True)
+        run_command(cmd, cwd=tmp_dir, interactive=True, env=secrets_env)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_spread_lxd.py
+++ b/tests/integration/test_spread_lxd.py
@@ -65,6 +65,41 @@ execute: |
     pwd
 """
 
+_SECRETS_SPREAD_YAML = """\
+project: secrets-test
+
+path: /home/ubuntu/proj
+
+kill-timeout: 30m
+
+backends:
+  integration-test:
+    systems:
+      - ubuntu-24.04
+
+environment:
+  CONCIERGE: concierge.yaml
+  TEST_SECRET: '$(HOST: echo "${TEST_SECRET:-}")'
+
+exclude:
+  - .git
+
+suites:
+  tests/integration/:
+    summary: integration tests
+    environment:
+      MODULE/test_basic: test_basic
+"""
+
+_SECRETS_TASK_YAML = """\
+summary: verify secrets are forwarded
+
+execute: |
+    test -n "$TEST_SECRET" || { echo "TEST_SECRET empty"; exit 1; }
+    test "$TEST_SECRET" = "s3cr3t-value" || { echo "wrong value"; exit 1; }
+    echo "secret correctly forwarded"
+"""
+
 
 class TestSpreadLxdLocal:
     """End-to-end tests using the local (LXD VM) backend."""
@@ -99,6 +134,23 @@ class TestSpreadLxdLocal:
         # After successful run, VM count should be same as before
         after = _count_spread_vms()
         assert after == before
+
+    def test_secrets_env_forwarded_to_vm(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Secrets from .secrets.env are available inside the spread VM."""
+        spread_path = tmp_path / "spread.yaml"  # type: ignore[operator]
+        spread_path.write_text(_SECRETS_SPREAD_YAML)
+
+        task_dir = tmp_path / "tests" / "integration" / "run"  # type: ignore[operator]
+        task_dir.mkdir(parents=True)
+        (task_dir / "task.yaml").write_text(_SECRETS_TASK_YAML)
+
+        secrets_path = tmp_path / ".secrets.env"  # type: ignore[operator]
+        secrets_path.write_text("TEST_SECRET=s3cr3t-value\n")
+
+        # Should succeed — spread picks up the secret via $(HOST: echo ...)
+        spread_run(tmp_path, ci=False)  # type: ignore[arg-type]
 
 
 def _count_spread_vms() -> int:

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -13,6 +13,7 @@ from ruamel.yaml import YAML
 from opcli.core.exceptions import ConfigurationError, SubprocessError, ValidationError
 from opcli.core.spread import (
     _arch_from_runner,
+    _load_secrets_env,
     _virtual_runner_map,
     spread_expand,
     spread_init,
@@ -988,6 +989,75 @@ class TestSpreadRun:
     def test_missing_spread_yaml_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ConfigurationError, match="not found"):
             spread_run(tmp_path)
+
+
+class TestLoadSecretsEnv:
+    """Tests for _load_secrets_env() — loading .secrets.env files."""
+
+    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+        assert _load_secrets_env(tmp_path) == {}
+
+    def test_loads_key_value_pairs(self, tmp_path: Path) -> None:
+        (tmp_path / ".secrets.env").write_text("FOO=bar\nBAZ=qux\n")
+        assert _load_secrets_env(tmp_path) == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_ignores_comments_and_blank_lines(self, tmp_path: Path) -> None:
+        content = "# a comment\n\nKEY=val\n   \n# another\n"
+        (tmp_path / ".secrets.env").write_text(content)
+        assert _load_secrets_env(tmp_path) == {"KEY": "val"}
+
+    def test_strips_double_quotes(self, tmp_path: Path) -> None:
+        (tmp_path / ".secrets.env").write_text('SECRET="my value"\n')
+        assert _load_secrets_env(tmp_path) == {"SECRET": "my value"}
+
+    def test_strips_single_quotes(self, tmp_path: Path) -> None:
+        (tmp_path / ".secrets.env").write_text("SECRET='my value'\n")
+        assert _load_secrets_env(tmp_path) == {"SECRET": "my value"}
+
+    def test_preserves_equals_in_value(self, tmp_path: Path) -> None:
+        (tmp_path / ".secrets.env").write_text("URL=postgres://u:p@h/db?opt=1\n")
+        assert _load_secrets_env(tmp_path) == {"URL": "postgres://u:p@h/db?opt=1"}
+
+    def test_skips_malformed_lines(self, tmp_path: Path) -> None:
+        (tmp_path / ".secrets.env").write_text("GOOD=val\nno_equals_here\nALSO=ok\n")
+        result = _load_secrets_env(tmp_path)
+        assert result == {"GOOD": "val", "ALSO": "ok"}
+
+
+class TestSpreadRunSecrets:
+    """Tests for secrets env integration in spread_run()."""
+
+    def test_secrets_env_passed_in_local_mode(self, tmp_path: Path) -> None:
+        """In local mode, .secrets.env vars are passed to run_command."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+        (tmp_path / ".secrets.env").write_text("MY_SECRET=hunter2\n")
+
+        with patch("opcli.core.spread.run_command") as mock_run:
+            spread_run(tmp_path, ci=False)
+
+        kwargs = mock_run.call_args[1]
+        assert kwargs["env"] == {"MY_SECRET": "hunter2"}
+
+    def test_secrets_env_not_loaded_in_ci_mode(self, tmp_path: Path) -> None:
+        """In CI mode, .secrets.env is not loaded (vars come from environment)."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+        (tmp_path / ".secrets.env").write_text("MY_SECRET=hunter2\n")
+
+        with patch("opcli.core.spread.run_command") as mock_run:
+            spread_run(tmp_path, ci=True)
+
+        kwargs = mock_run.call_args[1]
+        assert kwargs.get("env") is None
+
+    def test_no_secrets_file_passes_none(self, tmp_path: Path) -> None:
+        """When .secrets.env doesn't exist, env=None is passed."""
+        _write(tmp_path / "spread.yaml", _MINIMAL_SPREAD)
+
+        with patch("opcli.core.spread.run_command") as mock_run:
+            spread_run(tmp_path, ci=False)
+
+        kwargs = mock_run.call_args[1]
+        assert kwargs.get("env") is None
 
 
 _MINIMAL_SPREAD_WITH_BOTH_BACKENDS = """\


### PR DESCRIPTION
## Summary

Implements secrets support for integration tests (#115).

### Local mode
- New `_load_secrets_env(root)` loads `.secrets.env` (KEY=VALUE, comments, quoted values) from the project root
- `spread_run()` passes these as the `env` overlay to `run_command` in local mode only
- In CI, secrets are already in the environment so the file is not loaded

### CI mode (workflow)
- Added 5 optional `test-secret-{1..5}-name` inputs to `integration-test.yml`
- Added `secrets: inherit` so the workflow can access caller secrets
- Added "Export test secrets" step that resolves secret values by name, masks them with `::add-mask::`, and writes to `GITHUB_ENV`

### Testing
- 7 unit tests for `_load_secrets_env()` (missing file, key-value, comments, quotes, equals in value, malformed lines)
- 3 unit tests for `spread_run()` secrets integration (local passes env, CI skips, no file passes None)
- 1 integration test (`test_secrets_env_forwarded_to_vm`) verifying secrets reach the spread VM via `$(HOST: echo ...)`

Closes #115