### PR TITLE
fix: use charm.name from artifacts.yaml for output matching

### DIFF
--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -27,7 +27,6 @@ from opcli.core.yaml_io import (
     dump_artifacts_plan,
     load_artifacts_build,
     load_artifacts_plan,
-    load_yaml,
 )
 from opcli.models.artifacts import (
     CharmArtifact,
@@ -374,16 +373,6 @@ def _parse_arch_from_snap_path(path: str) -> str | None:
     return m.group("arch") if m else None
 
 
-def _read_charm_name(yaml_path: Path) -> str:
-    """Return the ``name:`` field from a charmcraft YAML file."""
-    data = load_yaml(yaml_path)
-    name = data.get("name")
-    if not isinstance(name, str) or not name:
-        msg = f"Could not read 'name' from {yaml_path}"
-        raise ConfigurationError(msg)
-    return name
-
-
 def _pick_new_charm_outputs(
     after: set[str],
     pack_dir: Path,
@@ -578,8 +567,7 @@ def _build_charm(
         if symlink_created and symlink_path and symlink_path.is_symlink():
             symlink_path.unlink()
     after = _snapshot_outputs(pack_dir, "charm")
-    charm_name = _read_charm_name(yaml_path)
-    new_outputs = _pick_new_charm_outputs(after, pack_dir, charm_name, attributed)
+    new_outputs = _pick_new_charm_outputs(after, pack_dir, charm.name, attributed)
     attributed.update(new_outputs)
     arch = _current_arch()
     charm_outputs = [

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -399,7 +399,8 @@ def _pick_new_charm_outputs(
     if not matching:
         msg = (
             f"No *.charm files for charm '{charm_name}' found in {pack_dir}. "
-            "Ensure the 'name' field in the charmcraft YAML matches the packed output."
+            "Ensure the 'name' in artifacts.yaml matches the charm name produced "
+            "by charmcraft (from charmcraft.yaml or metadata.yaml for split format)."
         )
         raise OpcliError(msg)
 

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -758,36 +758,35 @@ class TestArtifactsBuild:
         assert "./mycharm_ubuntu-22.04-amd64.charm" in paths
         assert "./mycharm_ubuntu-24.04-amd64.charm" in paths
 
-    def test_two_charms_same_output_filename_raises(self, tmp_path: Path) -> None:
-        """Two charms that produce the same output filename raise an error.
+    def test_charm_name_from_artifacts_yaml_not_charmcraft_yaml(
+        self, tmp_path: Path
+    ) -> None:
+        """Output matching uses charm.name from artifacts.yaml, not charmcraft.yaml.
 
-        If both charmcraft yamls declare the same internal name (e.g. 'any-charm'),
-        charmcraft produces identically-named .charm files. The second build
-        overwrites the first and the attribution would be silently wrong.
-        opcli must detect this and raise rather than silently recording stale data.
+        This covers the legacy split-format case where charmcraft.yaml has no
+        'name' field (name lives in metadata.yaml).  Previously opcli tried to
+        read the name from charmcraft.yaml and raised ConfigurationError; now it
+        relies on the name declared in artifacts.yaml.
         """
-        _write(tmp_path / "charmcraft-a.yaml", "name: same-charm\n")
-        _write(tmp_path / "charmcraft-b.yaml", "name: same-charm\n")
+        # charmcraft.yaml has no 'name' field (split format)
+        _write(tmp_path / "charmcraft.yaml", "type: charm\n")
 
         _write(
             tmp_path / "artifacts.yaml",
-            "version: 1\ncharms:\n"
-            "- name: charm-a\n  charmcraft-yaml: charmcraft-a.yaml\n"
-            "- name: charm-b\n  charmcraft-yaml: charmcraft-b.yaml\n",
+            "version: 1\ncharms:\n- name: indico\n  charmcraft-yaml: charmcraft.yaml\n",
         )
 
-        call_count = [0]
-
         def fake_run(cmd: list[str], **kwargs: object) -> None:
-            call_count[0] += 1
-            # Both builds produce the same filename (overwrite-in-place for #2)
-            _write(tmp_path / "same-charm_ubuntu-22.04-amd64.charm", "charm")
+            _write(tmp_path / "indico_ubuntu-20.04-amd64.charm", "charm")
 
-        with (
-            patch("opcli.core.artifacts.run_command", side_effect=fake_run),
-            pytest.raises(OpcliError, match="already produced by another artifact"),
-        ):
-            artifacts_build(tmp_path)
+        with patch("opcli.core.artifacts.run_command", side_effect=fake_run):
+            result = artifacts_build(tmp_path)
+
+        gen = load_artifacts_build(result)
+        assert len(gen.charms) == 1
+        assert gen.charms[0].name == "indico"
+        assert len(gen.charms[0].output) == 1
+        assert "indico_ubuntu-20.04-amd64.charm" in gen.charms[0].output[0].path
 
     def test_symlink_not_removed_if_replaced_by_real_file(self, tmp_path: Path) -> None:
         """If pack replaces the symlink with a real file, cleanup does not delete it.


### PR DESCRIPTION
## Problem

When building charms in the legacy split format (where `name` lives in `metadata.yaml` rather than `charmcraft.yaml`), `_build_charm` failed with:

```
error: Could not read 'name' from .../charmcraft.yaml
```

Seen in: https://github.com/javierdelapuente/indico-operator/actions/runs/26213133140/job/77132324163

## Root cause

`_build_charm` called `_read_charm_name(yaml_path)` to get the charm name for filtering packed output files. That function only looked at `charmcraft.yaml` and raised `ConfigurationError` if `name` was absent — it had no fallback to `metadata.yaml`.

## Fix

`charm.name` is already available on the `CharmArtifact` passed into `_build_charm` (from `artifacts.yaml`). There is no need to re-read it from the YAML file. Using `charm.name` directly removes the fragile YAML read, the now-dead `_read_charm_name` function, and the unused `load_yaml` import.

## Test changes

The existing `test_two_charms_same_output_filename_raises` tested a collision scenario that is now impossible — Pydantic's duplicate-name validator prevents two charms with the same name in `artifacts.yaml`. It is replaced with a regression test for the split-format case (`charmcraft.yaml` without a `name` field).