### PR TITLE
feat: add timestamped progress feedback for long-running operations

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 from opcli.core.discovery import discover_artifacts
 from opcli.core.exceptions import ConfigurationError, OpcliError, SubprocessError
+from opcli.core.progress import status, step
 from opcli.core.subprocess import run_command
 from opcli.core.yaml_io import (
     dump_artifacts_build,
@@ -160,16 +161,17 @@ def _push_rock_to_ghcr(
         raise OpcliError(msg)
 
     image_ref = f"ghcr.io/{ci.owner}/{ci.repo}/{rock.name}:{ci.sha}-{build.arch}"
-    run_command(
-        [
-            "skopeo",
-            "--insecure-policy",
-            "copy",
-            f"oci-archive:{rock_path}",
-            f"docker://{image_ref}",
-        ],
-        cwd=str(root),
-    )
+    with step(f"Pushing rock '{rock.name}' to GHCR"):
+        run_command(
+            [
+                "skopeo",
+                "--insecure-policy",
+                "copy",
+                f"oci-archive:{rock_path}",
+                f"docker://{image_ref}",
+            ],
+            cwd=str(root),
+        )
     logger.info("Pushed rock '%s' to %s", rock.name, image_ref)
     return GeneratedRock(
         name=rock.name,
@@ -535,7 +537,10 @@ def _build_rock(rock: RockArtifact, root: Path, attributed: set[str]) -> Generat
 
     symlink_path, symlink_created = _with_rock_symlink(yaml_path, pack_dir)
     try:
-        run_command([*_PACK_COMMANDS["rock"]], cwd=str(pack_dir), env=_ROCKCRAFT_ENV)
+        with step(f"Building rock '{rock.name}' (rockcraft pack)"):
+            run_command(
+                [*_PACK_COMMANDS["rock"]], cwd=str(pack_dir), env=_ROCKCRAFT_ENV
+            )
     finally:
         if symlink_created and symlink_path and symlink_path.is_symlink():
             symlink_path.unlink()
@@ -567,7 +572,8 @@ def _build_charm(
 
     symlink_path, symlink_created = _with_charm_symlink(yaml_path, pack_dir)
     try:
-        run_command([*_PACK_COMMANDS["charm"]], cwd=str(pack_dir))
+        with step(f"Building charm '{charm.name}' (charmcraft pack)"):
+            run_command([*_PACK_COMMANDS["charm"]], cwd=str(pack_dir))
     finally:
         if symlink_created and symlink_path and symlink_path.is_symlink():
             symlink_path.unlink()
@@ -611,7 +617,8 @@ def _build_snap(snap: SnapArtifact, root: Path, attributed: set[str]) -> Generat
         raise ConfigurationError(msg)
 
     before = _snapshot_outputs(pack_dir, "snap")
-    run_command([*_PACK_COMMANDS["snap"]], cwd=str(pack_dir))
+    with step(f"Building snap '{snap.name}' (snapcraft pack)"):
+        run_command([*_PACK_COMMANDS["snap"]], cwd=str(pack_dir))
     after = _snapshot_outputs(pack_dir, "snap")
     new_output = _pick_new_output(before, after, "snap", pack_dir, attributed)
     output_file = _relative_to_root(new_output, root)
@@ -662,6 +669,16 @@ def artifacts_build(
     rocks_to_build = _filter_by_name(plan.rocks, rock_names, "rock")
     charms_to_build = _filter_by_name(plan.charms, charm_names, "charm")
     snaps_to_build = _filter_by_name(plan.snaps, snap_names, "snap")
+
+    total = len(rocks_to_build) + len(charms_to_build) + len(snaps_to_build)
+    parts = []
+    if rocks_to_build:
+        parts.append(f"{len(rocks_to_build)} rock(s)")
+    if charms_to_build:
+        parts.append(f"{len(charms_to_build)} charm(s)")
+    if snaps_to_build:
+        parts.append(f"{len(snaps_to_build)} snap(s)")
+    status(f"Building {total} artifact(s): {', '.join(parts)}")
 
     # Track absolute output paths attributed to each artifact so far, to detect
     # collisions when multiple artifacts share a pack-dir.
@@ -1420,7 +1437,7 @@ def artifacts_fetch(
     for name in sorted(seen_artifacts):
         artifact_dir = root / name
         artifact_dir.mkdir(parents=True, exist_ok=True)
-        logger.info("Downloading artifact '%s' into '%s'...", name, artifact_dir)
+        status(f"Downloading artifact '{name}'")
         run_command(
             [
                 "gh",

--- a/src/opcli/core/install.py
+++ b/src/opcli/core/install.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import shutil
 
+from opcli.core.progress import status, step
 from opcli.core.subprocess import run_command
 
 
@@ -19,12 +20,14 @@ def install_spread() -> None:
     Installs Go via snap and builds spread from source.
     """
     if shutil.which("spread"):
+        status("spread already installed")
         return
-    run_command(["snap", "install", "go", "--classic"])
-    run_command(
-        ["go", "install", "github.com/canonical/spread/cmd/spread@latest"],
-    )
-    run_command(["ln", "-sf", "/root/go/bin/spread", "/usr/local/bin/spread"])
+    with step("Installing spread (Go + build from source)"):
+        run_command(["snap", "install", "go", "--classic"])
+        run_command(
+            ["go", "install", "github.com/canonical/spread/cmd/spread@latest"],
+        )
+        run_command(["ln", "-sf", "/root/go/bin/spread", "/usr/local/bin/spread"])
 
 
 def install_tox() -> None:
@@ -33,17 +36,20 @@ def install_tox() -> None:
     Uses /usr/local/bin as the tool bin directory so that tox is
     available system-wide.
     """
-    run_command(
-        ["uv", "tool", "install", "tox", "--with", "tox-uv", "--quiet"],
-        env={
-            "UV_TOOL_BIN_DIR": "/usr/local/bin",
-            "UV_TOOL_DIR": "/usr/local/share/uv-tools",
-        },
-    )
+    with step("Installing tox"):
+        run_command(
+            ["uv", "tool", "install", "tox", "--with", "tox-uv", "--quiet"],
+            env={
+                "UV_TOOL_BIN_DIR": "/usr/local/bin",
+                "UV_TOOL_DIR": "/usr/local/share/uv-tools",
+            },
+        )
 
 
 def install_concierge() -> None:
     """Install the concierge snap if not already on PATH."""
     if shutil.which("concierge"):
+        status("concierge already installed")
         return
-    run_command(["snap", "install", "concierge", "--classic"])
+    with step("Installing concierge"):
+        run_command(["snap", "install", "concierge", "--classic"])

--- a/src/opcli/core/progress.py
+++ b/src/opcli/core/progress.py
@@ -1,0 +1,39 @@
+"""Timestamped progress output for long-running operations.
+
+All messages go to stderr so that stdout remains clean for
+machine-parseable output (JSON, shell commands, YAML).
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+def _timestamp() -> str:
+    """Return a compact HH:MM:SS timestamp."""
+    return time.strftime("%H:%M:%S")
+
+
+def status(message: str) -> None:
+    """Print a timestamped status line to stderr."""
+    sys.stderr.write(f"[{_timestamp()}] {message}\n")
+    sys.stderr.flush()
+
+
+@contextmanager
+def step(description: str) -> Iterator[None]:
+    """Context manager that prints start/done with elapsed time."""
+    status(description)
+    t0 = time.monotonic()
+    yield
+    elapsed = time.monotonic() - t0
+    if elapsed < 60:  # noqa: PLR2004
+        elapsed_str = f"{elapsed:.1f}s"
+    else:
+        minutes = int(elapsed // 60)
+        seconds = elapsed % 60
+        elapsed_str = f"{minutes}m {seconds:.0f}s"
+    status(f"done: {description} ({elapsed_str})")

--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -23,6 +23,7 @@ import socket
 from pathlib import Path
 
 from opcli.core.exceptions import ConfigurationError
+from opcli.core.progress import status
 from opcli.core.subprocess import run_command
 from opcli.core.yaml_io import dump_artifacts_build, load_artifacts_build
 
@@ -61,7 +62,7 @@ def provision_prepare(
         ["concierge", "prepare", "-c", str(concierge_path)],
         cwd=str(root),
     )
-    logger.info("Provisioning complete via %s", concierge_file)
+    status("Provisioning complete")
 
 
 def provision_load(
@@ -111,6 +112,7 @@ def provision_load(
 
             # Push directly from .rock archive to registry in one step — no Docker
             # daemon needed (avoids failures in MicroK8s-only environments).
+            status(f"Pushing '{rock.name}' ({build.arch}) → {image_ref}")
             run_command(
                 [
                     "sudo",

--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -29,6 +29,7 @@ from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import LiteralScalarString
 
 from opcli.core.exceptions import ConfigurationError, ValidationError
+from opcli.core.progress import status
 from opcli.core.secrets import is_ci as _is_ci_impl
 from opcli.core.secrets import load_secrets_env as _load_secrets_env_impl
 from opcli.core.subprocess import run_command
@@ -831,6 +832,7 @@ def spread_run(
         cmd = ["spread"]
         if extra_args:
             cmd.extend(extra_args)
+        status(f"Running spread ({'CI' if is_ci else 'local'} mode)")
         run_command(cmd, cwd=tmp_dir, interactive=True, env=secrets_env)
 
 


### PR DESCRIPTION
## Summary

Adds a lightweight progress module that prints timestamped status lines to stderr during long-running operations. Users now see what's happening instead of staring at a silent terminal.

## Changes

- **New:** `src/opcli/core/progress.py` — two primitives:
  - `status(msg)` — prints `[HH:MM:SS] msg` to stderr
  - `step(desc)` — context manager that prints start + done with elapsed time

- **Integrated into:**
  - `artifacts build` — summary count + per-artifact step timing
  - `artifacts fetch` — per-download status
  - `spread run` — mode announcement (local/CI)
  - `provision load` — per-rock push status
  - `install *` — step timing for tool installs

## Example output

```
[14:32:01] Building 2 artifact(s): 1 rock(s), 1 charm(s)
[14:32:01] Building rock 'my-rock' (rockcraft pack)
[14:35:12] done: Building rock 'my-rock' (rockcraft pack) (3m 11s)
[14:35:12] Building charm 'my-charm' (charmcraft pack)
[14:36:45] done: Building charm 'my-charm' (charmcraft pack) (1m 33s)
```

## Design decisions

- All progress goes to **stderr** — stdout stays clean for machine-parseable output (JSON, YAML, shell commands)
- Simple timestamped lines — no spinner/rich dependency, works in all terminals and CI logs
- `step()` context manager reports elapsed time automatically on completion
