### PR TITLE
workflow: bail out test jobs early when build has failed

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -180,6 +180,25 @@ jobs:
             echo "$name=$value" >> "$GITHUB_ENV"
           done
 
+      # ── Early bail-out if the build already failed ─────────────────────────
+      # The test job starts without waiting for the build (by design — provisioning
+      # runs in parallel).  However, if the build has already failed by the time we
+      # reach this point, there is no reason to continue.  The "Collect artifacts"
+      # job in the build workflow is skipped/failed/cancelled when a build fails,
+      # so we use its conclusion as the signal.
+      - name: Check build status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          conclusion=$(gh run view "${{ github.run_id }}" \
+            --repo "${{ github.repository }}" \
+            --json jobs \
+            --jq '.jobs[] | select(.name | contains("Collect artifacts")) | .conclusion')
+          if [[ "$conclusion" =~ ^(skipped|failure|cancelled)$ ]]; then
+            echo "::error::Build failed — 'Collect artifacts' job conclusion is '$conclusion'. Skipping test."
+            exit 1
+          fi
+
       # ── Run the spread task ───────────────────────────────────────────────
       # Artifact download happens inside spread _CI_PREPARE (after provisioning).
       - name: Run spread task


### PR DESCRIPTION
When a build fails, the 'Collect artifacts' job is skipped. Previously, test jobs would spend ~5 minutes on provisioning (installing uv, opcli, spread, allocating VM) before discovering the failure inside spread's `_CI_PREPARE` script.

This adds a lightweight 'Check build status' step right before 'Run spread task' that queries the Collect artifacts job conclusion via `gh run view`. If it's already `skipped`/`failure`/`cancelled`, the test job exits immediately.

The existing retry-based detection in `opcli artifacts fetch --wait` still covers the rarer case where the build fails mid-provisioning.

**Triggered by:** https://github.com/javierdelapuente/paas-charm/actions/runs/26169386366