### PR TITLE
fix: enable IPv4 forwarding to fix LXD+Docker connectivity

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -208,6 +208,17 @@ jobs:
             exit 1
           fi
 
+      # ── Fix LXD+Docker connectivity ─────────────────────────────────────
+      # Docker sets the global FORWARD policy to DROP, which prevents LXD from
+      # forwarding traffic.  Enabling IPv4 forwarding before LXD starts and
+      # resetting the policy avoids this.
+      # See https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/#network-lxd-docker
+      - name: Fix LXD+Docker forwarding
+        run: |
+          echo "net.ipv4.conf.all.forwarding=1" | sudo tee /etc/sysctl.d/99-forwarding.conf
+          sudo systemctl restart systemd-sysctl
+          sudo iptables -P FORWARD ACCEPT
+
       # ── Run the spread task ───────────────────────────────────────────────
       # Artifact download happens inside spread _CI_PREPARE (after provisioning).
       - name: Run spread task


### PR DESCRIPTION
Docker sets the global FORWARD policy to DROP, which prevents LXD containers from reaching the internet during integration tests (e.g. `juju bootstrap lxd` fails because apt can't fetch packages).

This adds a workflow step before spread runs that:
1. Enables IPv4 forwarding via sysctl (persistent)
2. Resets iptables FORWARD policy to ACCEPT

Reference: https://documentation.ubuntu.com/lxd/latest/howto/network_bridge_firewalld/#network-lxd-docker

Fixes the failure in https://github.com/javierdelapuente/paas-charm/actions/runs/26274403860/job/77344023074?pr=12