### PR TITLE
fix: add ubuntu user to lxd group in CI prepare

### DIFF
--- a/src/opcli/core/spread.py
+++ b/src/opcli/core/spread.py
@@ -286,6 +286,7 @@ opcli install spread
 opcli install tox
 opcli install concierge
 opcli provision prepare -c "$CONCIERGE"
+usermod -aG lxd ubuntu || true
 runuser -l ubuntu -c \
   "cd \\"${SPREAD_PATH}\\" && opcli provision registry"
 opcli provision load
@@ -311,6 +312,7 @@ opcli install spread
 opcli install tox
 opcli install concierge
 opcli provision prepare -c "$CONCIERGE"
+usermod -aG lxd ubuntu || true
 """
 
 _CI_PREPARE_AFTER_USER = """\


### PR DESCRIPTION
The `test_http_proxy` integration test in paas-charm fails because the `ubuntu` user is not in the `lxd` group:

```
jubilant._juju.CLIError: Command '['juju', 'bootstrap', 'lxd', 'localhost']' returned non-zero exit status 1.
Stderr:
ERROR Permission denied, are you in the lxd group?
```

**Root cause:** The `_CI_ALLOCATE` script creates the `ubuntu` user, and `_CI_PREPARE_BEFORE_USER` installs LXD via `opcli provision prepare` (concierge), but never adds `ubuntu` to the `lxd` group. Tests run as `ubuntu` via `runuser`, so LXD socket access fails.

**Fix:** Add `usermod -aG lxd ubuntu` after the `opcli provision prepare` step in the CI prepare script.

Ref: https://github.com/javierdelapuente/paas-charm/actions/runs/26171962026/job/76996902630?pr=12