### PR TITLE
refactor: rename opcli spread tasks → opcli spread jobs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,7 +2,7 @@ name: Integration Test
 
 # Reusable workflow that:
 #   1. Builds all artifacts (calls build-artifacts.yml)
-#   2. Generates a spread test matrix (opcli spread tasks)
+#   2. Generates a spread test matrix (opcli spread jobs)
 #   3. Runs each spread test task in a dedicated job
 #
 # Call from your operator repository:
@@ -104,7 +104,7 @@ jobs:
       - name: Generate spread task matrix
         id: tasks
         run: |
-          matrix=$(opcli spread tasks)
+          matrix=$(opcli spread jobs)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "Test matrix: $matrix"
 

--- a/docs/ISD277-redesign.md
+++ b/docs/ISD277-redesign.md
@@ -343,7 +343,7 @@ The functionality for opcli is grouped into four command families:  artifacts , 
 | opcli spread init | Discovers integration tests and generates spread.yaml and tests/integration/run/task.yaml |  |
 | opcli spread run | Expands the virtual backend in spread.yaml and runs spread as a subprocess, passing the same arguments as received. | As in craft-application, the CI env var defines whether to run locally or in the pipeline. All arguments after -- are passed verbatim to the spread subprocess. |
 | opcli spread expand | Prints the fully expanded spread.yaml | As in craft-application, the CI env var defines whether to run locally or in the pipeline |
-| opcli spread tasks | Prints the list of spread tasks/variants discovered in spread.yaml. | |
+| opcli spread jobs | Prints the list of spread jobs/variants discovered in spread.yaml. | |
 
 ### **opcli pytest**
 

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -191,7 +191,7 @@ backends:
 ```
 
 These fields are stripped before the YAML is passed to spread — they are
-opcli-only metadata. `runner` and `arch` are consumed by `opcli spread tasks`
+opcli-only metadata. `runner` and `arch` are consumed by `opcli spread jobs`
 from the raw (unexpanded) `spread.yaml` to build the CI matrix, then stripped
 in both local and CI expansion. During local expansion, `cpu`/`memory`/`disk`
 are injected into the `allocate` script as per-system `case` arms using
@@ -568,11 +568,11 @@ be unreachable after delivery.
 
 ---
 
-## 20. `opcli spread tasks` — new command for GitHub Actions test matrix
+## 20. `opcli spread jobs` — new command for GitHub Actions test matrix
 
 **Spec:** Does not describe this command.
 
-**Implementation:** `opcli spread tasks` reads `spread.yaml` (without expanding
+**Implementation:** `opcli spread jobs` reads `spread.yaml` (without expanding
 it), extracts all `MODULE/*` variants from the suites, and prints a JSON object
 suitable for use as a GitHub Actions `strategy.matrix`:
 
@@ -685,7 +685,7 @@ opcli spread run -- integration-test-local:ubuntu-24.04:tests/integration/run:te
 opcli spread run -- integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm
 ```
 
-And `opcli spread tasks` produces entries like:
+And `opcli spread jobs` produces entries like:
 
 ```json
 {"name": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm", "selector": "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm", "runs-on": ["self-hosted", "noble"]}

--- a/src/opcli/commands/spread.py
+++ b/src/opcli/commands/spread.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import typer
 
-from opcli.core.spread import spread_expand, spread_init, spread_run, spread_tasks
+from opcli.core.spread import spread_expand, spread_init, spread_jobs, spread_run
 
 app = typer.Typer(
     help="Generate, expand, and run spread-based integration tests.",
@@ -48,7 +48,7 @@ def expand() -> None:
 
 
 @app.command()
-def tasks() -> None:
-    """Print CI test task selectors as a JSON array for GitHub Actions matrix."""
-    entries = spread_tasks(Path.cwd())
+def jobs() -> None:
+    """Print CI test job selectors as a JSON array for GitHub Actions matrix."""
+    entries = spread_jobs(Path.cwd())
     typer.echo(json.dumps({"include": entries}))

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -835,7 +835,7 @@ def spread_run(
 
 
 # ---------------------------------------------------------------------------
-#  spread tasks — enumerate CI test selectors for GitHub Actions matrix
+#  spread jobs — enumerate CI test selectors for GitHub Actions matrix
 # ---------------------------------------------------------------------------
 
 _DEFAULT_RUNNER = "ubuntu-latest"
@@ -909,7 +909,7 @@ def _virtual_runner_map(
     return runner_map, arch_map, ci_names
 
 
-def spread_tasks(root: Path) -> list[dict[str, str]]:
+def spread_jobs(root: Path) -> list[dict[str, str]]:
     """Return all CI spread task selectors as a list of GitHub Actions matrix entries.
 
     Calls ``spread -list`` on the expanded (CI-mode) ``spread.yaml``, restricted
@@ -939,7 +939,7 @@ def spread_tasks(root: Path) -> list[dict[str, str]]:
     expanded["reroot"] = _compose_reroot(expanded.get("reroot"))
 
     entries: list[dict[str, str]] = []
-    with tempfile.TemporaryDirectory(prefix=".spread-tasks-", dir=root) as tmp_dir:
+    with tempfile.TemporaryDirectory(prefix=".spread-jobs-", dir=root) as tmp_dir:
         tmp_yaml = Path(tmp_dir) / _SPREAD_YAML
         with tmp_yaml.open("w") as fh:
             _yaml.dump(_literalize(expanded), fh)

--- a/tests/unit/test_spread.py
+++ b/tests/unit/test_spread.py
@@ -17,8 +17,8 @@ from opcli.core.spread import (
     _virtual_runner_map,
     spread_expand,
     spread_init,
+    spread_jobs,
     spread_run,
-    spread_tasks,
 )
 from opcli.core.subprocess import SubprocessResult
 
@@ -1472,7 +1472,7 @@ class TestArchFromRunner:
 
 
 class TestSpreadTasks:
-    """Tests for spread_tasks()."""
+    """Tests for spread_jobs()."""
 
     _SPREAD_LIST_TWO_VARIANTS = (
         "integration-test-ci:ubuntu-22.04:tests/integration/run:test_charm\n"
@@ -1496,7 +1496,7 @@ class TestSpreadTasks:
             "opcli.core.spread.run_command",
             return_value=self._mock_list(self._SPREAD_LIST_TWO_VARIANTS),
         ):
-            entries = spread_tasks(tmp_path)
+            entries = spread_jobs(tmp_path)
 
         names = [e["name"] for e in entries]
         assert (
@@ -1517,7 +1517,7 @@ class TestSpreadTasks:
             "opcli.core.spread.run_command",
             return_value=self._mock_list(raw_selector + "\n"),
         ):
-            entries = spread_tasks(tmp_path)
+            entries = spread_jobs(tmp_path)
 
         assert len(entries) == 1
         assert entries[0]["selector"] == raw_selector
@@ -1530,7 +1530,7 @@ class TestSpreadTasks:
             "opcli.core.spread.run_command",
             return_value=self._mock_list(self._SPREAD_LIST_TWO_VARIANTS),
         ):
-            entries = spread_tasks(tmp_path)
+            entries = spread_jobs(tmp_path)
 
         ubuntu_22_entries = [e for e in entries if "ubuntu-22.04" in e["selector"]]
         assert all(e["runs-on"] == '"ubuntu-22.04-runner"' for e in ubuntu_22_entries)
@@ -1543,7 +1543,7 @@ class TestSpreadTasks:
             "opcli.core.spread.run_command",
             return_value=self._mock_list(self._SPREAD_LIST_NO_VARIANT),
         ):
-            entries = spread_tasks(tmp_path)
+            entries = spread_jobs(tmp_path)
 
         assert len(entries) == 1
         assert (
@@ -1554,7 +1554,7 @@ class TestSpreadTasks:
     def test_missing_spread_yaml_raises(self, tmp_path: Path) -> None:
         """Raises ConfigurationError when spread.yaml is missing."""
         with pytest.raises(ConfigurationError):
-            spread_tasks(tmp_path)
+            spread_jobs(tmp_path)
 
     def test_spread_list_called_with_ci_backend_selectors(self, tmp_path: Path) -> None:
         """spread -list is invoked with one selector per virtual backend."""
@@ -1564,7 +1564,7 @@ class TestSpreadTasks:
             "opcli.core.spread.run_command",
             return_value=self._mock_list(self._SPREAD_LIST_ONE_VARIANT),
         ) as mock_run:
-            spread_tasks(tmp_path)
+            spread_jobs(tmp_path)
 
         cmd = mock_run.call_args[0][0]
         assert cmd[0] == "spread"
@@ -1596,7 +1596,7 @@ suites:
             "opcli.core.spread.run_command",
             return_value=self._mock_list(self._SPREAD_LIST_ONE_VARIANT),
         ) as mock_run:
-            spread_tasks(tmp_path)
+            spread_jobs(tmp_path)
 
         cmd = mock_run.call_args[0][0]
         assert "integration-test-ci:" in cmd
@@ -1692,7 +1692,7 @@ suites:
                 "integration-test-ci:ubuntu-24.04-arm64:tests/integration/run:test_charm\n"
             ),
         ):
-            entries = spread_tasks(tmp_path)
+            entries = spread_jobs(tmp_path)
 
         assert len(entries) == 1
         assert entries[0]["arch"] == "arm64"
@@ -1704,7 +1704,7 @@ suites:
             "opcli.core.spread.run_command",
             return_value=self._mock_list(self._SPREAD_LIST_ONE_VARIANT),
         ):
-            entries = spread_tasks(tmp_path)
+            entries = spread_jobs(tmp_path)
 
         assert all(e["arch"] == "amd64" for e in entries)
 
@@ -1733,7 +1733,7 @@ suites:
                 "integration-test-ci:ubuntu-24.04:tests/integration/run:test_charm\n"
             ),
         ):
-            entries = spread_tasks(tmp_path)
+            entries = spread_jobs(tmp_path)
 
         assert all(e["arch"] == "arm64" for e in entries)
 
@@ -1751,7 +1751,7 @@ suites:
             "opcli.core.spread.run_command",
             return_value=self._mock_list(list_output),
         ):
-            entries = spread_tasks(tmp_path)
+            entries = spread_jobs(tmp_path)
 
         selectors = [e["selector"] for e in entries]
         names = [e["name"] for e in entries]
@@ -1765,14 +1765,14 @@ suites:
         )
 
     def test_temp_dir_cleaned_up_after_tasks(self, tmp_path: Path) -> None:
-        """Temporary spread.yaml directory is removed after spread_tasks returns."""
+        """Temporary spread.yaml directory is removed after spread_jobs returns."""
         _write(tmp_path / "spread.yaml", _SPREAD_NO_RUNNER)
 
         with patch(
             "opcli.core.spread.run_command",
             return_value=self._mock_list(self._SPREAD_LIST_ONE_VARIANT),
         ):
-            spread_tasks(tmp_path)
+            spread_jobs(tmp_path)
 
-        leftover = list(tmp_path.glob(".spread-tasks-*"))
+        leftover = list(tmp_path.glob(".spread-jobs-*"))
         assert leftover == []


### PR DESCRIPTION
The command discovers CI *jobs* (GitHub Actions matrix entries), not spread tasks. Rename to better reflect what it produces.

- `spread_tasks()` → `spread_jobs()`
- `opcli spread tasks` → `opcli spread jobs`
- Updated workflow, docs, and tests