### PR TITLE
fix: move secrets: inherit from callee to caller in workflows

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -47,7 +47,6 @@ on:
         description: "Name of secret #5 to pass to integration tests"
         type: string
         default: ""
-    secrets: inherit
 
 jobs:
   # ── Job 1: build all artifacts ──────────────────────────────────────────────

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -27,6 +27,7 @@ jobs:
     uses: ./.github/workflows/integration-test.yml
     with:
       working-directory: examples
+    secrets: inherit
     permissions:
       packages: write
       contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,8 @@ gh pr merge <number> --squash
 
 **CI must be green before merging. No exceptions.**
 
+**If a CI check fails, fix it.** Never dismiss a failure as "pre-existing" or "unrelated to this PR". If a workflow is broken, investigate and fix it in the same PR (or a preceding one) before merging. The goal is to keep `main` green at all times.
+
 All commits must include:
 ```
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


### PR DESCRIPTION
## Problem

The `Test Integration` workflow has been failing immediately (0s, 'workflow file issue') on every run since commit 5f46181 (PR #139).

## Root Cause

`secrets: inherit` was placed inside the `on.workflow_call` block of `integration-test.yml` (the reusable workflow / callee). This is **invalid GitHub Actions syntax** — `secrets: inherit` is a caller-side directive that belongs in `jobs.<id>.secrets`, not in the workflow definition.

## Fix

- Remove `secrets: inherit` from `integration-test.yml` (callee)
- Add `secrets: inherit` to `test-integration.yml` (caller)

This ensures secrets (needed for the 'Export test secrets' step) are properly forwarded from the caller to the reusable workflow.