### PR TITLE
Rename 'builds' to 'platforms' in artifacts.yaml and 'output' to 'builds' in artifacts.build.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ version: 1
 rocks:
   - name: my-rock
     rockcraft-yaml: rocks/my-rock/rockcraft.yaml
-    builds:
+    platforms:
       - arch: amd64
       - arch: arm64
         runner: [self-hosted, arm64]
@@ -139,7 +139,7 @@ snaps:
 Key fields:
 - **`*-yaml`**: explicit path to the craft YAML file (not a directory).
 - **`pack-dir`**: working directory for the build tool (defaults to the YAML's parent dir).
-- **`builds[].runner`**: GitHub Actions runner labels (used by `opcli artifacts matrix`; defaults to `["ubuntu-latest"]` at matrix generation time when omitted).
+- **`platforms[].runner`**: GitHub Actions runner labels (used by `opcli artifacts matrix`; defaults to `["ubuntu-latest"]` at matrix generation time when omitted).
 
 ## `spread.yaml` virtual backends
 

--- a/docs/ISD277-redesign.md
+++ b/docs/ISD277-redesign.md
@@ -176,12 +176,12 @@ version: 1
 rocks:
   - name: indico
     rockcraft-yaml: indico_rock/rockcraft.yaml
-    output:
+    builds:
       file: ./indico_rock/indico_1.0_amd64.rock
 charms:
   - name: indico
     charmcraft-yaml: charmcraft.yaml
-    output:
+    builds:
       files:
         - path: ./indico_ubuntu-22.04-amd64.charm
           base: ubuntu@22.04
@@ -194,7 +194,7 @@ charms:
 snaps:
   - name: my-snap
     snapcraft-yaml: snap/snapcraft.yaml
-    output:
+    builds:
       file: ./snap/my-snap_1.0_amd64.snap
 ```
 
@@ -205,12 +205,12 @@ version: 1
 rocks:
   - name: indico
     rockcraft-yaml: indico_rock/rockcraft.yaml
-    output:
+    builds:
       image: ghcr.io/canonical/indico:abc1234-22.04
 charms:
   - name: indico
     charmcraft-yaml: charmcraft.yaml
-    output:
+    builds:
       artifact: charm-indico
       run-id: "1234567890"
     resources:

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -113,24 +113,24 @@ is **not** auto-generated and must be created manually if needed.
 
 ## 5. `opcli artifacts build` produces CI-format output when run in GitHub Actions
 
-**Spec:** Describes `output.file` paths for all artifact types. The spec
+**Spec:** Describes `builds.file` paths for all artifact types. The spec
 mentions GHCR image refs and GitHub artifact refs in the CI-format YAML but
 does not explicitly specify how they are produced.
 
 **Implementation:** When `GITHUB_ACTIONS=true`, `opcli artifacts build`:
 
 - **Rocks**: pushes the built `.rock` image to GHCR via `skopeo` and writes
-  `output: [{arch: <arch>, image: ghcr.io/<owner-lowercased>/<repo>/<rock>:<sha7>-<arch>}]`
-  (no `output[*].file`).
-- **Charms / Snaps**: writes `output: [{arch: <arch>, artifact: built-<type>-<name>-<arch>, run-id: <GITHUB_RUN_ID>}]`
-  (no `output[*].files`).
+  `builds: [{arch: <arch>, image: ghcr.io/<owner-lowercased>/<repo>/<rock>:<sha7>-<arch>}]`
+  (no `builds[*].file`).
+- **Charms / Snaps**: writes `builds: [{arch: <arch>, artifact: built-<type>-<name>-<arch>, run-id: <GITHUB_RUN_ID>}]`
+  (no `builds[*].files`).
 
 A companion command `opcli artifacts collect` (also not in the spec — see below)
 merges the per-artifact partial files from parallel build jobs.
 
-`opcli pytest expand` emits rock image flags from `rocks[].output.image` for
+`opcli pytest expand` emits rock image flags from `rocks[].builds.image` for
 CI-format files. It logs a warning and skips `--charm-file=` for charms whose
-output is `artifact: + run-id:` (CI-built charms), because charm download
+builds entry is `artifact: + run-id:` (CI-built charms), because charm download
 belongs in the test workflow, not inside opcli.
 
 **Rationale:** Detecting `GITHUB_ACTIONS=true` rather than generic `CI` is
@@ -140,12 +140,12 @@ variables (`GITHUB_RUN_ID`, `GITHUB_REPOSITORY_OWNER`, `GITHUB_REPOSITORY`,
 
 ---
 
-## 6. `artifacts.build.yaml` output paths are repo-relative
+## 6. `artifacts.build.yaml` build paths are repo-relative
 
-**Spec:** Does not explicitly specify whether `output.file` paths are absolute
+**Spec:** Does not explicitly specify whether `builds.file` paths are absolute
 or relative.
 
-**Implementation:** `opcli artifacts build` always writes `output.file` as a
+**Implementation:** `opcli artifacts build` always writes `builds.file` as a
 path relative to the repository root (e.g. `./mycharm/mycharm_amd64.charm`).
 Building an artifact whose output lands outside the repository root is an
 error.
@@ -308,19 +308,19 @@ artifact types.
 
 ---
 
-## 12. Multi-base charm output — flat list with `arch`+`path`+`base` per entry
+## 12. Multi-base charm builds — flat list with `arch`+`path`+`base` per entry
 
-**Spec:** The `artifacts.build.yaml` schema shows a single `output.file`
+**Spec:** The `artifacts.build.yaml` schema shows a single `builds.file`
 path for each charm entry:
 
 ```yaml
 charms:
   - name: indico
-    output:
+    builds:
       file: ./indico_ubuntu-22.04-amd64.charm
 ```
 
-**Implementation:** The `output:` field is a **flat list** (`list[CharmOutput]`).
+**Implementation:** The `builds:` field is a **flat list** (`list[CharmOutput]`).
 Each entry has `arch`, `path`, and optional `base` fields. Because `charmcraft pack`
 produces **one `.charm` file per declared base** in a single invocation
 (e.g. ubuntu@20.04, ubuntu@22.04, ubuntu@24.04 each produce a separate file),
@@ -329,7 +329,7 @@ each file becomes its own top-level entry in the list:
 ```yaml
 charms:
   - name: aproxy
-    output:
+    builds:
       - arch: amd64
         path: ./aproxy_ubuntu-20.04-amd64.charm
         base: ubuntu@20.04
@@ -354,7 +354,7 @@ For CI-built charms, `artifact` and `run-id` replace `path` in the entry
 ```yaml
 charms:
   - name: aproxy
-    output:
+    builds:
       - arch: amd64
         artifact: built-charm-aproxy-amd64
         run-id: "1234567890"
@@ -435,7 +435,7 @@ downside.
   into a single `artifacts.build.yaml`. Each artifact can appear in multiple
   partials as long as no two partials contain the same `(name, arch)` pair — this
   enables multi-arch builds where each runner produces a partial for its arch and
-  the collect step merges the output lists. It also validates that every rock
+  the collect step merges the builds lists. It also validates that every rock
   referenced by a charm resource is present in the collected set.
 
 **Rationale:** Each parallel build job produces its own partial
@@ -468,17 +468,17 @@ environment-agnostic.
 ## 17. Rock images are not duplicated on charm resources
 
 **Spec:** The CI-format `artifacts.build.yaml` example in the spec shows
-`image:` fields on both `rocks[].output` and `charms[].resources[]`.
+`image:` fields on both `rocks[].builds` and `charms[].resources[]`.
 
 **Implementation:** The `GeneratedResource` model has no `image` field. Rock
-images live exclusively on `rocks[].output.image`. Charm resources only carry
+images live exclusively on `rocks[].builds.image`. Charm resources only carry
 `type: oci-image` and `rock: <rock-name>`.
 
 ```yaml
 # Implemented schema (single source of truth)
 rocks:
   - name: my-rock
-    output:
+    builds:
       - arch: amd64
         image: ghcr.io/owner/repo/my-rock:abc1234-amd64   # ← image lives here only
 charms:
@@ -490,12 +490,12 @@ charms:
 ```
 
 Any consumer that needs the image for `my-rock-image` looks up `my-rock` in
-the `rocks` list and reads `output.image` from there.
+the `rocks` list and reads `builds.image` from there.
 
 **Affected consumers:**
 - `opcli pytest expand` — already iterates `rocks` for image flags; charm resource
   entries for rock-backed resources are skipped (the rock flag covers them).
-- `opcli provision load` — updates only `rock.output.image`; no charm resource
+- `opcli provision load` — updates only `rock.builds.image`; no charm resource
   fields to update.
 
 **Rationale:** Duplicating the image ref creates two sources of truth that can
@@ -555,7 +555,7 @@ This is used in the CI `Test Integration` workflow after downloading
 charm artifacts from GitHub Actions. The downloaded files land flat in the
 working directory (e.g. `./k8s-charm_ubuntu-24.04-amd64.charm`). Running
 `opcli artifacts localize` discovers those files and replaces the CI-only
-`output[*].artifact` entries with flat `CharmOutput` entries carrying `path`
+`builds[*].artifact` entries with flat `CharmOutput` entries carrying `path`
 and `base` (one entry per discovered `.charm` file).
 Downstream, `opcli pytest expand` reads these paths and passes them as
 `--charm-file=` arguments to pytest.

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -415,7 +415,7 @@ downside.
 
 - **`opcli artifacts matrix`** reads `artifacts.yaml` and prints a JSON object
   suitable for use as a GitHub Actions `strategy.matrix`. Each matrix entry is
-  expanded per `builds:` target (one entry per `{artifact, arch}` pair) and
+  expanded per `platforms:` target (one entry per `{artifact, arch}` pair) and
   includes `name`, `type`, `arch`, and `runner` fields:
   ```json
   {"include": [

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -732,7 +732,7 @@ def artifacts_matrix(root: Path) -> dict[str, list[dict[str, object]]]:
     GitHub runner label strings.
 
     Rocks come first, then charms, then snaps.  Within each kind, entries are
-    ordered by artifact declaration order, then by ``builds`` order.
+    ordered by artifact declaration order, then by ``platforms`` order.
 
     The result is JSON-serialisable and suitable for use as a GitHub Actions
     ``strategy.matrix`` value via ``$GITHUB_OUTPUT``.
@@ -748,7 +748,7 @@ def artifacts_matrix(root: Path) -> dict[str, list[dict[str, object]]]:
     plan = load_artifacts_plan(plan_path)
     include: list[dict[str, object]] = []
     for rock in plan.rocks:
-        for build in rock.builds:
+        for build in rock.platforms:
             include.append(
                 {
                     "name": rock.name,
@@ -758,7 +758,7 @@ def artifacts_matrix(root: Path) -> dict[str, list[dict[str, object]]]:
                 }
             )
     for charm in plan.charms:
-        for build in charm.builds:
+        for build in charm.platforms:
             include.append(
                 {
                     "name": charm.name,
@@ -768,7 +768,7 @@ def artifacts_matrix(root: Path) -> dict[str, list[dict[str, object]]]:
                 }
             )
     for snap in plan.snaps:
-        for build in snap.builds:
+        for build in snap.platforms:
             include.append(
                 {
                     "name": snap.name,

--- a/src/opcli/core/artifacts.py
+++ b/src/opcli/core/artifacts.py
@@ -137,17 +137,17 @@ def _push_rock_to_ghcr(
 
     The rock ``.rock`` file is pushed to
     ``ghcr.io/<owner>/<repo>/<name>:<sha7>-<arch>`` using ``skopeo copy``.
-    The returned object has its ``output`` rewritten to a single
+    The returned object has its ``builds`` rewritten to a single
     :class:`RockArchBuild` with ``image`` set and no ``file``.
 
     Raises:
         OpcliError: If the rock output list is empty or has no local file.
         SubprocessError: If the skopeo push fails.
     """
-    if not rock.output:
+    if not rock.builds:
         msg = f"Rock '{rock.name}' has no build output to push to GHCR."
         raise OpcliError(msg)
-    build = rock.output[0]
+    build = rock.builds[0]
     if not build.file:
         msg = f"Rock '{rock.name}' has no local file to push to GHCR."
         raise OpcliError(msg)
@@ -175,7 +175,7 @@ def _push_rock_to_ghcr(
     return GeneratedRock(
         name=rock.name,
         **{"rockcraft-yaml": rock.rockcraft_yaml},
-        output=[RockOutput(arch=build.arch, image=image_ref)],
+        builds=[RockOutput(arch=build.arch, image=image_ref)],
     )
 
 
@@ -185,11 +185,11 @@ def _to_ci_charm(charm: GeneratedCharm, ci: _CIContext) -> GeneratedCharm:
     The artifact name includes the architecture so parallel multi-arch builds
     produce distinct artifact names (e.g. ``built-charm-my-charm-amd64``).
     """
-    arch = charm.output[0].arch if charm.output else _current_arch()
+    arch = charm.builds[0].arch if charm.builds else _current_arch()
     return GeneratedCharm(
         name=charm.name,
         **{"charmcraft-yaml": charm.charmcraft_yaml},
-        output=[
+        builds=[
             CharmOutput.model_validate(
                 {
                     "arch": arch,
@@ -208,11 +208,11 @@ def _to_ci_snap(snap: GeneratedSnap, ci: _CIContext) -> GeneratedSnap:
     The artifact name includes the architecture so parallel multi-arch builds
     produce distinct artifact names (e.g. ``built-snap-my-snap-amd64``).
     """
-    arch = snap.output[0].arch if snap.output else _current_arch()
+    arch = snap.builds[0].arch if snap.builds else _current_arch()
     return GeneratedSnap(
         name=snap.name,
         **{"snapcraft-yaml": snap.snapcraft_yaml},
-        output=[
+        builds=[
             SnapOutput.model_validate(
                 {
                     "arch": arch,
@@ -542,7 +542,7 @@ def _build_rock(rock: RockArtifact, root: Path, attributed: set[str]) -> Generat
     return GeneratedRock(
         name=rock.name,
         **{"rockcraft-yaml": rock.rockcraft_yaml},
-        output=[RockOutput(arch=_current_arch(), file=output_file)],
+        builds=[RockOutput(arch=_current_arch(), file=output_file)],
     )
 
 
@@ -590,7 +590,7 @@ def _build_charm(
     return GeneratedCharm(
         name=charm.name,
         **{"charmcraft-yaml": charm.charmcraft_yaml},
-        output=charm_outputs,
+        builds=charm_outputs,
         resources=resources if resources else None,
     )
 
@@ -615,7 +615,7 @@ def _build_snap(snap: SnapArtifact, root: Path, attributed: set[str]) -> Generat
     return GeneratedSnap(
         name=snap.name,
         **{"snapcraft-yaml": snap.snapcraft_yaml},
-        output=[SnapOutput(arch=_current_arch(), file=output_file)],
+        builds=[SnapOutput(arch=_current_arch(), file=output_file)],
     )
 
 
@@ -800,11 +800,11 @@ def _merge_artifact_outputs[T: (GeneratedRock, GeneratedCharm, GeneratedSnap)](
     items: list[T],
     kind: str,
 ) -> list[T]:
-    """Merge artifacts with the same name by combining their output lists.
+    """Merge artifacts with the same name by combining their builds lists.
 
     In a multi-arch CI build, each arch produces a separate partial file for
-    the same artifact but with a different arch entry in ``output``.  This
-    function groups them by name and concatenates the ``output`` lists so that
+    the same artifact but with a different arch entry in ``builds``.  This
+    function groups them by name and concatenates the ``builds`` lists so that
     the collected file holds all arches for each artifact.
 
     For rocks and snaps, raises :class:`ConfigurationError` if the same
@@ -818,8 +818,8 @@ def _merge_artifact_outputs[T: (GeneratedRock, GeneratedCharm, GeneratedSnap)](
             merged[item.name] = item
         else:
             existing = merged[item.name]
-            existing_keys = {_output_key(b) for b in existing.output}
-            for build in item.output:
+            existing_keys = {_output_key(b) for b in existing.builds}
+            for build in item.builds:
                 key = _output_key(build)
                 if key in existing_keys:
                     msg = (
@@ -828,7 +828,7 @@ def _merge_artifact_outputs[T: (GeneratedRock, GeneratedCharm, GeneratedSnap)](
                         "exactly one partial file."
                     )
                     raise ConfigurationError(msg)
-            existing.output.extend(item.output)
+            existing.builds.extend(item.builds)
     return list(merged.values())
 
 
@@ -1034,7 +1034,7 @@ def _localize_charm(
     new_entries: list[CharmOutput] = []
     localized = 0
 
-    for idx, build in enumerate(charm.output):
+    for idx, build in enumerate(charm.builds):
         if build.path or not build.artifact:
             continue
         artifact_dir = root / build.artifact
@@ -1073,8 +1073,8 @@ def _localize_charm(
 
     if indices_to_replace:
         replace_set = set(indices_to_replace)
-        charm.output = [
-            b for i, b in enumerate(charm.output) if i not in replace_set
+        charm.builds = [
+            b for i, b in enumerate(charm.builds) if i not in replace_set
         ] + new_entries
 
     return localized
@@ -1111,7 +1111,7 @@ def artifacts_localize(root: Path) -> int:
         updated += _localize_charm(charm, root, missing)
 
     for snap in generated.snaps:
-        for snap_build in snap.output:
+        for snap_build in snap.builds:
             if snap_build.file or not snap_build.artifact:
                 continue
             artifact_dir = root / snap_build.artifact
@@ -1415,11 +1415,11 @@ def artifacts_fetch(
     # Download each charm / snap artifact archive (deduplicated)
     seen_artifacts: set[str] = set()
     for charm in generated.charms:
-        for build in charm.output:
+        for build in charm.builds:
             if build.artifact:
                 seen_artifacts.add(build.artifact)
     for snap in generated.snaps:
-        for snap_build in snap.output:
+        for snap_build in snap.builds:
             if snap_build.artifact:
                 seen_artifacts.add(snap_build.artifact)
 

--- a/src/opcli/core/provision.py
+++ b/src/opcli/core/provision.py
@@ -99,7 +99,7 @@ def provision_load(
     pushed: list[str] = []
 
     for rock in generated.rocks:
-        for build in rock.output:
+        for build in rock.builds:
             if not build.file:
                 continue
 

--- a/src/opcli/core/pytest_args.py
+++ b/src/opcli/core/pytest_args.py
@@ -126,7 +126,7 @@ def assemble_pytest_args(
     # This runs unconditionally so no rock: annotation is needed on charm resources.
     rock_flag_names: set[str] = set()
     for rock in generated.rocks:
-        rock_builds = _select_arch_builds(rock.output, arch, rock.name)
+        rock_builds = _select_arch_builds(rock.builds, arch, rock.name)
         for rock_build in rock_builds:
             value = rock_build.image or rock_build.file
             if value:
@@ -135,7 +135,7 @@ def assemble_pytest_args(
                 args.append(f"--{flag_name}={value}")
 
     for charm in generated.charms:
-        charm_builds = _select_arch_builds(charm.output, arch, charm.name)
+        charm_builds = _select_arch_builds(charm.builds, arch, charm.name)
         for charm_build in charm_builds:
             if charm_build.path:
                 args.append(f"--charm-file={charm_build.path}")

--- a/src/opcli/models/artifacts.py
+++ b/src/opcli/models/artifacts.py
@@ -10,8 +10,8 @@ Schema version: 1
 - An optional ``pack-dir`` field controls the working directory for the build
   tool (e.g. run ``rockcraft pack`` from the repo root when ``go.mod`` lives
   there but ``rockcraft.yaml`` is in a subdirectory).
-- An optional ``builds`` list declares the target architectures and GitHub
-  runner labels for each artifact.  Defaults to a single amd64 build.
+- An optional ``platforms`` list declares the target architectures and GitHub
+  runner labels for each artifact.  Defaults to a single amd64 platform.
 """
 
 from __future__ import annotations
@@ -39,7 +39,7 @@ class BuildTarget(BaseModel):
     runner: list[str] | None = None
 
 
-def _default_builds() -> list[BuildTarget]:
+def _default_platforms() -> list[BuildTarget]:
     return [BuildTarget(arch="amd64")]
 
 
@@ -52,7 +52,9 @@ class CharmArtifact(BaseModel):
     charmcraft_yaml: str = Field(alias="charmcraft-yaml")
     pack_dir: str | None = Field(default=None, alias="pack-dir")
     resources: dict[str, ArtifactResource] = {}
-    builds: list[BuildTarget] = Field(default_factory=_default_builds)
+    platforms: list[BuildTarget] = Field(
+        default_factory=_default_platforms, alias="platforms"
+    )
 
 
 class RockArtifact(BaseModel):
@@ -63,7 +65,9 @@ class RockArtifact(BaseModel):
     name: str
     rockcraft_yaml: str = Field(alias="rockcraft-yaml")
     pack_dir: str | None = Field(default=None, alias="pack-dir")
-    builds: list[BuildTarget] = Field(default_factory=_default_builds)
+    platforms: list[BuildTarget] = Field(
+        default_factory=_default_platforms, alias="platforms"
+    )
 
 
 class SnapArtifact(BaseModel):
@@ -74,7 +78,9 @@ class SnapArtifact(BaseModel):
     name: str
     snapcraft_yaml: str = Field(alias="snapcraft-yaml")
     pack_dir: str | None = Field(default=None, alias="pack-dir")
-    builds: list[BuildTarget] = Field(default_factory=_default_builds)
+    platforms: list[BuildTarget] = Field(
+        default_factory=_default_platforms, alias="platforms"
+    )
 
 
 class ArtifactsPlan(BaseModel):

--- a/src/opcli/models/artifacts_build.py
+++ b/src/opcli/models/artifacts_build.py
@@ -8,7 +8,7 @@ Schema version: 1
 - Charm entries include a ``resources`` mapping with resolved output paths
   (image reference), making ``artifacts.build.yaml`` self-contained for
   pytest flag assembly without needing to also read ``artifacts.yaml``.
-- ``output`` is always a **flat list of per-file build entries** (:class:`RockOutput`,
+- ``builds`` is always a **flat list of per-file build entries** (:class:`RockOutput`,
   :class:`CharmOutput`, or :class:`SnapOutput`).
   Rocks and snaps have one entry per built arch.
   Charms have one entry per produced ``.charm`` file (one per base per arch for local
@@ -118,7 +118,7 @@ class GeneratedRock(BaseModel):
 
     name: str
     rockcraft_yaml: str = Field(alias="rockcraft-yaml")
-    output: list[RockOutput]
+    builds: list[RockOutput]
 
 
 class GeneratedCharm(BaseModel):
@@ -128,7 +128,7 @@ class GeneratedCharm(BaseModel):
 
     name: str
     charmcraft_yaml: str = Field(alias="charmcraft-yaml")
-    output: list[CharmOutput]
+    builds: list[CharmOutput]
     resources: dict[str, GeneratedResource] | None = None
 
 
@@ -139,7 +139,7 @@ class GeneratedSnap(BaseModel):
 
     name: str
     snapcraft_yaml: str = Field(alias="snapcraft-yaml")
-    output: list[SnapOutput]
+    builds: list[SnapOutput]
 
 
 class ArtifactsGenerated(BaseModel):

--- a/tests/unit/test_artifacts.py
+++ b/tests/unit/test_artifacts.py
@@ -94,9 +94,9 @@ class TestArtifactsBuild:
         gen = load_artifacts_build(result)
         assert len(gen.charms) == 1
         assert gen.charms[0].name == "mycharm"
-        assert len(gen.charms[0].output) == 1
-        assert gen.charms[0].output[0].path.startswith("./")
-        assert gen.charms[0].output[0].path.endswith(".charm")
+        assert len(gen.charms[0].builds) == 1
+        assert gen.charms[0].builds[0].path.startswith("./")
+        assert gen.charms[0].builds[0].path.endswith(".charm")
 
     def test_build_multi_base_charm(self, tmp_path: Path) -> None:
         """Multi-base charm: all produced files appear as flat output entries."""
@@ -114,7 +114,7 @@ class TestArtifactsBuild:
             result = artifacts_build(tmp_path)
 
         gen = load_artifacts_build(result)
-        outputs = gen.charms[0].output
+        outputs = gen.charms[0].builds
         expected_count = 3
         assert len(outputs) == expected_count
         paths = {o.path for o in outputs}
@@ -147,7 +147,7 @@ class TestArtifactsBuild:
             result = artifacts_build(tmp_path)
 
         gen = load_artifacts_build(result)
-        outputs = gen.charms[0].output
+        outputs = gen.charms[0].builds
         expected_count = 2
         assert len(outputs) == expected_count
         paths = {o.path for o in outputs}
@@ -172,8 +172,8 @@ class TestArtifactsBuild:
         assert "rockcraft" in mock_run.call_args[0][0]
         gen = load_artifacts_build(result)
         assert len(gen.rocks) == 1
-        assert gen.rocks[0].output[0].file is not None
-        assert gen.rocks[0].output[0].file.startswith("./")
+        assert gen.rocks[0].builds[0].file is not None
+        assert gen.rocks[0].builds[0].file.startswith("./")
 
     def test_build_rock_sets_experimental_extensions_env(self, tmp_path: Path) -> None:
         """rockcraft pack must always pass ROCKCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS."""
@@ -351,7 +351,7 @@ class TestArtifactsBuild:
         _write(
             tmp_path / "artifacts.build.yaml",
             "version: 1\ncharms:\n- name: c\n  source: .\n"
-            "  output:\n    file: ./c.charm\n",
+            "  builds:\n    file: ./c.charm\n",
         )
         with pytest.raises(Exception, match="validation error"):
             load_artifacts_build(tmp_path / "artifacts.build.yaml")
@@ -386,7 +386,7 @@ class TestArtifactsBuild:
         # Symlink must be removed after build
         assert not (tmp_path / "rockcraft.yaml").exists()
         gen = load_artifacts_build(result)
-        assert gen.rocks[0].output[0].file is not None
+        assert gen.rocks[0].builds[0].file is not None
 
     def test_build_rock_pack_dir_real_file_raises(self, tmp_path: Path) -> None:
         """A real rockcraft.yaml with different content at pack-dir raises."""
@@ -438,7 +438,7 @@ class TestArtifactsBuild:
 
         assert symlink_created == [False], "no symlink when content is identical"
         gen = load_artifacts_build(result)
-        assert gen.rocks[0].output[0].file is not None
+        assert gen.rocks[0].builds[0].file is not None
 
     def test_build_rock_pack_dir_existing_symlink_replaced(
         self, tmp_path: Path
@@ -467,7 +467,7 @@ class TestArtifactsBuild:
         # Symlink removed after build
         assert not existing_symlink.exists()
         gen = load_artifacts_build(result)
-        assert gen.rocks[0].output[0].file is not None
+        assert gen.rocks[0].builds[0].file is not None
 
     def test_build_rock_nonstandard_yaml_name_creates_symlink(
         self, tmp_path: Path
@@ -506,7 +506,7 @@ class TestArtifactsBuild:
         )
         assert not (tmp_path / "rockcraft.yaml").exists(), "symlink removed after build"
         gen = load_artifacts_build(result)
-        assert gen.rocks[0].output[0].file is not None
+        assert gen.rocks[0].builds[0].file is not None
 
     def test_build_rock_standard_yaml_name_no_symlink(self, tmp_path: Path) -> None:
         """When yaml is already named rockcraft.yaml in pack-dir, no symlink needed."""
@@ -716,8 +716,8 @@ class TestArtifactsBuild:
         charm_a = next(c for c in gen.charms if c.name == "charm-a")
         charm_b = next(c for c in gen.charms if c.name == "charm-b")
 
-        a_paths = {o.path for o in charm_a.output}
-        b_paths = {o.path for o in charm_b.output}
+        a_paths = {o.path for o in charm_a.builds}
+        b_paths = {o.path for o in charm_b.builds}
 
         assert a_paths == {
             "./charm-a_ubuntu-22.04-amd64.charm",
@@ -751,7 +751,7 @@ class TestArtifactsBuild:
             result = artifacts_build(tmp_path)
 
         gen = load_artifacts_build(result)
-        outputs = gen.charms[0].output
+        outputs = gen.charms[0].builds
         expected_count = 2
         assert len(outputs) == expected_count
         paths = {o.path for o in outputs}
@@ -785,8 +785,8 @@ class TestArtifactsBuild:
         gen = load_artifacts_build(result)
         assert len(gen.charms) == 1
         assert gen.charms[0].name == "indico"
-        assert len(gen.charms[0].output) == 1
-        assert "indico_ubuntu-20.04-amd64.charm" in gen.charms[0].output[0].path
+        assert len(gen.charms[0].builds) == 1
+        assert "indico_ubuntu-20.04-amd64.charm" in gen.charms[0].builds[0].path
 
     def test_symlink_not_removed_if_replaced_by_real_file(self, tmp_path: Path) -> None:
         """If pack replaces the symlink with a real file, cleanup does not delete it.
@@ -885,7 +885,7 @@ class TestArtifactsBuild:
         _write(
             tmp_path / "artifacts.build.yaml",
             "version: 1\nrocks:\n- name: leftover\n  rockcraft-yaml: x.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./x.rock\n",
+            "  builds:\n  - arch: amd64\n    file: ./x.rock\n",
         )
 
         with patch("opcli.core.artifacts.run_command"):
@@ -998,14 +998,14 @@ class TestArtifactsCollect:
             "rock-job",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
+            "  builds:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
         )
         charm_partial = self._partial(
             tmp_path,
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n"
+            "  builds:\n  - arch: amd64\n"
             "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
             "    base: ubuntu@24.04\n",
         )
@@ -1026,14 +1026,14 @@ class TestArtifactsCollect:
             "rock-job",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
+            "  builds:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
         )
         charm_partial = self._partial(
             tmp_path,
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n"
+            "  builds:\n  - arch: amd64\n"
             "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
             "    base: ubuntu@24.04\n"
             "  resources:\n"
@@ -1046,7 +1046,7 @@ class TestArtifactsCollect:
 
         gen = load_artifacts_build(tmp_path / "artifacts.build.yaml")
         # Image lives on the rock, not on the resource
-        assert gen.rocks[0].output[0].file == "./my-rock_1.0_amd64.rock"
+        assert gen.rocks[0].builds[0].file == "./my-rock_1.0_amd64.rock"
         resource = gen.charms[0].resources["my-rock-image"]  # type: ignore[index]
         assert resource.rock == "my-rock"
 
@@ -1056,14 +1056,14 @@ class TestArtifactsCollect:
             "rock1-job",
             "version: 1\n"
             "rocks:\n- name: rock-a\n  rockcraft-yaml: rock-a/rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./rock-a_1.0_amd64.rock\n",
+            "  builds:\n  - arch: amd64\n    file: ./rock-a_1.0_amd64.rock\n",
         )
         rock2 = self._partial(
             tmp_path,
             "rock2-job",
             "version: 1\n"
             "rocks:\n- name: rock-b\n  rockcraft-yaml: rock-b/rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./rock-b_1.0_amd64.rock\n",
+            "  builds:\n  - arch: amd64\n    file: ./rock-b_1.0_amd64.rock\n",
         )
 
         artifacts_collect(tmp_path, [rock1, rock2])
@@ -1089,7 +1089,7 @@ class TestArtifactsCollect:
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n"
+            "  builds:\n  - arch: amd64\n"
             "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
             "    base: ubuntu@24.04\n"
             "  resources:\n"
@@ -1108,14 +1108,14 @@ class TestArtifactsCollect:
             "rock-job-1",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
+            "  builds:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
         )
         rock2 = self._partial(
             tmp_path,
             "rock-job-2",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./my-rock_2.0_amd64.rock\n",
+            "  builds:\n  - arch: amd64\n    file: ./my-rock_2.0_amd64.rock\n",
         )
 
         with pytest.raises(ConfigurationError, match="my-rock"):
@@ -1128,14 +1128,14 @@ class TestArtifactsCollect:
             "rock-amd64-job",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
+            "  builds:\n  - arch: amd64\n    file: ./my-rock_1.0_amd64.rock\n",
         )
         rock_arm64 = self._partial(
             tmp_path,
             "rock-arm64-job",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n  - arch: arm64\n    file: ./my-rock_1.0_arm64.rock\n",
+            "  builds:\n  - arch: arm64\n    file: ./my-rock_1.0_arm64.rock\n",
         )
 
         artifacts_collect(tmp_path, [rock_amd64, rock_arm64])
@@ -1144,8 +1144,8 @@ class TestArtifactsCollect:
         assert len(gen.rocks) == 1
         assert gen.rocks[0].name == "my-rock"
         expected_arch_count = 2
-        assert len(gen.rocks[0].output) == expected_arch_count
-        arches = {b.arch for b in gen.rocks[0].output}
+        assert len(gen.rocks[0].builds) == expected_arch_count
+        arches = {b.arch for b in gen.rocks[0].builds}
         assert arches == {"amd64", "arm64"}
 
     def test_merges_same_charm_different_arches(self, tmp_path: Path) -> None:
@@ -1155,7 +1155,7 @@ class TestArtifactsCollect:
             "charm-amd64-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n"
+            "  builds:\n  - arch: amd64\n"
             "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
             "    base: ubuntu@24.04\n",
         )
@@ -1164,7 +1164,7 @@ class TestArtifactsCollect:
             "charm-arm64-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: arm64\n"
+            "  builds:\n  - arch: arm64\n"
             "    path: ./my-charm_ubuntu-24.04-arm64.charm\n"
             "    base: ubuntu@24.04\n",
         )
@@ -1175,8 +1175,8 @@ class TestArtifactsCollect:
         assert len(gen.charms) == 1
         assert gen.charms[0].name == "my-charm"
         expected_arch_count = 2
-        assert len(gen.charms[0].output) == expected_arch_count
-        arches = {b.arch for b in gen.charms[0].output}
+        assert len(gen.charms[0].builds) == expected_arch_count
+        arches = {b.arch for b in gen.charms[0].builds}
         assert arches == {"amd64", "arm64"}
 
     def test_merges_same_snap_different_arches(self, tmp_path: Path) -> None:
@@ -1186,14 +1186,14 @@ class TestArtifactsCollect:
             "snap-amd64-job",
             "version: 1\n"
             "snaps:\n- name: my-snap\n  snapcraft-yaml: snap/snapcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./my-snap_1.0_amd64.snap\n",
+            "  builds:\n  - arch: amd64\n    file: ./my-snap_1.0_amd64.snap\n",
         )
         snap_arm64 = self._partial(
             tmp_path,
             "snap-arm64-job",
             "version: 1\n"
             "snaps:\n- name: my-snap\n  snapcraft-yaml: snap/snapcraft.yaml\n"
-            "  output:\n  - arch: arm64\n    file: ./my-snap_1.0_arm64.snap\n",
+            "  builds:\n  - arch: arm64\n    file: ./my-snap_1.0_arm64.snap\n",
         )
 
         artifacts_collect(tmp_path, [snap_amd64, snap_arm64])
@@ -1202,8 +1202,8 @@ class TestArtifactsCollect:
         assert len(gen.snaps) == 1
         assert gen.snaps[0].name == "my-snap"
         expected_arch_count = 2
-        assert len(gen.snaps[0].output) == expected_arch_count
-        arches = {b.arch for b in gen.snaps[0].output}
+        assert len(gen.snaps[0].builds) == expected_arch_count
+        arches = {b.arch for b in gen.snaps[0].builds}
         assert arches == {"amd64", "arm64"}
 
 
@@ -1239,7 +1239,7 @@ class TestArtifactsBuildCIMode:
 
         gen = load_artifacts_build(result)
         assert len(gen.rocks) == 1
-        rock_out = gen.rocks[0].output
+        rock_out = gen.rocks[0].builds
         assert rock_out[0].file is None
         assert rock_out[0].image == "ghcr.io/myorg/my-repo/my-rock:abc1234-amd64"
 
@@ -1272,7 +1272,7 @@ class TestArtifactsBuildCIMode:
 
         gen = load_artifacts_build(result)
         assert len(gen.charms) == 1
-        charm_out = gen.charms[0].output
+        charm_out = gen.charms[0].builds
         assert charm_out[0].path is None
         assert charm_out[0].artifact == "built-charm-my-charm-amd64"
         assert charm_out[0].run_id == "9876543210"
@@ -1296,7 +1296,7 @@ class TestArtifactsBuildCIMode:
 
         gen = load_artifacts_build(result)
         assert len(gen.snaps) == 1
-        snap_out = gen.snaps[0].output
+        snap_out = gen.snaps[0].builds
         assert snap_out[0].file is None
         assert snap_out[0].artifact == "built-snap-my-snap-amd64"
         assert snap_out[0].run_id == "9876543210"
@@ -1321,7 +1321,7 @@ class TestArtifactsBuildCIMode:
             result = artifacts_build(tmp_path, charm_names=["my-charm"])
 
         gen = load_artifacts_build(result)
-        charm_out = gen.charms[0].output
+        charm_out = gen.charms[0].builds
         assert charm_out[0].artifact is None
         assert len(charm_out) == 1
         assert "my-charm_ubuntu-24.04-amd64.charm" in charm_out[0].path
@@ -1374,9 +1374,9 @@ class TestArtifactsBuildCIMode:
             result = artifacts_build(tmp_path, rock_names=["my-rock"])
 
         gen = load_artifacts_build(result)
-        assert gen.rocks[0].output[0].image is not None
-        assert "MyOrg" not in gen.rocks[0].output[0].image
-        assert "myorg" in gen.rocks[0].output[0].image
+        assert gen.rocks[0].builds[0].image is not None
+        assert "MyOrg" not in gen.rocks[0].builds[0].image
+        assert "myorg" in gen.rocks[0].builds[0].image
 
 
 class TestArtifactsCollectCIMode:
@@ -1397,7 +1397,7 @@ class TestArtifactsCollectCIMode:
             "rock-job",
             "version: 1\n"
             "rocks:\n- name: my-rock\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n"
+            "  builds:\n  - arch: amd64\n"
             "    image: ghcr.io/myorg/my-repo/my-rock:abc1234\n",
         )
         charm_partial = self._partial(
@@ -1405,7 +1405,7 @@ class TestArtifactsCollectCIMode:
             "charm-job",
             "version: 1\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    artifact: built-charm-my-charm\n"
+            "  builds:\n  - arch: amd64\n    artifact: built-charm-my-charm\n"
             "    run-id: '9876543210'\n"
             "  resources:\n"
             "    my-rock-image:\n"
@@ -1416,13 +1416,13 @@ class TestArtifactsCollectCIMode:
         artifacts_collect(tmp_path, [rock_partial, charm_partial])
 
         gen = load_artifacts_build(tmp_path / "artifacts.build.yaml")
-        assert gen.rocks[0].output[0].image == "ghcr.io/myorg/my-repo/my-rock:abc1234"
+        assert gen.rocks[0].builds[0].image == "ghcr.io/myorg/my-repo/my-rock:abc1234"
         resource = gen.charms[0].resources["my-rock-image"]  # type: ignore[index]
-        # Resource carries the rock reference; image resolved from rock.output.image
+        # Resource carries the rock reference; image resolved from rock.builds.image
         assert resource.rock == "my-rock"
         # Charm itself still has artifact ref
-        assert gen.charms[0].output[0].artifact == "built-charm-my-charm"
-        assert gen.charms[0].output[0].run_id == "9876543210"
+        assert gen.charms[0].builds[0].artifact == "built-charm-my-charm"
+        assert gen.charms[0].builds[0].run_id == "9876543210"
 
 
 class TestArtifactsLocalize:
@@ -1433,7 +1433,7 @@ class TestArtifactsLocalize:
         "charms:\n"
         "- name: my-charm\n"
         "  charmcraft-yaml: charmcraft.yaml\n"
-        "  output:\n"
+        "  builds:\n"
         "  - arch: amd64\n"
         "    artifact: built-charm-my-charm\n"
         "    run-id: '9876543210'\n"
@@ -1450,8 +1450,8 @@ class TestArtifactsLocalize:
 
         assert count == 1
         gen = load_artifacts_build(tmp_path / "artifacts.build.yaml")
-        assert len(gen.charms[0].output) == 1
-        path = gen.charms[0].output[0].path
+        assert len(gen.charms[0].builds) == 1
+        path = gen.charms[0].builds[0].path
         assert path is not None
         assert path.endswith(".charm")
         assert path.startswith("./"), f"Expected relative path, got: {path}"
@@ -1465,7 +1465,7 @@ class TestArtifactsLocalize:
             "charms:\n"
             "- name: my-charm\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n"
+            "  builds:\n"
             "  - arch: amd64\n"
             "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
         )
@@ -1499,7 +1499,7 @@ class TestArtifactsLocalize:
             "charms:\n"
             "- name: my-charm\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n"
+            "  builds:\n"
             "  - arch: amd64\n"
             "    path: ./my-charm_ubuntu-24.04-amd64.charm\n"
         )
@@ -1532,11 +1532,11 @@ class TestArtifactsLocalize:
 
         gen = load_artifacts_build(tmp_path / "artifacts.build.yaml")
         charm = gen.charms[0]
-        assert len(charm.output) == 2  # noqa: PLR2004
-        paths = {o.path for o in charm.output}
+        assert len(charm.builds) == 2  # noqa: PLR2004
+        paths = {o.path for o in charm.builds}
         assert any("22.04" in p for p in paths)
         assert any("24.04" in p for p in paths)
-        bases = {o.base for o in charm.output}
+        bases = {o.base for o in charm.builds}
         assert "ubuntu@22.04" in bases
         assert "ubuntu@24.04" in bases
 
@@ -1549,26 +1549,26 @@ class TestArtifactsFetch:
         "rocks:\n"
         "- name: my-rock\n"
         "  rockcraft-yaml: rock/rockcraft.yaml\n"
-        "  output:\n"
+        "  builds:\n"
         "  - arch: amd64\n"
         "    image: ghcr.io/owner/repo/my-rock:abc1234-amd64\n"
         "charms:\n"
         "- name: my-charm\n"
         "  charmcraft-yaml: charmcraft.yaml\n"
-        "  output:\n"
+        "  builds:\n"
         "  - arch: amd64\n"
         "    artifact: built-charm-my-charm-amd64\n"
         "    run-id: '99887766'\n"
         "- name: other-charm\n"
         "  charmcraft-yaml: other/charmcraft.yaml\n"
-        "  output:\n"
+        "  builds:\n"
         "  - arch: amd64\n"
         "    artifact: built-charm-other-charm-amd64\n"
         "    run-id: '99887766'\n"
         "snaps:\n"
         "- name: my-snap\n"
         "  snapcraft-yaml: snap/snapcraft.yaml\n"
-        "  output:\n"
+        "  builds:\n"
         "  - arch: amd64\n"
         "    artifact: built-snap-my-snap-amd64\n"
         "    run-id: '99887766'\n"
@@ -1722,12 +1722,12 @@ class TestArtifactsFetch:
 
         gen = load_artifacts_build(tmp_path / "artifacts.build.yaml")
         for charm in gen.charms:
-            charm_paths = [o.path for o in charm.output if o.path]
+            charm_paths = [o.path for o in charm.builds if o.path]
             assert charm_paths, f"Charm '{charm.name}' was not localised"
             assert charm_paths[0].endswith(".charm")
         for snap in gen.snaps:
-            assert snap.output[0].file, f"Snap '{snap.name}' was not localised"
-            assert snap.output[0].file.endswith(".snap")
+            assert snap.builds[0].file, f"Snap '{snap.name}' was not localised"
+            assert snap.builds[0].file.endswith(".snap")
 
     def test_wait_retries_until_artifact_appears(self, tmp_path: Path) -> None:
         """With wait=True, retries the initial download and succeeds on 2nd attempt."""
@@ -1786,7 +1786,7 @@ class TestArtifactsFetch:
             "rocks:\n"
             "- name: my-rock\n"
             "  rockcraft-yaml: rock/rockcraft.yaml\n"
-            "  output:\n"
+            "  builds:\n"
             "  - arch: amd64\n"
             "    image: ghcr.io/owner/repo/my-rock:abc1234\n"
         )
@@ -1821,7 +1821,7 @@ class TestArtifactsFetch:
             "rocks:\n"
             "- name: my-rock\n"
             "  rockcraft-yaml: rock/rockcraft.yaml\n"
-            "  output:\n"
+            "  builds:\n"
             "  - arch: amd64\n"
             "    image: ghcr.io/owner/repo/my-rock:abc1234\n"
         )

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -213,7 +213,7 @@ class TestYamlIO:
                 GeneratedRock(
                     name="r1",
                     rockcraft_yaml="rd/rockcraft.yaml",
-                    output=[RockOutput(arch="amd64", file="./r1.rock")],
+                    builds=[RockOutput(arch="amd64", file="./r1.rock")],
                 )
             ],
         )
@@ -228,7 +228,7 @@ class TestYamlIO:
                 GeneratedCharm(
                     name="c1",
                     charmcraft_yaml="charmcraft.yaml",
-                    output=[CharmOutput(arch="amd64", artifact="a1", run_id="42")],
+                    builds=[CharmOutput(arch="amd64", artifact="a1", run_id="42")],
                 )
             ],
         )
@@ -237,7 +237,7 @@ class TestYamlIO:
         raw = path.read_text()
         assert "run-id" in raw
         loaded = load_artifacts_build(path)
-        assert loaded.charms[0].output[0].run_id == "42"
+        assert loaded.charms[0].builds[0].run_id == "42"
 
     def test_load_invalid_yaml_raises(self, tmp_path: Path) -> None:
         path = tmp_path / "bad.yaml"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -185,14 +185,14 @@ class TestArtifactsGenerated:
                 GeneratedRock(
                     name="indico",
                     rockcraft_yaml="indico_rock/rockcraft.yaml",
-                    output=[RockOutput(arch="amd64", file="./indico.rock")],
+                    builds=[RockOutput(arch="amd64", file="./indico.rock")],
                 )
             ],
             charms=[
                 GeneratedCharm(
                     name="indico",
                     charmcraft_yaml="charmcraft.yaml",
-                    output=[
+                    builds=[
                         CharmOutput(
                             arch="amd64",
                             path="./indico.charm",
@@ -202,8 +202,8 @@ class TestArtifactsGenerated:
                 )
             ],
         )
-        assert gen.rocks[0].output[0].file == "./indico.rock"
-        assert gen.charms[0].output[0].path == "./indico.charm"
+        assert gen.rocks[0].builds[0].file == "./indico.rock"
+        assert gen.charms[0].builds[0].path == "./indico.charm"
 
     def test_generated_extra_fields_rejected(self) -> None:
         with pytest.raises(ValidationError, match="Extra inputs"):
@@ -215,7 +215,7 @@ class TestArtifactsGenerated:
                 GeneratedSnap(
                     name="mysnap",
                     snapcraft_yaml="snap/snapcraft.yaml",
-                    output=[SnapOutput(arch="amd64", file="./mysnap.snap")],
+                    builds=[SnapOutput(arch="amd64", file="./mysnap.snap")],
                 )
             ],
         )

--- a/tests/unit/test_provision.py
+++ b/tests/unit/test_provision.py
@@ -23,18 +23,18 @@ version: 1
 rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
-  output:
+  builds:
   - arch: amd64
     file: ./rock_dir/myrock.rock
 - name: otherrock
   rockcraft-yaml: other/rockcraft.yaml
-  output:
+  builds:
   - arch: amd64
     image: ghcr.io/canonical/otherrock:abc
 charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
-  output:
+  builds:
   - arch: amd64
     path: ./mycharm_ubuntu-22.04-amd64.charm
     base: ubuntu@22.04
@@ -45,18 +45,18 @@ version: 1
 rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
-  output:
+  builds:
   - arch: amd64
     file: ./rock_dir/myrock.rock
 - name: otherrock
   rockcraft-yaml: other_dir/rockcraft.yaml
-  output:
+  builds:
   - arch: amd64
     image: ghcr.io/canonical/otherrock:abc
 charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
-  output:
+  builds:
   - arch: amd64
     path: ./mycharm_ubuntu-22.04-amd64.charm
     base: ubuntu@22.04
@@ -139,7 +139,7 @@ class TestProvisionLoad:
             tmp_path / "artifacts.build.yaml",
             "version: 1\n"
             "rocks:\n- name: r1\n  rockcraft-yaml: rd/rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    image: ghcr.io/r1:v1\n",
+            "  builds:\n  - arch: amd64\n    image: ghcr.io/r1:v1\n",
         )
 
         with (
@@ -182,7 +182,7 @@ class TestProvisionLoad:
         assert "--dest-tls-verify=false" in cmd
 
     def test_updates_artifacts_build_with_image_ref(self, tmp_path: Path) -> None:
-        """After pushing, rock.output.image is set and file is preserved."""
+        """After pushing, rock.builds.image is set and file is preserved."""
         _write(tmp_path / "artifacts.build.yaml", _GENERATED_WITH_ROCKS)
 
         with (
@@ -193,8 +193,8 @@ class TestProvisionLoad:
 
         updated = load_artifacts_build(tmp_path / "artifacts.build.yaml")
         myrock = next(r for r in updated.rocks if r.name == "myrock")
-        assert myrock.output[0].image == "localhost:32000/myrock:amd64"
-        assert myrock.output[0].file == "./rock_dir/myrock.rock"
+        assert myrock.builds[0].image == "localhost:32000/myrock:amd64"
+        assert myrock.builds[0].file == "./rock_dir/myrock.rock"
 
     def test_updates_charm_resources_for_pushed_rock(self, tmp_path: Path) -> None:
         """provision_load pushes rocks; charm resources reference via rock: field."""
@@ -212,7 +212,7 @@ class TestProvisionLoad:
         updated = load_artifacts_build(tmp_path / "artifacts.build.yaml")
         # Rock output.image is updated after push
         myrock = next(r for r in updated.rocks if r.name == "myrock")
-        assert myrock.output[0].image == "localhost:32000/myrock:amd64"
+        assert myrock.builds[0].image == "localhost:32000/myrock:amd64"
         # Charm resources still only carry the rock reference, not a duplicated image
         charm = updated.charms[0]
         assert charm.resources is not None
@@ -225,7 +225,7 @@ class TestProvisionLoad:
             tmp_path / "artifacts.build.yaml",
             "version: 1\n"
             "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./rock_dir/myrock.rock\n"
+            "  builds:\n  - arch: amd64\n    file: ./rock_dir/myrock.rock\n"
             "    image: localhost:32000/myrock:amd64\n",
         )
 
@@ -370,7 +370,7 @@ class TestProvisionRegistry:
         content = (
             "version: 1\nrocks: []\ncharms:\n"
             "- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n"
+            "  builds:\n  - arch: amd64\n"
             "    path: ./c.charm\n    base: ubuntu@22.04\n"
         )
         _write(tmp_path / "artifacts.build.yaml", content)

--- a/tests/unit/test_pytest_args.py
+++ b/tests/unit/test_pytest_args.py
@@ -27,13 +27,13 @@ version: 1
 rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
-  output:
+  builds:
   - arch: amd64
     file: ./rock_dir/myrock.rock
 charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
-  output:
+  builds:
   - arch: amd64
     path: ./mycharm_ubuntu-22.04-amd64.charm
     base: ubuntu@22.04
@@ -48,13 +48,13 @@ version: 1
 rocks:
 - name: myrock
   rockcraft-yaml: rock_dir/rockcraft.yaml
-  output:
+  builds:
   - arch: amd64
     image: ghcr.io/canonical/myrock:abc123
 charms:
 - name: mycharm
   charmcraft-yaml: charmcraft.yaml
-  output:
+  builds:
   - arch: amd64
     artifact: charm-mycharm
     run-id: "999"
@@ -69,7 +69,7 @@ version: 1
 charms:
 - name: simple
   charmcraft-yaml: charmcraft.yaml
-  output:
+  builds:
   - arch: amd64
     path: ./simple_ubuntu-22.04-amd64.charm
     base: ubuntu@22.04
@@ -87,7 +87,7 @@ class TestAssemblePytestArgs:
         _write(
             tmp_path / "artifacts.build.yaml",
             "version: 1\ncharms:\n- name: c\n  source: .\n"
-            "  output:\n  - arch: amd64\n    path: ./c.charm\n",
+            "  builds:\n  - arch: amd64\n    path: ./c.charm\n",
         )
         with pytest.raises(Exception, match=_V1_ERROR_MATCH):
             assemble_pytest_args(tmp_path)
@@ -141,7 +141,7 @@ class TestAssemblePytestArgs:
             tmp_path / "artifacts.build.yaml",
             "version: 1\ncharms:\n- name: aproxy\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n"
+            "  builds:\n"
             "  - arch: amd64\n    path: ./aproxy_ubuntu-20.04-amd64.charm\n"
             "    base: ubuntu@20.04\n"
             "  - arch: amd64\n    path: ./aproxy_ubuntu-22.04-amd64.charm\n"
@@ -168,7 +168,7 @@ class TestAssemblePytestArgs:
         _write(
             tmp_path / "artifacts.build.yaml",
             "version: 1\ncharms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    path: ./c_ubuntu-22.04-amd64.charm\n"
+            "  builds:\n  - arch: amd64\n    path: ./c_ubuntu-22.04-amd64.charm\n"
             "    base: ubuntu@22.04\n"
             "  resources:\n    img:\n      type: oci-image\n      rock: myrock\n",
         )
@@ -184,10 +184,10 @@ class TestAssemblePytestArgs:
             tmp_path / "artifacts.build.yaml",
             "version: 1\n"
             "rocks:\n- name: myrock\n  rockcraft-yaml: rock_dir/rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./rock_dir/myrock.rock\n"
+            "  builds:\n  - arch: amd64\n    file: ./rock_dir/myrock.rock\n"
             "    image: localhost:32000/myrock:latest\n"
             "charms:\n- name: c\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    path: ./c_ubuntu-22.04-amd64.charm\n"
+            "  builds:\n  - arch: amd64\n    path: ./c_ubuntu-22.04-amd64.charm\n"
             "    base: ubuntu@22.04\n"
             "  resources:\n    myrock-image:\n      type: oci-image\n"
             "      rock: myrock\n",
@@ -209,10 +209,10 @@ class TestAssemblePytestArgs:
             tmp_path / "artifacts.build.yaml",
             "version: 1\n"
             "rocks:\n- name: expressjs-app\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./expressjs-app_1.0_amd64.rock\n"
+            "  builds:\n  - arch: amd64\n    file: ./expressjs-app_1.0_amd64.rock\n"
             "charms:\n- name: expressjs-k8s\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n"
+            "  builds:\n  - arch: amd64\n"
             "    path: ./expressjs-k8s_ubuntu-22.04-amd64.charm\n"
             "    base: ubuntu@22.04\n"
             "  resources:\n    app-image:\n      type: oci-image\n"
@@ -235,11 +235,11 @@ class TestAssemblePytestArgs:
             "version: 1\n"
             "rocks:\n"
             "- name: expressjs-app\n  rockcraft-yaml: rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./expressjs-app_1.0_amd64.rock\n"
+            "  builds:\n  - arch: amd64\n    file: ./expressjs-app_1.0_amd64.rock\n"
             "- name: fastapi-app\n  rockcraft-yaml: fastapi/rockcraft.yaml\n"
-            "  output:\n  - arch: amd64\n    file: ./fastapi-app_1.0_amd64.rock\n"
+            "  builds:\n  - arch: amd64\n    file: ./fastapi-app_1.0_amd64.rock\n"
             "charms:\n- name: my-charm\n  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n"
+            "  builds:\n  - arch: amd64\n"
             "    path: ./my-charm_ubuntu-22.04-amd64.charm\n"
             "    base: ubuntu@22.04\n",
         )
@@ -255,7 +255,7 @@ class TestAssemblePytestArgs:
             tmp_path / "artifacts.build.yaml",
             "version: 1\ncharms:\n- name: mycharm\n"
             "  charmcraft-yaml: charmcraft.yaml\n"
-            "  output:\n  - arch: amd64\n"
+            "  builds:\n  - arch: amd64\n"
             "    path: ./mycharm_ubuntu-22.04-amd64.charm\n"
             "    base: ubuntu@22.04\n"
             "  resources:\n    standalone-image:\n      type: oci-image\n",


### PR DESCRIPTION
Aligns YAML key naming with charmcraft.yaml and rockcraft.yaml conventions.

### Changes

**Commit 1 — `artifacts.yaml`: `builds` → `platforms`**
- Renamed field on `CharmArtifact`, `RockArtifact`, `SnapArtifact`
- Updated matrix-generation logic in `core/artifacts.py`
- Updated `README.md` and `docs/divergences.md`

**Commit 2 — `artifacts.build.yaml`: `output` → `builds`**
- Renamed field on `GeneratedRock`, `GeneratedCharm`, `GeneratedSnap`
- Updated all consumers: `core/artifacts.py`, `core/provision.py`, `core/pytest_args.py`
- Updated `docs/ISD277-redesign.md` and `docs/divergences.md` YAML examples and references
- Updated all unit tests

All 365 unit tests pass; linting, formatting, and mypy are clean.