### PR TITLE
fix: merge filtered build results into existing artifacts.build.yaml

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -684,9 +684,37 @@ def artifacts_build(
     )
 
     dest = root / _ARTIFACTS_GENERATED_YAML
+
+    # When a filter is active and an existing build file exists, merge new
+    # entries into the previous results so unrelated artifacts are preserved.
+    if any_filter and dest.exists():
+        existing = load_artifacts_build(dest)
+        generated = _merge_generated(existing, generated)
+
     dump_artifacts_build(generated, dest)
     logger.info("Wrote %s", dest)
     return dest
+
+
+def _merge_generated(
+    existing: ArtifactsGenerated, new: ArtifactsGenerated
+) -> ArtifactsGenerated:
+    """Merge *new* build entries into *existing*, replacing by name."""
+
+    def _merge_by_name[T: (GeneratedRock, GeneratedCharm, GeneratedSnap)](
+        old_list: list[T], new_list: list[T]
+    ) -> list[T]:
+        new_names = {item.name for item in new_list}
+        # Keep existing entries whose name was NOT rebuilt, then append new.
+        merged = [item for item in old_list if item.name not in new_names]
+        merged.extend(new_list)
+        return merged
+
+    return ArtifactsGenerated(
+        rocks=_merge_by_name(existing.rocks, new.rocks),
+        charms=_merge_by_name(existing.charms, new.charms),
+        snaps=_merge_by_name(existing.snaps, new.snaps),
+    )
 
 
 def artifacts_matrix(root: Path) -> dict[str, list[dict[str, object]]]:

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -819,6 +819,84 @@ class TestArtifactsBuild:
         assert (tmp_path / "charmcraft.yaml").exists()
         assert not (tmp_path / "charmcraft.yaml").is_symlink()
 
+    def test_filtered_build_merges_into_existing(self, tmp_path: Path) -> None:
+        """Filtered build preserves previously built artifacts in the file."""
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
+            "charms:\n- name: mycharm\n  charmcraft-yaml: charmcraft.yaml\n",
+        )
+        (tmp_path / "rock_dir").mkdir()
+        _write(tmp_path / "rock_dir" / "rockcraft.yaml", "name: myrock\n")
+        _write(tmp_path / "rock_dir" / "myrock_1.0_amd64.rock", "fake")
+        _write(tmp_path / "charmcraft.yaml", "name: mycharm\n")
+        _write(tmp_path / "mycharm_ubuntu-22.04-amd64.charm", "fake")
+
+        # First: build everything (creates artifacts.build.yaml with rock + charm)
+        with patch("opcli.core.artifacts.run_command"):
+            artifacts_build(tmp_path)
+
+        # Second: rebuild only the charm with a filter
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path, charm_names=["mycharm"])
+
+        gen = load_artifacts_build(result)
+        # Rock from previous build must still be present
+        assert len(gen.rocks) == 1
+        assert gen.rocks[0].name == "myrock"
+        # Charm must be the freshly rebuilt one
+        assert len(gen.charms) == 1
+        assert gen.charms[0].name == "mycharm"
+
+    def test_filtered_build_replaces_same_name_entry(self, tmp_path: Path) -> None:
+        """Rebuilding an artifact replaces its entry, not duplicates it."""
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n",
+        )
+        (tmp_path / "rock_dir").mkdir()
+        _write(tmp_path / "rock_dir" / "rockcraft.yaml", "name: myrock\n")
+        _write(tmp_path / "rock_dir" / "myrock_1.0_amd64.rock", "fake")
+
+        # Build the rock once
+        with patch("opcli.core.artifacts.run_command"):
+            artifacts_build(tmp_path)
+
+        # Rebuild same rock with filter — should replace, not duplicate
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path, rock_names=["myrock"])
+
+        gen = load_artifacts_build(result)
+        assert len(gen.rocks) == 1
+        assert gen.rocks[0].name == "myrock"
+
+    def test_unfiltered_build_does_not_merge(self, tmp_path: Path) -> None:
+        """Without filters, the build file is overwritten (no merge)."""
+        _write(
+            tmp_path / "artifacts.yaml",
+            "version: 1\n"
+            "charms:\n- name: mycharm\n  charmcraft-yaml: charmcraft.yaml\n",
+        )
+        _write(tmp_path / "charmcraft.yaml", "name: mycharm\n")
+        _write(tmp_path / "mycharm_ubuntu-22.04-amd64.charm", "fake")
+
+        # Manually seed a build file with a rock entry that shouldn't survive
+        _write(
+            tmp_path / "artifacts.build.yaml",
+            "version: 1\nrocks:\n- name: leftover\n  rockcraft-yaml: x.yaml\n"
+            "  output:\n  - arch: amd64\n    file: ./x.rock\n",
+        )
+
+        with patch("opcli.core.artifacts.run_command"):
+            result = artifacts_build(tmp_path)
+
+        gen = load_artifacts_build(result)
+        # Unfiltered build should overwrite entirely — no leftover rock
+        assert len(gen.rocks) == 0
+        assert len(gen.charms) == 1
+
 
 class TestArtifactsMatrix:
     """Tests for artifacts_matrix()."""


### PR DESCRIPTION
When a filter (`--charm`/`--rock`/`--snap`) is used and `artifacts.build.yaml` already exists, load it first and merge new entries by name — replacing rebuilt artifacts while preserving unrelated ones. Without filters, the file is still overwritten entirely (existing behavior).

## Changes
- **`core/artifacts.py`**: Added `_merge_generated()` helper and merge logic in `artifacts_build()` when a filter is active and the build file pre-exists.
- **`tests/unit/test_artifacts.py`**: Three new tests covering merge, replace-by-name, and unfiltered-overwrite cases.

Closes #150