### PR TITLE
fix: align naming in reusable workflow jobs and steps

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -41,7 +41,8 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Get workflow version
         id: workflow-version
@@ -84,7 +85,8 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install uv
         run: sudo snap install astral-uv --classic
@@ -134,7 +136,7 @@ jobs:
       - name: Build ${{ matrix.type }} ${{ matrix.name }}
         run: opcli artifacts build --${{ matrix.type }} ${{ matrix.name }}
 
-      - name: Upload built ${{ matrix.type }}
+      - name: Upload ${{ matrix.type }} ${{ matrix.name }}
         if: matrix.type != 'rock'
         uses: actions/upload-artifact@v4
         with:
@@ -142,7 +144,7 @@ jobs:
           path: ${{ inputs.working-directory }}/**/*.${{ matrix.type }}
           if-no-files-found: error
 
-      - name: Upload partial artifacts.build.yaml
+      - name: Upload partial build manifest
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-build-${{ matrix.type }}-${{ matrix.name }}-${{ matrix.arch }}
@@ -158,7 +160,8 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Install uv
         run: sudo snap install astral-uv --classic
@@ -171,18 +174,18 @@ jobs:
             uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ needs.build-matrix.outputs.opcli-sha }}"
           fi
 
-      - name: Download all partial artifacts.build.yaml files
+      - name: Download build partials
         uses: actions/download-artifact@v4
         with:
           pattern: artifacts-build-*
           path: ${{ inputs.working-directory }}/partial-artifacts/
 
-      - name: Merge partials
+      - name: Merge build manifests
         run: |
           opcli artifacts collect \
             $(find ./partial-artifacts -name "artifacts.build.yaml" | sort | tr '\n' ' ')
 
-      - name: Upload merged artifacts.build.yaml
+      - name: Upload build manifest
         uses: actions/upload-artifact@v4
         with:
           name: artifacts-build

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -61,8 +61,8 @@ jobs:
 
   # ── Job 2: generate the spread test matrix ──────────────────────────────────
   # Runs in parallel with the build job — only needs spread.yaml from the repo.
-  test-plan:
-    name: Generate test matrix
+  test-matrix:
+    name: Test matrix
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -101,7 +101,7 @@ jobs:
           go install github.com/canonical/spread/cmd/spread@latest
           sudo ln -sf ~/go/bin/spread /usr/local/bin/spread
 
-      - name: Generate spread task matrix
+      - name: Generate test matrix
         id: tasks
         run: |
           matrix=$(opcli spread jobs)
@@ -109,19 +109,19 @@ jobs:
           echo "Test matrix: $matrix"
 
   # ── Job 3: run each spread task ─────────────────────────────────────────────
-  # Starts as soon as test-plan finishes — does NOT wait for the build job.
+  # Starts as soon as test-matrix finishes — does NOT wait for the build job.
   # Provisioning runs in parallel with the build.  The spread _CI_PREPARE script
   # waits for and downloads the build artifacts before executing tests.
   test:
     name: "${{ matrix.name }}"
-    needs: [test-plan]
+    needs: [test-matrix]
     runs-on: ${{ fromJSON(matrix.runs-on) }}
     permissions:
       contents: read
       actions: read
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.test-plan.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.test-matrix.outputs.matrix) }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
@@ -143,7 +143,7 @@ jobs:
           if grep -q 'name = "opcli"' "${GITHUB_WORKSPACE}/pyproject.toml" 2>/dev/null; then
             uv tool install "${GITHUB_WORKSPACE}"
           else
-            uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ needs.test-plan.outputs.opcli-sha }}"
+            uv tool install "git+https://github.com/javierdelapuente/operator-ci-poc.git@${{ needs.test-matrix.outputs.opcli-sha }}"
           fi
 
       # ── Install spread ────────────────────────────────────────────────────

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -68,13 +68,14 @@ jobs:
       contents: read
       actions: read
     outputs:
-      matrix: ${{ steps.tasks.outputs.matrix }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
       opcli-sha: ${{ steps.workflow-version.outputs.sha }}
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Get workflow version
         id: workflow-version
@@ -102,7 +103,7 @@ jobs:
           sudo ln -sf ~/go/bin/spread /usr/local/bin/spread
 
       - name: Generate test matrix
-        id: tasks
+        id: matrix
         run: |
           matrix=$(opcli spread jobs)
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
@@ -126,9 +127,10 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Setup tmate session
+      - name: Set up tmate session
         if: runner.debug == 1
         uses: mxschmitt/action-tmate@v3
         with:
@@ -186,7 +188,7 @@ jobs:
       # reach this point, there is no reason to continue.  The "Collect artifacts"
       # job in the build workflow is skipped/failed/cancelled when a build fails,
       # so we use its conclusion as the signal.
-      - name: Check build status
+      - name: Abort if build failed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Align the `integration-test.yml` reusable workflow naming with the pattern established in `build-artifacts.yml`:

| Aspect | Before | After |
|--------|--------|-------|
| Job ID | `test-plan` | `test-matrix` |
| Job display name | "Generate test matrix" | "Test matrix" |
| Step name | "Generate spread task matrix" | "Generate test matrix" |

This makes both reusable workflows follow the same `{thing}-matrix` pattern for their matrix-generating jobs, and the same "Generate {thing} matrix" pattern for the step that produces the JSON output.