### PR TITLE
docs: add run/expand alignment rule and docs-per-PR requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ docs/          # Spec + divergences
 2. **Subprocess rule.** All external binary calls go through `core/subprocess.py:run_command`. This is the mock boundary in tests.
 3. **Never overwrite `spread.yaml`.** Always produce a transformed copy in a temp file.
 4. **Avoid `Any`.** Prefer specific types; `mypy --strict` must pass. Legacy `Any` in YAML-handling helpers is tolerated but should not spread.
+5. **CLI consistency: `run` / `expand` pairs.** Commands that execute a subprocess (`run`) and commands that print the equivalent command (`expand`) must be aligned in arguments, flags, and semantics. If `opcli foo run --bar baz` executes something, then `opcli foo expand --bar baz` must print the equivalent command with the same flags accepted. This applies to `spread`, `pytest`, and any future command groups with this pattern.
 
 ---
 
@@ -144,6 +145,8 @@ gh pr merge <number> --squash
 **CI must be green before merging. No exceptions.**
 
 **If a CI check fails, fix it.** Never dismiss a failure as "pre-existing" or "unrelated to this PR". If a workflow is broken, investigate and fix it in the same PR (or a preceding one) before merging. The goal is to keep `main` green at all times.
+
+**Every PR must update docs.** If a PR changes CLI behavior, adds/removes commands, modifies flags, or alters workflows, the corresponding documentation must be updated in the same PR. This includes `docs/ISD277-redesign.md` (spec), `docs/divergences.md`, `README.md`, and `AGENTS.md` as applicable. No code-only PRs that leave docs stale.
 
 All commits must include:
 ```


### PR DESCRIPTION
Adds two rules to AGENTS.md:

1. **CLI consistency (key constraint #5):** `run` and `expand` command pairs must accept identical flags and have consistent semantics.
2. **Docs requirement:** Every PR that changes CLI behavior must update the corresponding documentation.