### PR TITLE
docs: fix AGENTS.md inaccuracies and remove unused syrupy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@ Instructions for AI coding agents working on this repository.
 
 - **Spec:** [`docs/ISD277-redesign.md`](docs/ISD277-redesign.md) — read before implementing new features.
 - **Divergences:** [`docs/divergences.md`](docs/divergences.md) — where implementation differs from spec.
-- **opcli owns:** file-based contracts, artifact discovery, subprocess execution, YAML transforms.
-- **opcli does NOT own:** GitHub workflow orchestration, artifact upload/download, runner selection, GitHub API calls.
+- **opcli owns:** file-based contracts, artifact discovery, subprocess execution, YAML transforms, artifact download (`gh run download`), CI job status queries (`gh api`).
+- **opcli does NOT own:** GitHub workflow orchestration, artifact upload, runner selection.
 
 ---
 
@@ -44,6 +44,7 @@ tests/
   unit/        # Fast tests — mock external processes
   integration/ # Requires LXD/spread — skip-guarded with @pytest.mark.integration
 docs/          # Spec + divergences
+examples/      # Example project layout (artifacts.yaml, spread.yaml, concierge.yaml)
 ```
 
 ### Key constraints
@@ -64,9 +65,9 @@ docs/          # Spec + divergences
 | Packaging | `uv` |
 | CLI | `Typer` |
 | Data models | `Pydantic V2` |
-| Lint/format | `Ruff` (rules: `E F W I UP B SIM PL RUF`) |
+| Lint/format | `Ruff` (rules: `E F W I UP B SIM PL RUF`; ignores: `B008` globally, `E501` in `spread.py`) |
 | YAML (user files) | `ruamel.yaml` (preserves comments) |
-| Testing | `pytest` + `pytest-mock` + `syrupy` |
+| Testing | `pytest` + `pytest-mock` |
 
 ---
 
@@ -113,7 +114,7 @@ These encode hard-won correctness lessons — do not violate.
 
 3. **`after - before` for output detection.** Never use `sorted(after)` alone. The set difference identifies files produced by *this* specific build invocation.
 
-4. **CI artifact download.** `artifacts_fetch` downloads to `root/{artifact-name}/` subdirectories to prevent filename collisions.
+4. **CI artifact download.** `artifacts_fetch` downloads to `root/{artifact-name}/` subdirectories to prevent filename collisions. All artifact names are validated via `_safe_artifact_dir()` to ensure they resolve under the project root (path traversal prevention).
 
 ---
 
@@ -135,7 +136,6 @@ All Typer callbacks catch `OpcliError` and emit user-friendly messages. No raw t
 
 - **TDD:** write unit tests before implementation for non-trivial features.
 - **Mock boundary:** mock at `run_command`. Never run real charmcraft/rockcraft/spread in unit tests.
-- **Snapshot testing:** `syrupy` for CLI output assertions.
 - **`pre_existing_before/after` pattern:** simulate build tool output by writing files inside the `fake_run` side-effect, not before it.
 
 ---
@@ -149,7 +149,7 @@ git checkout -b fix/my-fix
 # make changes
 git push --set-upstream origin fix/my-fix
 gh pr create --title "..." --body "..."
-gh pr checks <number> --watch   # WAIT for green (CI + Test Integration workflows)
+gh pr checks <number> --watch   # WAIT for CI workflow green
 gh pr merge <number> --squash
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,4 @@ dev = [
     "pytest>=9.0.3",
     "pytest-mock>=3.15.1",
     "ruff>=0.15.11",
-    "syrupy>=5.1.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-mock" },
     { name = "ruff" },
-    { name = "syrupy" },
 ]
 
 [package.metadata]
@@ -219,7 +218,6 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.15.11" },
-    { name = "syrupy", specifier = ">=5.1.0" },
 ]
 
 [[package]]
@@ -430,18 +428,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
-name = "syrupy"
-version = "5.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/b0/24bca682d6a6337854be37f242d116cceeda9942571d5804c44bc1bdd427/syrupy-5.1.0.tar.gz", hash = "sha256:df543c7aa50d3cf1246e83d58fe490afe5f7dab7b41e74ecc0d8d23ae19bd4b8", size = 50495, upload-time = "2026-01-25T14:53:06.2Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/70/cf880c3b95a6034ef673e74b369941b42315c01f1554a5637a4f8b911009/syrupy-5.1.0-py3-none-any.whl", hash = "sha256:95162d2b05e61ed3e13f117b88dfab7c58bd6f90e66ebbf918e8a77114ad51c5", size = 51658, upload-time = "2026-01-25T14:53:05.105Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes several inaccuracies in AGENTS.md and removes dead dependency.

## Changes

### AGENTS.md corrections
- **Line 14 (ownership):** opcli now owns artifact download (`gh run download`) and CI job queries (`gh api`). Updated to reflect reality.
- **Tech stack:** Removed syrupy (never used in any test file).
- **Testing conventions:** Removed snapshot testing bullet (aspirational, not factual).
- **Layout:** Added `examples/` directory.
- **Lint rules:** Documented `B008` ignore and `E501` per-file override.
- **Build invariants:** Documented `_safe_artifact_dir()` path traversal guard.
- **Git workflow:** Simplified CI check description.

### Dependency cleanup
- Removed `syrupy` from dev dependencies (unused).

All 372 tests pass. Lint/format/mypy clean.