### PR TITLE
feat: add opcli pytest run to execute integration tests

### DIFF
--- a/src/opcli/commands/pytest_cmd.py
+++ b/src/opcli/commands/pytest_cmd.py
@@ -5,12 +5,27 @@ from pathlib import Path
 
 import typer
 
-from opcli.core.pytest_args import assemble_tox_argv
+from opcli.core.pytest_args import assemble_tox_argv, pytest_run
 
 app = typer.Typer(
     help="Assemble pytest flags from build output and run integration tests.",
     no_args_is_help=True,
 )
+
+
+@app.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
+def run(
+    ctx: typer.Context,
+    *,
+    tox_env: str = typer.Option("integration", "-e", help="Tox environment name."),
+) -> None:
+    """Assemble and execute the tox integration test command.
+
+    Extra args after -- are forwarded to tox/pytest.
+    """
+    pytest_run(Path.cwd(), tox_env=tox_env, extra_args=ctx.args or None)
 
 
 @app.command(

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -1,4 +1,4 @@
-"""Core logic for ``opcli pytest expand``.
+"""Core logic for ``opcli pytest expand`` and ``opcli pytest run``.
 
 Reads ``artifacts.build.yaml`` (schema v1) and assembles the flags that
 tox/pytest need to locate built charms and their OCI-image resources.
@@ -31,6 +31,8 @@ from pathlib import Path
 from typing import overload
 
 from opcli.core.exceptions import ConfigurationError
+from opcli.core.secrets import is_ci, load_secrets_env
+from opcli.core.subprocess import run_command
 from opcli.core.yaml_io import load_artifacts_build
 from opcli.models.artifacts_build import (
     CharmOutput,
@@ -187,3 +189,32 @@ def assemble_tox_argv(
     if pytest_args:
         cmd += ["--", *pytest_args]
     return cmd
+
+
+def pytest_run(
+    root: Path,
+    *,
+    tox_env: str = "integration",
+    extra_args: list[str] | None = None,
+    ci: bool | None = None,
+) -> None:
+    """Assemble the tox command and execute it interactively.
+
+    In local mode, secrets from ``.secrets.env`` (if present) are loaded and
+    passed as environment variables to the tox subprocess.  In CI mode the
+    variables are expected to already be in the environment.
+
+    Raises:
+        ConfigurationError: If ``artifacts.build.yaml`` is missing.
+        SubprocessError: If tox exits non-zero.
+    """
+    cmd = assemble_tox_argv(root, tox_env=tox_env, extra_args=extra_args)
+
+    is_ci_env = ci if ci is not None else is_ci()
+    secrets_env: dict[str, str] | None = None
+    if not is_ci_env:
+        loaded = load_secrets_env(root)
+        if loaded:
+            secrets_env = loaded
+
+    run_command(cmd, cwd=str(root), interactive=True, env=secrets_env)

--- a/src/opcli/core/secrets.py
+++ b/src/opcli/core/secrets.py
@@ -1,0 +1,58 @@
+"""Shared secrets-env loading for local test execution."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_SECRETS_ENV_FILE = ".secrets.env"
+
+
+def is_ci() -> bool:
+    """Return True when running inside CI (truthy ``CI`` env var)."""
+    return bool(os.environ.get("CI"))
+
+
+def load_secrets_env(root: Path) -> dict[str, str]:
+    """Load secrets from ``.secrets.env`` in the project root.
+
+    The file uses plain ``KEY=VALUE`` format (one per line).  Blank lines and
+    lines starting with ``#`` are ignored.  Values may be optionally quoted
+    with single or double quotes.
+
+    Returns an empty dict if the file does not exist.
+    """
+    secrets_path = root / _SECRETS_ENV_FILE
+    if not secrets_path.is_file():
+        return {}
+
+    env: dict[str, str] = {}
+    for lineno, raw_line in enumerate(secrets_path.read_text().splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            logger.warning(
+                "%s:%d: skipping malformed line (no '=' found)",
+                _SECRETS_ENV_FILE,
+                lineno,
+            )
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        # Strip optional surrounding quotes
+        if (
+            len(value) >= 2  # noqa: PLR2004
+            and value[0] == value[-1]
+            and value[0] in ("'", '"')
+        ):
+            value = value[1:-1]
+        env[key] = value
+
+    if env:
+        logger.info("Loaded %d secret(s) from %s", len(env), _SECRETS_ENV_FILE)
+    return env

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import posixpath
 import tempfile
 from copy import deepcopy
@@ -30,6 +29,8 @@ from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import LiteralScalarString
 
 from opcli.core.exceptions import ConfigurationError, ValidationError
+from opcli.core.secrets import is_ci as _is_ci_impl
+from opcli.core.secrets import load_secrets_env as _load_secrets_env_impl
 from opcli.core.subprocess import run_command
 
 logger = logging.getLogger(__name__)
@@ -385,7 +386,7 @@ _RESOURCE_FIELDS: dict[str, str] = {"cpu": "CPU", "memory": "MEM", "disk": "DISK
 
 def _is_ci() -> bool:
     """Return True when running inside CI (truthy ``CI`` env var)."""
-    return bool(os.environ.get("CI"))
+    return _is_ci_impl()
 
 
 def _extract_system_resources(
@@ -785,43 +786,9 @@ _SECRETS_ENV_FILE = ".secrets.env"
 def _load_secrets_env(root: Path) -> dict[str, str]:
     """Load secrets from ``.secrets.env`` in the project root.
 
-    The file uses plain ``KEY=VALUE`` format (one per line).  Blank lines and
-    lines starting with ``#`` are ignored.  Values may be optionally quoted
-    with single or double quotes.
-
-    Returns an empty dict if the file does not exist.
+    Delegates to the shared :mod:`opcli.core.secrets` module.
     """
-    secrets_path = root / _SECRETS_ENV_FILE
-    if not secrets_path.is_file():
-        return {}
-
-    env: dict[str, str] = {}
-    for lineno, raw_line in enumerate(secrets_path.read_text().splitlines(), start=1):
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if "=" not in line:
-            logger.warning(
-                "%s:%d: skipping malformed line (no '=' found)",
-                _SECRETS_ENV_FILE,
-                lineno,
-            )
-            continue
-        key, _, value = line.partition("=")
-        key = key.strip()
-        value = value.strip()
-        # Strip optional surrounding quotes
-        if (
-            len(value) >= 2  # noqa: PLR2004
-            and value[0] == value[-1]
-            and value[0] in ("'", '"')
-        ):
-            value = value[1:-1]
-        env[key] = value
-
-    if env:
-        logger.info("Loaded %d secret(s) from %s", len(env), _SECRETS_ENV_FILE)
-    return env
+    return _load_secrets_env_impl(root)
 
 
 def spread_run(

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -1,4 +1,4 @@
-"""Tests for ``opcli pytest expand``."""
+"""Tests for ``opcli pytest expand`` and ``opcli pytest run``."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from opcli.core.exceptions import ConfigurationError
-from opcli.core.pytest_args import assemble_pytest_args, assemble_tox_argv
+from opcli.core.pytest_args import assemble_pytest_args, assemble_tox_argv, pytest_run
 
 _V1_ERROR_MATCH = "validation error"
 
@@ -318,3 +318,77 @@ class TestAssembleToxArgv:
     def test_missing_generated_raises(self, tmp_path: Path) -> None:
         with pytest.raises(ConfigurationError, match="not found"):
             assemble_tox_argv(tmp_path)
+
+
+class TestPytestRun:
+    """Tests for ``pytest_run`` — executes tox interactively."""
+
+    def test_runs_tox_interactively(
+        self, tmp_path: Path, mocker: pytest.MockerFixture
+    ) -> None:
+        _write(tmp_path / "artifacts.build.yaml", _GENERATED_LOCAL)
+        mock_run = mocker.patch("opcli.core.pytest_args.run_command")
+        mocker.patch("opcli.core.pytest_args.is_ci", return_value=False)
+        mocker.patch("opcli.core.pytest_args.load_secrets_env", return_value={})
+
+        pytest_run(tmp_path)
+
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args
+        assert call_kwargs.kwargs["interactive"] is True
+        assert call_kwargs.kwargs["cwd"] == str(tmp_path)
+        cmd = call_kwargs.args[0]
+        assert cmd[:3] == ["tox", "-e", "integration"]
+
+    def test_forwards_extra_args(
+        self, tmp_path: Path, mocker: pytest.MockerFixture
+    ) -> None:
+        _write(tmp_path / "artifacts.build.yaml", "version: 1\n")
+        mock_run = mocker.patch("opcli.core.pytest_args.run_command")
+        mocker.patch("opcli.core.pytest_args.is_ci", return_value=False)
+        mocker.patch("opcli.core.pytest_args.load_secrets_env", return_value={})
+
+        pytest_run(tmp_path, extra_args=["-k", "test_charm"])
+
+        cmd = mock_run.call_args.args[0]
+        assert "-k" in cmd
+        assert "test_charm" in cmd
+
+    def test_custom_tox_env(self, tmp_path: Path, mocker: pytest.MockerFixture) -> None:
+        _write(tmp_path / "artifacts.build.yaml", "version: 1\n")
+        mock_run = mocker.patch("opcli.core.pytest_args.run_command")
+        mocker.patch("opcli.core.pytest_args.is_ci", return_value=False)
+        mocker.patch("opcli.core.pytest_args.load_secrets_env", return_value={})
+
+        pytest_run(tmp_path, tox_env="e2e")
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[2] == "e2e"
+
+    def test_loads_secrets_env_locally(
+        self, tmp_path: Path, mocker: pytest.MockerFixture
+    ) -> None:
+        _write(tmp_path / "artifacts.build.yaml", "version: 1\n")
+        mock_run = mocker.patch("opcli.core.pytest_args.run_command")
+        mocker.patch("opcli.core.pytest_args.is_ci", return_value=False)
+        mocker.patch(
+            "opcli.core.pytest_args.load_secrets_env",
+            return_value={"SECRET_KEY": "val"},
+        )
+
+        pytest_run(tmp_path)
+
+        assert mock_run.call_args.kwargs["env"] == {"SECRET_KEY": "val"}
+
+    def test_skips_secrets_in_ci(
+        self, tmp_path: Path, mocker: pytest.MockerFixture
+    ) -> None:
+        _write(tmp_path / "artifacts.build.yaml", "version: 1\n")
+        mock_run = mocker.patch("opcli.core.pytest_args.run_command")
+        mocker.patch("opcli.core.pytest_args.is_ci", return_value=True)
+        mock_load = mocker.patch("opcli.core.pytest_args.load_secrets_env")
+
+        pytest_run(tmp_path)
+
+        mock_load.assert_not_called()
+        assert mock_run.call_args.kwargs["env"] is None

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -1,0 +1,37 @@
+"""Tests for ``opcli.core.secrets``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from opcli.core.secrets import load_secrets_env
+
+
+class TestLoadSecretsEnv:
+    """Tests for .secrets.env loading."""
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        assert load_secrets_env(tmp_path) == {}
+
+    def test_basic_key_value(self, tmp_path: Path) -> None:
+        (tmp_path / ".secrets.env").write_text("FOO=bar\nBAZ=qux\n")
+        assert load_secrets_env(tmp_path) == {"FOO": "bar", "BAZ": "qux"}
+
+    def test_strips_quotes(self, tmp_path: Path) -> None:
+        (tmp_path / ".secrets.env").write_text("A='single'\nB=\"double\"\n")
+        assert load_secrets_env(tmp_path) == {"A": "single", "B": "double"}
+
+    def test_ignores_comments_and_blanks(self, tmp_path: Path) -> None:
+        (tmp_path / ".secrets.env").write_text("# comment\n\nKEY=val\n")
+        assert load_secrets_env(tmp_path) == {"KEY": "val"}
+
+    def test_malformed_line_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        (tmp_path / ".secrets.env").write_text("NOEQUALS\nGOOD=val\n")
+        with caplog.at_level("WARNING"):
+            result = load_secrets_env(tmp_path)
+        assert result == {"GOOD": "val"}
+        assert "malformed" in caplog.text


### PR DESCRIPTION
## Summary

Adds `opcli pytest run` command that assembles the tox command (same as `expand`) and executes it interactively. Both `run` and `expand` accept identical flags (`-e/--tox-env` + extra args after `--`), satisfying the run/expand alignment rule from AGENTS.md.

## Key behaviors

- Executes tox with `interactive=True` — real-time output, color preserved, TTY signals propagated
- Loads `.secrets.env` in local mode (skipped in CI, matching `spread run` behavior)
- Exit code propagates correctly from tox/pytest
- Ctrl+C handled naturally via inherited TTY

## Changes

- **`src/opcli/core/secrets.py`** (new) — shared `is_ci()` and `load_secrets_env()` extracted from spread, reusable by both commands
- **`src/opcli/core/pytest_args.py`** — added `pytest_run()` function
- **`src/opcli/commands/pytest_cmd.py`** — added `run` command with same flags as `expand`
- **`src/opcli/core/spread.py`** — delegates to shared secrets module (no behavior change)
- **`tests/unit/test_secrets.py`** (new) — tests for secrets loading
- **`tests/unit/test_pytest_args.py`** — added `TestPytestRun` class

Closes #146